### PR TITLE
Fix CI: pin packageManager to pnpm@10.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
     "overrides": {
       "srvx@0.11.21": "0.11.20"
     }
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }


### PR DESCRIPTION
Root cause of both failed deploys (#36's and #37's): the dockerfile does `corepack enable` but `package.json` had no `packageManager` field, so CI's corepack fetched a newer pnpm major than the 10.28.1 used locally. The newer version (a) enforces a 24h minimum-release-age default — first failure, and (b) reads overrides config differently than what the lockfile recorded — second failure (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`).

Pinning `"packageManager": "pnpm@10.28.1"` makes corepack in Docker use the exact local version, eliminating the drift class entirely. The srvx override from #37 stays as belt-and-suspenders and can be dropped after 2026-07-05.

**Verification:**
- Simulated the exact Docker install layer (`COPY pnpm-lock.yaml package.json` → `corepack pnpm install --frozen-lockfile`) in a clean dir: passes, corepack resolves 10.28.1 from the pin.
- `pnpm test` — 3/3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)