### PR TITLE
Fix #4: role-based frontend route guards

### DIFF
--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,20 +1,40 @@
 import { authClient } from '../utils/auth-client'
 
+// Frontend route guard (issue #4) — defense in depth alongside the server-side
+// API middleware (server/middleware/auth.ts). We explicitly map which routes
+// each role may reach instead of only special-casing VOLUNTEER, so a CLIENT or
+// any unmapped role can't render internal pages (/people, /admin/*, dashboard).
+//
+// Role model (kept consistent with the server):
+//   - ADMIN     — full access to every internal page
+//   - VOLUNTEER — only /rides* and /settings
+//   - CLIENT / unmapped — no internal pages; sent to the /auth landing
+
+// Returns true when the given role is allowed to view the path.
+function canAccess(role: string | undefined, path: string): boolean {
+  if (role === 'ADMIN') return true
+
+  if (role === 'VOLUNTEER') {
+    return path.startsWith('/rides') || path === '/settings'
+  }
+
+  // CLIENT or any unmapped/unknown role: no internal pages.
+  return false
+}
+
 export default defineNuxtRouteMiddleware(async (to) => {
+  // The login page is always reachable.
+  if (to.path === '/auth') return
+
   const { data: session } = await authClient.useSession(useFetch)
 
   if (!session.value) {
-    if (to.path !== '/auth') {
-      return navigateTo('/auth')
-    }
-  } else {
-    // User is logged in
-    const role = session.value.user.role
-    if (role === 'VOLUNTEER') {
-      // Volunteers can only access /rides and its sub-paths, and /settings
-      if (!to.path.startsWith('/rides') && to.path !== '/settings') {
-        return navigateTo('/rides')
-      }
-    }
+    return navigateTo('/auth')
+  }
+
+  const role = session.value.user.role
+  if (!canAccess(role, to.path)) {
+    // Volunteers have a real landing page; everyone else goes back to /auth.
+    return navigateTo(role === 'VOLUNTEER' ? '/rides' : '/auth')
   }
 })

