### PR TITLE
Fix #3: scope API data to the requesting user

### DIFF
--- a/server/api/get/clients/index.ts
+++ b/server/api/get/clients/index.ts
@@ -1,6 +1,10 @@
 import { prisma } from '../../../utils/prisma'
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
+  // Bulk client roster carries full PII (name/phone/address) and is only used
+  // by admin-facing UI — keep it admin-only (issue #3).
+  requireAdmin(event)
+
   return await prisma.client.findMany({
     include: {
       user: true,

--- a/server/api/get/rides/index.ts
+++ b/server/api/get/rides/index.ts
@@ -1,10 +1,28 @@
+import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const sort = query.sort === 'desc' ? 'desc' : 'asc'
 
+  // The global auth middleware guarantees a session and stashes it here.
+  const session = event.context.auth as
+    | { user: { id: string; role?: string } }
+    | undefined
+  const role = session?.user?.role
+
+  // Data scoping (issue #3): a VOLUNTEER must only receive rides that are
+  // available to sign up for (CREATED) or that are assigned to them — never
+  // other volunteers' rides or the full roster of client PII. ADMINs see all.
+  let where: Prisma.RideWhereInput | undefined
+  if (role !== 'ADMIN') {
+    where = {
+      OR: [{ status: 'CREATED' }, { volunteer: { userId: session?.user?.id } }],
+    }
+  }
+
   return await prisma.ride.findMany({
+    where,
     include: {
       client: {
         include: {
@@ -22,4 +40,3 @@ export default defineEventHandler(async (event) => {
     },
   })
 })
-

--- a/server/api/get/rides/index.ts
+++ b/server/api/get/rides/index.ts
@@ -10,15 +10,19 @@ export default defineEventHandler(async (event) => {
     | { user: { id: string; role?: string } }
     | undefined
   const role = session?.user?.role
+  const userId = session?.user?.id
 
   // Data scoping (issue #3): a VOLUNTEER must only receive rides that are
   // available to sign up for (CREATED) or that are assigned to them — never
   // other volunteers' rides or the full roster of client PII. ADMINs see all.
+  // Fail closed: if the user id is somehow absent, never widen past available
+  // rides — { volunteer: { userId: undefined } } would make Prisma drop the
+  // filter and match every assigned ride, leaking PII.
   let where: Prisma.RideWhereInput | undefined
   if (role !== 'ADMIN') {
-    where = {
-      OR: [{ status: 'CREATED' }, { volunteer: { userId: session?.user?.id } }],
-    }
+    where = userId
+      ? { OR: [{ status: 'CREATED' }, { volunteer: { userId } }] }
+      : { status: 'CREATED' }
   }
 
   return await prisma.ride.findMany({

--- a/server/api/get/volunteers/index.ts
+++ b/server/api/get/volunteers/index.ts
@@ -1,6 +1,10 @@
 import { prisma } from '../../../utils/prisma'
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
+  // Bulk volunteer roster carries full PII and is only used by admin-facing UI
+  // (create/edit-ride volunteer picker, people page) — keep it admin-only (issue #3).
+  requireAdmin(event)
+
   return await prisma.volunteer.findMany({
     include: {
       user: true,

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -35,6 +35,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
   }
 
+  // Expose the resolved session to downstream handlers so they can scope data
+  // (issue #3) without re-running the session lookup.
+  event.context.auth = session
+
   const role = (session.user as { role?: string }).role
 
   if (role === 'ADMIN') return

--- a/server/utils/authz.ts
+++ b/server/utils/authz.ts
@@ -1,0 +1,25 @@
+import type { H3Event } from 'h3'
+
+type SessionCtx = { user: { id: string; role?: string } }
+
+/**
+ * Reads the session resolved by the global auth middleware
+ * (server/middleware/auth.ts) from the event context.
+ */
+export function getAuth(event: H3Event): SessionCtx | undefined {
+  return event.context.auth as SessionCtx | undefined
+}
+
+/**
+ * Guards an endpoint so only ADMINs can reach it. Used to keep bulk PII
+ * listings (client/volunteer rosters) off limits to non-admins (issue #3).
+ * The global middleware already enforces authentication, so a missing/non-admin
+ * role here means a logged-in non-admin.
+ */
+export function requireAdmin(event: H3Event): SessionCtx {
+  const session = getAuth(event)
+  if (session?.user?.role !== 'ADMIN') {
+    throw createError({ statusCode: 403, statusMessage: 'Admin access required' })
+  }
+  return session
+}

--- a/tests/e2e/pii-scoping.test.ts
+++ b/tests/e2e/pii-scoping.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #3: a VOLUNTEER used to receive the entire ride/people database (full
+// PII) and the app filtered it client-side. The server must instead scope the
+// data to what the requesting user is authorized to see.
+
+type Ride = {
+  id: string
+  status: string
+  volunteer: { userId: string } | null
+  client: { user: { name: string; phone: string | null } } | null
+}
+
+describe('issue #3 — server-side PII scoping', () => {
+  it('ADMIN still receives every ride (full dataset)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const rides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    expect(Array.isArray(rides)).toBe(true)
+    // Seed has 9 rides across all volunteers/clients.
+    expect(rides.length).toBeGreaterThanOrEqual(9)
+    // Admin can see rides assigned to volunteers other than themselves.
+    expect(rides.some((r) => r.volunteer !== null)).toBe(true)
+  })
+
+  it('VOLUNTEER only receives available (CREATED) rides plus their own', async () => {
+    const bobCookie = await loginAs('bob@example.com')
+    const me = await $fetch<{ user: { id: string } }>('/api/get/volunteers/bySession', {
+      headers: { cookie: bobCookie },
+    })
+    const myUserId = me.user.id
+
+    const rides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: bobCookie } })
+
+    // Every returned ride must be either available (CREATED) or assigned to Bob.
+    for (const ride of rides) {
+      const isAvailable = ride.status === 'CREATED'
+      const isMine = ride.volunteer?.userId === myUserId
+      expect(
+        isAvailable || isMine,
+        `ride ${ride.id} (status=${ride.status}) leaked to a volunteer it does not belong to`
+      ).toBe(true)
+    }
+
+    // No ride assigned to a *different* volunteer may appear (this is the leak).
+    const foreignAssigned = rides.filter(
+      (r) => r.volunteer && r.volunteer.userId !== myUserId
+    )
+    expect(foreignAssigned).toEqual([])
+
+    // Bob must still see his own assigned ride and available rides.
+    expect(rides.some((r) => r.volunteer?.userId === myUserId)).toBe(true)
+    expect(rides.some((r) => r.status === 'CREATED')).toBe(true)
+  })
+
+  it('VOLUNTEER cannot bulk-download the client roster (PII)', async () => {
+    const bobCookie = await loginAs('bob@example.com')
+    await expect(
+      $fetch('/api/get/clients', { headers: { cookie: bobCookie } })
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('VOLUNTEER cannot bulk-download the volunteer roster (PII)', async () => {
+    const bobCookie = await loginAs('bob@example.com')
+    await expect(
+      $fetch('/api/get/volunteers', { headers: { cookie: bobCookie } })
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('ADMIN can still read the client and volunteer rosters', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const clients = await $fetch<unknown[]>('/api/get/clients', { headers: { cookie } })
+    const volunteers = await $fetch<unknown[]>('/api/get/volunteers', { headers: { cookie } })
+    expect(Array.isArray(clients)).toBe(true)
+    expect(clients.length).toBeGreaterThanOrEqual(3)
+    expect(Array.isArray(volunteers)).toBe(true)
+    expect(volunteers.length).toBeGreaterThanOrEqual(3)
+  })
+})


### PR DESCRIPTION
## What was broken

When a VOLUNTEER viewed their dashboard, the app fetched `/api/get/rides`, `/api/get/clients`, and `/api/get/volunteers` in full — downloading the **entire** database of rides and people (names, phone numbers, home addresses) to the browser — then hid non-relevant records with client-side JavaScript. That is a PII leak: any authenticated volunteer could read every client's address and every other volunteer's contact info straight from the network responses. The global auth middleware (PR #39) gated *access* to these routes but did not *scope* what they return.

## What changed

Server-side data scoping (the layer after authentication):

- **`server/api/get/rides/index.ts`** — a non-ADMIN now receives only rides that are available to sign up for (`status = CREATED`) **or** assigned to them (`volunteer.userId === session.user.id`). ADMINs still receive every ride. This keeps the volunteer rides dashboard working (they still see available + their own rides) while no longer leaking other volunteers' assignments and the attached client PII.
- **`server/api/get/clients/index.ts`** and **`server/api/get/volunteers/index.ts`** — now **admin-only** (`403` otherwise). These bulk PII rosters are only consumed by admin-facing UI (the create/edit-ride volunteer picker and the people-management page).
- **`server/middleware/auth.ts`** — stashes the already-resolved session in `event.context.auth` so handlers can scope without a second session lookup.
- **`server/utils/authz.ts`** (new) — small auto-imported `requireAdmin(event)` / `getAuth(event)` helpers.

No auth config, schema, CI, docker, or dependency changes.

## Verification

New regression test `tests/e2e/pii-scoping.test.ts`:
- `VOLUNTEER only receives available (CREATED) rides plus their own` — asserts every returned ride is CREATED or assigned to the requester, and that no foreign volunteer's ride appears.
- `VOLUNTEER cannot bulk-download the client roster (PII)` → expects `403`.
- `VOLUNTEER cannot bulk-download the volunteer roster (PII)` → expects `403`.
- `ADMIN still receives every ride (full dataset)` and `ADMIN can still read the client and volunteer rosters` — confirms admin behavior is unchanged.

Confirmed the three volunteer-scoping tests **fail on the unmodified code** for the right reasons (a foreign COMPLETED ride leaked to Bob; `/api/get/clients` and `/api/get/volunteers` returned full rosters) and **pass** after the fix. Full suite green (15 tests), `pnpm build` succeeds.

## Reviewer note

`app/pages/rides/index.vue` and `app/pages/rides/[id].vue` still call `useFetch('/api/get/volunteers')` unconditionally, and `rides/index.vue` also calls `/api/get/clients`. For a volunteer these now return `403`; the data was only ever used inside `v-if="isAdmin"` blocks (the volunteer picker / create-ride modal), so `useFetch` just surfaces an error ref and the computed option lists fall back to `[]` — the pages render fine and volunteer-facing functionality is unaffected. A follow-up could gate those `useFetch` calls behind `isAdmin` to avoid the benign 403s, but that is frontend cleanup out of scope here.

Fixes #3