### PR TITLE
Fix #41: scope single-record & admin-only endpoints

### DIFF
--- a/server/api/get/addresses/index.ts
+++ b/server/api/get/addresses/index.ts
@@ -1,6 +1,11 @@
 import { prisma } from '../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Client addresses are PII (issue #41). Only the create-ride autocomplete
+  // uses this, and that form is admin-only (rides/index.vue gates it behind
+  // isAdmin; #3 already made the sibling clients/volunteers lists admin-only).
+  requireAdmin(event)
+
   const query = getQuery(event)
   const search = query.search as string
 

--- a/server/api/get/admins/index.ts
+++ b/server/api/get/admins/index.ts
@@ -1,6 +1,10 @@
 import { prisma } from '../../../utils/prisma'
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
+  // Admin roster is management data / PII (issue #41). Consumer: people.vue,
+  // an admin-only page (volunteers are redirected by the route guard).
+  requireAdmin(event)
+
   return await prisma.user.findMany({
     where: {
       role: 'ADMIN',

--- a/server/api/get/metrics/completionRate/index.ts
+++ b/server/api/get/metrics/completionRate/index.ts
@@ -1,6 +1,10 @@
 import { prisma } from '../../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Dashboard metrics are admin-only (issue #41). Consumer: index.vue, the
+  // admin dashboard (volunteers are redirected by the route guard, #4).
+  requireAdmin(event)
+
   const query = getQuery(event)
   const startDate = query.startDate ? new Date(String(query.startDate)) : undefined
   const endDate = query.endDate ? new Date(String(query.endDate)) : undefined

--- a/server/api/get/metrics/hours/index.ts
+++ b/server/api/get/metrics/hours/index.ts
@@ -1,6 +1,10 @@
 import { prisma } from '../../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Dashboard metrics are admin-only (issue #41). Consumer: index.vue, the
+  // admin dashboard (volunteers are redirected by the route guard, #4).
+  requireAdmin(event)
+
   const query = getQuery(event)
   const startDate = query.startDate ? new Date(String(query.startDate)) : undefined
   const endDate = query.endDate ? new Date(String(query.endDate)) : undefined

--- a/server/api/get/metrics/topRiders/index.ts
+++ b/server/api/get/metrics/topRiders/index.ts
@@ -1,8 +1,12 @@
 import { prisma } from '../../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Dashboard metrics expose client names (PII) and are admin-only (issue #41).
+  // Consumer: index.vue, the admin dashboard (volunteers are redirected, #4).
+  requireAdmin(event)
+
   const query = getQuery(event)
-  
+
   let startFilter: Date
   let endFilter: Date
 

--- a/server/api/get/rides/byId/[id].ts
+++ b/server/api/get/rides/byId/[id].ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  return await prisma.ride.findUnique({
+  const ride = await prisma.ride.findUnique({
     where: { id },
     include: {
       client: {
@@ -25,4 +25,21 @@ export default defineEventHandler(async (event) => {
       }
     }
   })
+
+  // Record-level scoping (issue #41, same class as #3): a non-admin may only
+  // retrieve a ride that is available to sign up for (CREATED) or that is
+  // assigned to them — never another volunteer's ride and its client PII.
+  // Return 404 rather than 403 so we don't reveal that the ride exists.
+  const session = getAuth(event)
+  const role = session?.user?.role
+  if (role !== 'ADMIN') {
+    const userId = session?.user?.id
+    const isAvailable = ride?.status === 'CREATED'
+    const isMine = !!userId && ride?.volunteer?.userId === userId
+    if (!ride || (!isAvailable && !isMine)) {
+      throw createError({ statusCode: 404, statusMessage: 'Ride not found' })
+    }
+  }
+
+  return ride
 })

--- a/server/api/get/users/byEmail/[email].get.ts
+++ b/server/api/get/users/byEmail/[email].get.ts
@@ -1,6 +1,9 @@
 import { prisma } from '../../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Admin management data (issue #41): looking up arbitrary users is PII.
+  requireAdmin(event)
+
   const email = getRouterParam(event, 'email')
 
   if (!email) {

--- a/server/api/get/users/byId/[id].get.ts
+++ b/server/api/get/users/byId/[id].get.ts
@@ -1,6 +1,9 @@
 import { prisma } from '../../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
+  // Admin management data (issue #41): looking up arbitrary users is PII.
+  requireAdmin(event)
+
   const id = getRouterParam(event, 'id')
 
   if (!id) {

--- a/server/api/get/users/index.ts
+++ b/server/api/get/users/index.ts
@@ -1,5 +1,7 @@
 import { prisma } from '../../../utils/prisma'
 
 export default defineEventHandler((event) => {
+  // Admin management data (issue #41): the full user table is PII.
+  requireAdmin(event)
   return prisma.user.findMany()
 })

--- a/tests/e2e/record-scoping.test.ts
+++ b/tests/e2e/record-scoping.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #41: #3 scoped the *list* endpoints, but single-record and other
+// authenticated endpoints still returned full data to any logged-in non-admin.
+//   - get/rides/byId/[id]  — a volunteer could fetch ANY ride (client PII),
+//     even one not theirs and not available -> must be record-scoped.
+//   - get/users/*, get/admins, get/addresses, get/metrics/* — admin-only data.
+
+type Ride = {
+  id: string
+  status: string
+  volunteer: { userId: string } | null
+  client: { user: { name: string; phone: string | null } } | null
+}
+
+describe('issue #41 — single-record & admin-only endpoint scoping', () => {
+  describe('get/rides/byId/[id] — record scoping', () => {
+    it('VOLUNTEER cannot fetch another volunteer\'s non-available ride by id (404)', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const bobCookie = await loginAs('bob@example.com')
+      const me = await $fetch<{ user: { id: string } }>('/api/get/volunteers/bySession', {
+        headers: { cookie: bobCookie },
+      })
+      const myUserId = me.user.id
+
+      // Admin sees every ride; find one that is NOT available (CREATED) and NOT
+      // Bob's — i.e. a ride assigned to (or completed by) another volunteer.
+      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const foreign = allRides.find(
+        (r) => r.status !== 'CREATED' && r.volunteer && r.volunteer.userId !== myUserId
+      )
+      expect(foreign, 'seed should contain a ride owned by another volunteer').toBeTruthy()
+
+      await expect(
+        $fetch(`/api/get/rides/byId/${foreign!.id}`, { headers: { cookie: bobCookie } })
+      ).rejects.toMatchObject({ statusCode: 404 })
+    })
+
+    it('VOLUNTEER CAN fetch an available (CREATED) ride by id', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const bobCookie = await loginAs('bob@example.com')
+
+      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const available = allRides.find((r) => r.status === 'CREATED')
+      expect(available, 'seed should contain an available ride').toBeTruthy()
+
+      const ride = await $fetch<Ride>(`/api/get/rides/byId/${available!.id}`, {
+        headers: { cookie: bobCookie },
+      })
+      expect(ride.id).toBe(available!.id)
+    })
+
+    it('VOLUNTEER CAN fetch their own assigned ride by id', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const bobCookie = await loginAs('bob@example.com')
+      const me = await $fetch<{ user: { id: string } }>('/api/get/volunteers/bySession', {
+        headers: { cookie: bobCookie },
+      })
+      const myUserId = me.user.id
+
+      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const mine = allRides.find((r) => r.volunteer && r.volunteer.userId === myUserId)
+      expect(mine, 'seed should contain a ride assigned to Bob').toBeTruthy()
+
+      const ride = await $fetch<Ride>(`/api/get/rides/byId/${mine!.id}`, {
+        headers: { cookie: bobCookie },
+      })
+      expect(ride.id).toBe(mine!.id)
+    })
+
+    it('ADMIN can fetch any ride by id', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const anyAssigned = allRides.find((r) => r.status !== 'CREATED' && r.volunteer)
+      expect(anyAssigned).toBeTruthy()
+      const ride = await $fetch<Ride>(`/api/get/rides/byId/${anyAssigned!.id}`, {
+        headers: { cookie: adminCookie },
+      })
+      expect(ride.id).toBe(anyAssigned!.id)
+    })
+  })
+
+  describe('admin-only endpoints', () => {
+    const adminOnly = [
+      '/api/get/users',
+      '/api/get/admins',
+      '/api/get/addresses',
+      '/api/get/metrics/completionRate',
+      '/api/get/metrics/hours',
+      '/api/get/metrics/topRiders',
+    ]
+
+    for (const path of adminOnly) {
+      it(`VOLUNTEER gets 403 on ${path}`, async () => {
+        const bobCookie = await loginAs('bob@example.com')
+        await expect(
+          $fetch(path, { headers: { cookie: bobCookie } })
+        ).rejects.toMatchObject({ statusCode: 403 })
+      })
+
+      it(`ADMIN still succeeds on ${path}`, async () => {
+        const adminCookie = await loginAs('reachtusharwani@gmail.com')
+        const res = await $fetch(path, { headers: { cookie: adminCookie } })
+        expect(res).toBeDefined()
+      })
+    }
+
+    it('VOLUNTEER gets 403 on get/users/byId/[id]', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const bobCookie = await loginAs('bob@example.com')
+      const admins = await $fetch<{ id: string }[]>('/api/get/admins', {
+        headers: { cookie: adminCookie },
+      })
+      const someUserId = admins[0]!.id
+      await expect(
+        $fetch(`/api/get/users/byId/${someUserId}`, { headers: { cookie: bobCookie } })
+      ).rejects.toMatchObject({ statusCode: 403 })
+    })
+
+    it('ADMIN can read get/users/byId/[id]', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const admins = await $fetch<{ id: string; email: string }[]>('/api/get/admins', {
+        headers: { cookie: adminCookie },
+      })
+      const target = admins[0]!
+      const byId = await $fetch<{ id: string }>(`/api/get/users/byId/${target.id}`, {
+        headers: { cookie: adminCookie },
+      })
+      expect(byId.id).toBe(target.id)
+    })
+
+    it('VOLUNTEER gets 403 on get/users/byEmail/[email] (admin still not 403)', async () => {
+      const adminCookie = await loginAs('reachtusharwani@gmail.com')
+      const bobCookie = await loginAs('bob@example.com')
+      const email = 'martha@example.com'
+      await expect(
+        $fetch(`/api/get/users/byEmail/${email}`, { headers: { cookie: bobCookie } })
+      ).rejects.toMatchObject({ statusCode: 403 })
+      // ADMIN must not be blocked by the guard (200 with body or null, never 403).
+      await $fetch(`/api/get/users/byEmail/${email}`, { headers: { cookie: adminCookie } })
+    })
+  })
+})


### PR DESCRIPTION
## What was broken

#3 scoped the **list** endpoints (`get/rides`, `get/clients`, `get/volunteers`), but single-record and other authenticated endpoints still returned full data to any logged-in non-admin VOLUNTEER. A volunteer could fetch **any** ride by id — including client name/phone/address — even for rides not theirs and not available; and `get/users/*`, `get/admins`, `get/addresses`, `get/metrics/*` had no per-user scoping (e.g. a volunteer could pull the completion-rate/hours metrics and the top-riders list of client names).

## What changed

Reuses the existing `getAuth`/`requireAdmin` helpers in `server/utils/authz.ts` (from #3) — no new mechanism.

**Record-scoped** (mirrors `get/rides/index.ts`):
- `server/api/get/rides/byId/[id].ts` — a non-admin may retrieve a ride **only** if it is `CREATED` (available to sign up) or assigned to them; otherwise **404**. 404 rather than 403 is deliberate so the endpoint does not reveal that a ride the caller isn't authorized to see exists. ADMIN sees any ride; the not-found case for ADMIN still returns `null` as before.

**Made admin-only** (`requireAdmin` → 403 for non-admins). Consumers checked:
- `server/api/get/users/index.ts`, `byId/[id].get.ts`, `byEmail/[email].get.ts` — no frontend consumers; pure admin management data.
- `server/api/get/admins/index.ts` — consumer `app/pages/people.vue`, an admin-only page (route guard redirects volunteers).
- `server/api/get/addresses/index.ts` — consumer is the create-ride autocomplete on `app/pages/rides/index.vue`, which is admin-gated (`v-if="isAdmin"`); the sibling `clients`/`volunteers` fetches on that same page were already made admin-only in #3, so the shared page already tolerates a 403 on an unconditional `useFetch`.
- `server/api/get/metrics/completionRate|hours|topRiders/index.ts` — consumer `app/pages/index.vue`, the admin dashboard guarded by the route middleware from #4.

## Verification

Regression test: `tests/e2e/record-scoping.test.ts`.

**Revert-check (test proves the bug):** with the source fix stashed (test only), the 9 security assertions fail for the right reason — the volunteer receives the protected data instead of a rejection, e.g.:
- `byId` foreign ride: `promise resolved "{ …(16) }" instead of rejecting` (expected 404)
- `/api/get/metrics/completionRate`: `promise resolved "{ percentage: 33, total: 9, …(1) }" instead of rejecting` (expected 403)
- `/api/get/metrics/topRiders`: `promise resolved "[ { name: 'Sarah Connor', …(1) }, …(2) ]"` (expected 403)
- `/api/get/users`, `/api/get/admins`, `/api/get/addresses`, `get/users/byId`, `get/users/byEmail` all resolved with data instead of 403.

With the fix restored, all pass. **Full suite: 39 passed (5 files). `pnpm build` succeeds.**

Test coverage added:
- VOLUNTEER gets 404 fetching another volunteer's non-available ride by id; CAN fetch an available (`CREATED`) ride and their own assigned ride; ADMIN can fetch any.
- VOLUNTEER gets 403 on each admin-only endpoint; ADMIN still succeeds.

Fixes #41