--- a/tests/e2e/route-guard.test.ts
+++ b/tests/e2e/route-guard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #4: the global route middleware must guard internal pages per role,
+// not only special-case VOLUNTEER. A logged-in CLIENT (or any unmapped role)
+// must not be able to render /people, /admin/*, or the dashboard.
+//
+// Nuxt route middleware runs during SSR, so a blocked navigation returns an
+// HTTP redirect. We use `fetch` (not `$fetch`) so redirects are NOT followed,
+// and assert on the redirect status + Location.
+
+// Internal admin-only pages that a CLIENT and a VOLUNTEER must never reach.
+const ADMIN_ONLY = ['/', '/people', '/admin/notifications']
+// Pages the global middleware lets a VOLUNTEER reach. `/settings` is
+// additionally guarded by the page itself (volunteer-only, out of scope for
+// #4), so we only assert /rides here for the "VOLUNTEER can reach" case.
+const VOLUNTEER_ALLOWED = ['/rides', '/settings']
+const VOLUNTEER_REACHABLE = ['/rides']
+
+function isRedirect(res: { status: number }) {
+  return res.status >= 300 && res.status < 400
+}
+
+describe('frontend route guard (#4)', () => {
+  it('redirects a logged-in CLIENT away from every internal page', async () => {
+    const cookie = await loginAs('martha@example.com')
+    for (const path of [...ADMIN_ONLY, ...VOLUNTEER_ALLOWED]) {
+      const res = await appFetch(path, { headers: { cookie }, redirect: 'manual' })
+      expect(isRedirect(res), `CLIENT should be redirected away from ${path} (got ${res.status})`).toBe(
+        true
+      )
+      const location = res.headers.get('location') || ''
+      expect(location, `CLIENT redirect from ${path} should not stay on an internal page`).toContain(
+        '/auth'
+      )
+    }
+  })
+
+  it('redirects a VOLUNTEER away from admin-only pages', async () => {
+    const cookie = await loginAs('bob@example.com')
+    for (const path of ADMIN_ONLY) {
+      const res = await appFetch(path, { headers: { cookie }, redirect: 'manual' })
+      expect(
+        isRedirect(res),
+        `VOLUNTEER should be redirected away from ${path} (got ${res.status})`
+      ).toBe(true)
+    }
+  })
+
+  it('lets a VOLUNTEER reach their own pages', async () => {
+    const cookie = await loginAs('bob@example.com')
+    for (const path of VOLUNTEER_REACHABLE) {
+      const res = await appFetch(path, { headers: { cookie }, redirect: 'manual' })
+      expect(isRedirect(res), `VOLUNTEER should reach ${path} (got redirect ${res.status})`).toBe(
+        false
+      )
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('lets an ADMIN reach the admin-only internal pages', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    for (const path of ADMIN_ONLY) {
+      const res = await appFetch(path, { headers: { cookie }, redirect: 'manual' })
+      expect(isRedirect(res), `ADMIN should reach ${path} (got redirect ${res.status})`).toBe(false)
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('redirects an unauthenticated visitor to /auth', async () => {
+    const res = await appFetch('/people', { redirect: 'manual' })
+    expect(isRedirect(res)).toBe(true)
+    expect(res.headers.get('location') || '').toContain('/auth')
+  })
+})


### PR DESCRIPTION
## What was broken

The global route middleware (`app/middleware/auth.global.ts`) only restricted users whose role was explicitly `VOLUNTEER`. Any other logged-in role fell through the `else` branch with no check, so a `CLIENT` (or any unmapped/unknown role) could render the entire internal site — `/people`, `/admin/notifications`, and the root dashboard `/`. This is the frontend route-guard half of the security model; the server-side API middleware (`server/middleware/auth.ts`, PR #40) already 401/403s API calls by role, but pages still rendered.

## What changed

Replaced the single-role special case with an explicit role→allowed-route decision (`canAccess`), keeping it consistent with the server role model:

- **ADMIN** — full access to every internal page.
- **VOLUNTEER** — only `/rides*` and `/settings`.
- **CLIENT / unmapped** — no internal pages; redirected to the `/auth` landing.

`/auth` returns early so there's no redirect loop; a blocked VOLUNTEER still lands on `/rides` (unchanged from before).

Only `app/middleware/auth.global.ts` changed (net +20 lines). No auth config, schema, CI, docker, or dependency changes.

## Verification

New SSR-level regression test: `tests/e2e/route-guard.test.ts` — `frontend route guard (#4)`. Nuxt route middleware runs during SSR, so a blocked navigation returns an HTTP redirect. The test uses `fetch` (not `$fetch`, so redirects are not auto-followed) with `redirect: 'manual'`, authenticates via `loginAs()`, and asserts:

- `redirects a logged-in CLIENT away from every internal page` — CLIENT hitting `/`, `/people`, `/admin/notifications`, `/rides`, `/settings` gets a 3xx to `/auth`.
- `redirects a VOLUNTEER away from admin-only pages` — `/`, `/people`, `/admin/notifications` redirect.
- `lets a VOLUNTEER reach their own pages` — `/rides` returns 200.
- `lets an ADMIN reach the admin-only internal pages` — `/`, `/people`, `/admin/notifications` return 200.
- `redirects an unauthenticated visitor to /auth`.

**Pre-fix:** the CLIENT test failed with `CLIENT should be redirected away from / (got 200)` — the dashboard rendered for a client. **Post-fix:** all 5 tests pass; full suite green (`vitest run` — 4 files, 20 tests); `pnpm build` succeeds.

## Reviewer notes

- `/settings` is additionally guarded by the page itself (`app/pages/settings.vue` redirects non-VOLUNTEER to `/`), so ADMIN visiting `/settings` is redirected by that page, not the middleware. That page-level guard is pre-existing and out of scope for #4, so the test only asserts VOLUNTEER can reach `/rides` (not `/settings`) and does not assert ADMIN on `/settings`.
- Access rules were inferred from the server middleware role model (`server/middleware/auth.ts`) and confirmed against the actual pages under `app/pages/` (`index`, `people`, `admin/notifications`, `rides/*`, `settings`, `auth`). Worth a sanity check that CLIENT having no internal landing (sent to `/auth`) is the intended UX.

Fixes #4