### PR TITLE
Fix #1: enforce auth + role checks on all API routes

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,51 @@
+import { auth } from '../utils/auth'
+
+// Global API authorization (issues #1, #2).
+//
+// Every /api route requires an authenticated session, except:
+//   - /api/auth/**  — better-auth's own login/OTP endpoints
+// Role model:
+//   - ADMIN      — full access
+//   - VOLUNTEER  — reads, plus their own self-service writes (see VOLUNTEER_WRITE_ALLOW)
+//   - CLIENT     — no access to the internal API (the app is admin/volunteer facing)
+//
+// Endpoint handlers may still add finer checks (e.g. signup.ts verifies the
+// volunteer owns the ride); this middleware is the coarse gate in front of them.
+
+// Volunteer self-service writes, matched against the path.
+const VOLUNTEER_WRITE_ALLOW = [
+  /^\/api\/post\/rides\/[^/]+\/signup$/,
+  /^\/api\/post\/rides\/[^/]+\/unsignup$/,
+  /^\/api\/put\/volunteers\/bySession(\/|$)/,
+]
+
+function isWrite(method: string) {
+  return method === 'POST' || method === 'PUT' || method === 'DELETE' || method === 'PATCH'
+}
+
+export default defineEventHandler(async (event) => {
+  const path = event.path.split('?')[0]
+
+  // Only guard the API, and let better-auth manage its own routes.
+  if (!path.startsWith('/api/')) return
+  if (path.startsWith('/api/auth/')) return
+
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+
+  const role = (session.user as { role?: string }).role
+
+  if (role === 'ADMIN') return
+
+  if (role === 'VOLUNTEER') {
+    if (isWrite(event.method) && !VOLUNTEER_WRITE_ALLOW.some((re) => re.test(path))) {
+      throw createError({ statusCode: 403, statusMessage: 'Admin access required' })
+    }
+    return
+  }
+
+  // CLIENT or any unmapped role: no internal API access.
+  throw createError({ statusCode: 403, statusMessage: 'You do not have access to this resource' })
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -19,6 +19,11 @@ export const auth = betterAuth({
     provider: 'sqlite',
   }),
   trustedOrigins: ['http://localhost:3000', 'http://192.168.4.240:3000'],
+  // Disabled only in the e2e suite (production build ⇒ rate limiting on by
+  // default, which throttles a test that logs in many times from one IP).
+  rateLimit: {
+    enabled: process.env.DISABLE_RATE_LIMIT !== 'true',
+  },
   user: {
     additionalFields: {
       role: {
@@ -38,18 +43,16 @@ export const auth = betterAuth({
       if (ctx.path !== '/email-otp/send-verification-otp') {
         return
       }
-      try {
-        const user = await $fetch(`/api/get/users/byEmail/${ctx.body?.email}`)
-        if (!user) {
-          throw new APIError('BAD_REQUEST', {
-            message: 'Contact admin to add your user to the system first',
-          })
-        }
-      } catch (err) {
-        if (err instanceof APIError) {
-          throw err
-        }
-        console.log(`Error fetching user using email: ${err}`)
+      // Query the database directly rather than looping back through the HTTP
+      // API (avoids self-request latency/deadlocks, and the API is now behind
+      // auth middleware which would reject this pre-session call). See #20.
+      const email = ctx.body?.email
+      if (!email) return
+      const user = await prisma.user.findUnique({ where: { email } })
+      if (!user) {
+        throw new APIError('BAD_REQUEST', {
+          message: 'Contact admin to add your user to the system first',
+        })
       }
     }),
   },

--- a/tests/e2e/auth-middleware.test.ts
+++ b/tests/e2e/auth-middleware.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #1: every core CRUD endpoint must require an authenticated session.
+// Issue #2: only admins may create/promote admins.
+describe('API auth middleware (#1, #2)', () => {
+  it('rejects unauthenticated reads of core data', async () => {
+    for (const path of [
+      '/api/get/rides',
+      '/api/get/clients',
+      '/api/get/volunteers',
+      '/api/get/users',
+      '/api/get/admins',
+      '/api/get/addresses',
+      '/api/get/metrics/completionRate',
+    ]) {
+      await expect($fetch(path), `${path} should require auth`).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    }
+  })
+
+  it('rejects unauthenticated writes and deletes', async () => {
+    await expect(
+      $fetch('/api/post/admins', {
+        method: 'POST',
+        body: { name: 'Intruder', email: 'intruder@example.com' },
+      })
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    await expect(
+      $fetch('/api/delete/clients/any-id', { method: 'DELETE' })
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    await expect(
+      $fetch('/api/put/rides/any-id', { method: 'PUT', body: { notes: 'hax' } })
+    ).rejects.toMatchObject({ statusCode: 401 })
+  })
+
+  it('forbids volunteers from admin-only actions (#2)', async () => {
+    const cookie = await loginAs('bob@example.com')
+
+    await expect(
+      $fetch('/api/post/admins', {
+        method: 'POST',
+        headers: { cookie },
+        body: { name: 'Evil Bob', email: 'evil-bob@example.com' },
+      })
+    ).rejects.toMatchObject({ statusCode: 403 })
+
+    await expect(
+      $fetch('/api/delete/volunteers/any-id', { method: 'DELETE', headers: { cookie } })
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('forbids client-role users entirely', async () => {
+    const cookie = await loginAs('martha@example.com')
+    await expect($fetch('/api/get/rides', { headers: { cookie } })).rejects.toMatchObject({
+      statusCode: 403,
+    })
+  })
+
+  it('volunteers keep the access their dashboard needs', async () => {
+    const cookie = await loginAs('bob@example.com')
+    const rides = await $fetch('/api/get/rides', { headers: { cookie } })
+    expect(Array.isArray(rides)).toBe(true)
+
+    const me = await $fetch<{ user: { email: string } }>('/api/get/volunteers/bySession', {
+      headers: { cookie },
+    })
+    expect(me.user.email).toBe('bob@example.com')
+  })
+
+  it('admins can still manage admins', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const created = await $fetch<{ role: string }>('/api/post/admins', {
+      method: 'POST',
+      headers: { cookie },
+      body: { name: 'New Admin', email: 'new-admin@example.com' },
+    })
+    expect(created.role).toBe('ADMIN')
+  })
+
+  it('login gate still blocks unknown emails from requesting an OTP (#20 regression guard)', async () => {
+    const res = await appFetch('/api/auth/email-otp/send-verification-otp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '10.99.9.1' },
+      body: JSON.stringify({ email: 'total-stranger@example.com', type: 'sign-in' }),
+    })
+    expect(res.status).toBe(400)
+  })
+})

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -8,8 +8,9 @@ await setup({
 })
 
 describe('test harness smoke test', () => {
-  it('boots the app and serves seeded data', async () => {
-    const rides = await $fetch('/api/get/rides')
+  it('boots the app and serves seeded data (authenticated)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const rides = await $fetch('/api/get/rides', { headers: { cookie } })
     expect(Array.isArray(rides)).toBe(true)
     expect(rides.length).toBeGreaterThanOrEqual(9)
   })

--- a/tests/utils/auth.ts
+++ b/tests/utils/auth.ts
@@ -6,16 +6,27 @@ import Database from 'better-sqlite3'
 //   VOLUNTEER: bob@example.com, alice@example.com
 //   CLIENT:    martha@example.com, george@example.com, sarah@example.com
 
+const sessionCache = new Map<string, string>()
+let ipCounter = 0
+
 /**
  * Logs in through the real better-auth email-OTP flow without SMTP.
  * The app swallows email-send failures, but better-auth stores the OTP in the
  * `verification` table first — so we request an OTP, read it straight from the
  * test database, and complete sign-in. Returns a Cookie header value.
+ *
+ * Sessions are cached per email, and each login uses a unique X-Forwarded-For
+ * so better-auth's per-IP rate limiter (active in production builds) doesn't
+ * throttle suites that log in repeatedly.
  */
 export async function loginAs(email: string): Promise<string> {
+  const cached = sessionCache.get(email)
+  if (cached) return cached
+
+  const fakeIp = `10.99.0.${++ipCounter}`
   const sendRes = await appFetch('/api/auth/email-otp/send-verification-otp', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': fakeIp },
     body: JSON.stringify({ email, type: 'sign-in' }),
   })
   if (!sendRes.ok) {
@@ -26,7 +37,7 @@ export async function loginAs(email: string): Promise<string> {
 
   const signInRes = await appFetch('/api/auth/sign-in/email-otp', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': fakeIp },
     body: JSON.stringify({ email, otp }),
   })
   if (!signInRes.ok) {
@@ -38,7 +49,9 @@ export async function loginAs(email: string): Promise<string> {
     throw new Error(`sign-in for ${email} returned no Set-Cookie header`)
   }
   // "name=value; Path=/; HttpOnly" -> "name=value", joined for a Cookie header
-  return setCookies.map((c) => c.split(';')[0]).join('; ')
+  const cookie = setCookies.map((c) => c.split(';')[0]).join('; ')
+  sessionCache.set(email, cookie)
+  return cookie
 }
 
 function readLatestOtp(email: string): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     env: {
       DATABASE_URL: `file:${testDb}`,
       BETTER_AUTH_SECRET: 'test-secret-not-for-production',
+      DISABLE_RATE_LIMIT: 'true',
     },
     testTimeout: 30_000,
     // First hook builds the Nuxt app; allow plenty of time.


### PR DESCRIPTION
## What was broken
25 of 33 API endpoints had **zero authentication** — any unauthenticated request could read, modify, or delete rides, clients, volunteers, users, and admins (#1). That included `POST /api/post/admins`, so anyone could promote themselves to ADMIN (#2).

## What changed
- **`server/middleware/auth.ts`** (new) — global Nitro middleware gating every `/api` route except better-auth's own `/api/auth/**`:
  - No session → **401**
  - `ADMIN` → full access
  - `VOLUNTEER` → reads + own self-service writes (ride signup/unsignup, `put/volunteers/bySession/*`); any other write → **403**
  - `CLIENT` / unmapped role → **403** (the internal API is admin/volunteer facing)
- **`server/utils/auth.ts`** — the login before-hook now queries Prisma directly instead of `$fetch`ing `/api/get/users/byEmail`. That loopback call would otherwise hit the new middleware pre-session, always error, and silently disable the "contact admin to be added" login gate. This also resolves #20.
- Per-handler checks (e.g. `signup.ts` verifying ride ownership) are unchanged — the middleware is the coarse gate in front of them.

## Verification
- `tests/e2e/auth-middleware.test.ts` (new, 7 cases): unauthenticated reads/writes → 401; volunteer → 403 on `post/admins` and `delete/volunteers`; client → 403 on `get/rides`; volunteer and admin happy paths; unknown-email login gate still returns 400.
- **Revert-check**: with the middleware removed, the 4 core enforcement tests fail; restored, they pass — the tests genuinely pin the hole.
- Full suite: 10/10 green. `pnpm build` succeeds.
- Rate limiting is disabled **only** in the e2e env (`DISABLE_RATE_LIMIT=true` in `vitest.config.ts`); production builds keep better-auth's default rate limiting on.

## Notes for reviewer
- This is a `P0: critical` security change to the production auth surface — merging deploys. Please eyeball the role model before merge.
- #3 (PII overfetching — volunteers can still *read* all rides/clients) is intentionally **not** addressed here; it needs per-user query scoping and has its own issue.

Fixes #1
Fixes #2
Fixes #20