### PR TITLE
Fix #31: validate request bodies on write endpoints

### DIFF
--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -1,10 +1,30 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
 import { sendEmail } from '../../../utils/email'
 import { sendNotification } from '../../../utils/notification'
+import { readValidatedBody } from '../../../utils/validation'
+
+// Whitelist of the ONLY fields an update may set (issue #31). Anything else
+// (clientId, createdAt, address ids, unknown keys, …) is rejected with a 400
+// rather than mass-assigned into prisma.ride.update. All fields are optional so
+// partial updates (e.g. the "mark complete" flow sending only status +
+// totalRideTime) still work; unknown keys are rejected via .strict().
+const updateRideSchema = z
+  .object({
+    status: z.enum(['CREATED', 'ASSIGNED', 'COMPLETED']).optional(),
+    // Empty string means "unassign"; handled below into null.
+    volunteerId: z.string().nullable().optional(),
+    scheduledTime: z.string().min(1).optional(),
+    pickupTime: z.string().min(1).nullable().optional(),
+    totalRideTime: z.number().optional(),
+    notes: z.string().nullable().optional(),
+    pickupDisplay: z.string().min(1).optional(),
+    dropoffDisplay: z.string().min(1).optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
-  const body = await readBody(event)
 
   if (!id) {
     throw createError({
@@ -12,6 +32,8 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'ID is required',
     })
   }
+
+  const body = await readValidatedBody(event, updateRideSchema)
 
   // Fetch existing ride to check previous state
   const existingRide = await prisma.ride.findUnique({
@@ -33,24 +55,36 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const updateData: any = { ...body }
-  if (updateData.scheduledTime) {
-    updateData.scheduledTime = new Date(updateData.scheduledTime)
+  // Build the Prisma update payload only from validated, whitelisted fields.
+  const updateData: {
+    status?: 'CREATED' | 'ASSIGNED' | 'COMPLETED'
+    volunteerId?: string | null
+    scheduledTime?: Date
+    pickupTime?: Date | null
+    totalRideTime?: number
+    notes?: string | null
+    pickupDisplay?: string
+    dropoffDisplay?: string
+  } = {}
+
+  if (body.status !== undefined) updateData.status = body.status
+  if (body.totalRideTime !== undefined) updateData.totalRideTime = body.totalRideTime
+  if (body.notes !== undefined) updateData.notes = body.notes
+  if (body.pickupDisplay !== undefined) updateData.pickupDisplay = body.pickupDisplay
+  if (body.dropoffDisplay !== undefined) updateData.dropoffDisplay = body.dropoffDisplay
+
+  if (body.scheduledTime !== undefined) {
+    updateData.scheduledTime = new Date(body.scheduledTime)
   }
-  if (updateData.pickupTime) {
-    updateData.pickupTime = new Date(updateData.pickupTime)
-  } else if (updateData.pickupTime === null) {
-    // allow clearing the pickup time
-    updateData.pickupTime = null
+  if (body.pickupTime !== undefined) {
+    // null (or empty) clears the pickup time; a string sets it.
+    updateData.pickupTime = body.pickupTime ? new Date(body.pickupTime) : null
   }
 
-  // Handle volunteer assignment/unassignment
+  // Handle volunteer assignment/unassignment (empty string => unassign)
   if (body.volunteerId !== undefined) {
-    if (body.volunteerId && body.volunteerId.trim() !== '') {
-      updateData.volunteerId = body.volunteerId
-    } else {
-      updateData.volunteerId = null
-    }
+    updateData.volunteerId =
+      body.volunteerId && body.volunteerId.trim() !== '' ? body.volunteerId : null
   }
 
   const ride = await prisma.ride.update({
@@ -111,7 +145,7 @@ export default defineEventHandler(async (event) => {
 
   // 2. RIDE_CANCELLED
   // (Currently no CANCELLED status in RideStatus enum, handling for future proofing or custom status strings)
-  if (body.status === 'CANCELLED' && (existingRide.status as string) !== 'CANCELLED') {
+  if ((body.status as string) === 'CANCELLED' && (existingRide.status as string) !== 'CANCELLED') {
     // Notify the volunteer who WAS assigned (even if unassigned in this update, though unlikely for cancellation)
     // Assuming volunteer is still attached or was attached in existingRide
     const volunteerToNotify = existingRide.volunteer // Notify the volunteer who was assigned before cancellation

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,23 @@
+import type { H3Event } from 'h3'
+import type { ZodType } from 'zod'
+
+/**
+ * Reads and validates the request body against a zod schema (issue #31).
+ *
+ * On failure throws a 400 with per-field messages instead of letting an
+ * unvalidated body reach Prisma (which mass-assigns unknown columns and
+ * 500s on unrecognized keys). On success returns the parsed, whitelisted
+ * data — callers should build their Prisma `data` object only from this.
+ */
+export async function readValidatedBody<T>(event: H3Event, schema: ZodType<T>): Promise<T> {
+  const body = await readBody(event)
+  const result = schema.safeParse(body)
+  if (!result.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid request body',
+      data: { errors: result.error.flatten().fieldErrors },
+    })
+  }
+  return result.data
+}

--- a/tests/e2e/ride-input-validation.test.ts
+++ b/tests/e2e/ride-input-validation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Regression coverage for issue #31: PUT /api/put/rides/[id] spread the raw
+// request body straight into prisma.ride.update, allowing mass assignment of
+// any column and 500-ing on unknown keys.
+
+async function adminCookie() {
+  return loginAs('reachtusharwani@gmail.com')
+}
+
+async function firstRideId(cookie: string): Promise<string> {
+  const rides = await $fetch<Array<{ id: string }>>('/api/get/rides', {
+    headers: { cookie },
+  })
+  expect(rides.length).toBeGreaterThan(0)
+  return rides[0]!.id
+}
+
+describe('PUT /api/put/rides/[id] input validation (#31)', () => {
+  it('rejects a forbidden field (mass assignment) with 400 and does not persist it', async () => {
+    const cookie = await adminCookie()
+    const id = await firstRideId(cookie)
+
+    const before = await $fetch<{ clientId: string }>(`/api/get/rides/byId/${id}`, {
+      headers: { cookie },
+    })
+
+    await expect(
+      $fetch(`/api/put/rides/${id}`, {
+        method: 'PUT',
+        headers: { cookie },
+        body: {
+          status: 'ASSIGNED',
+          clientId: 'forged-client-id',
+          totalRideTime: 999,
+          createdAt: '2000-01-01T00:00:00.000Z',
+        },
+      })
+    ).rejects.toMatchObject({ statusCode: 400 })
+
+    const after = await $fetch<{ clientId: string }>(`/api/get/rides/byId/${id}`, {
+      headers: { cookie },
+    })
+    // The forbidden clientId must not have been written.
+    expect(after.clientId).toBe(before.clientId)
+    expect(after.clientId).not.toBe('forged-client-id')
+  })
+
+  it('rejects an unknown/bogus key with 400 instead of an opaque 500', async () => {
+    const cookie = await adminCookie()
+    const id = await firstRideId(cookie)
+
+    await expect(
+      $fetch(`/api/put/rides/${id}`, {
+        method: 'PUT',
+        headers: { cookie },
+        body: { notAColumn: 'boom' },
+      })
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('accepts a valid update (status + notes) and returns 200', async () => {
+    const cookie = await adminCookie()
+    const id = await firstRideId(cookie)
+
+    const updated = await $fetch<{ status: string; notes: string | null }>(
+      `/api/put/rides/${id}`,
+      {
+        method: 'PUT',
+        headers: { cookie },
+        body: { status: 'ASSIGNED', notes: 'validated update ok' },
+      }
+    )
+    expect(updated.status).toBe('ASSIGNED')
+    expect(updated.notes).toBe('validated update ok')
+  })
+
+  it('accepts unassigning a volunteer via empty-string volunteerId (preserved behavior)', async () => {
+    const cookie = await adminCookie()
+    const id = await firstRideId(cookie)
+
+    const updated = await $fetch<{ volunteerId: string | null }>(`/api/put/rides/${id}`, {
+      method: 'PUT',
+      headers: { cookie },
+      body: { volunteerId: '' },
+    })
+    expect(updated.volunteerId).toBeNull()
+  })
+})


### PR DESCRIPTION
## What was broken

`server/api/put/rides/[id].ts` spread the entire client-controlled request body straight into `prisma.ride.update` (`const updateData: any = { ...body }`). This allowed **mass assignment** of any `Ride` column (overwrite `clientId`, forge `createdAt`/`totalRideTime`/`pickupDisplay`, etc.) and, because Prisma rejects unrecognized keys, any slightly-wrong payload crashed the request with an opaque **500** (`PrismaClientValidationError`).

## What changed

- New shared helper `server/utils/validation.ts` — `readValidatedBody(event, schema)` reads the body, `safeParse`s it, and throws a **400** with per-field error messages on failure (Nitro auto-imports `server/utils/*`).
- `server/api/put/rides/[id].ts` now defines a `.strict()` zod schema of only the updatable fields (`status` enum CREATED|ASSIGNED|COMPLETED, `volunteerId` nullable, `scheduledTime`, `pickupTime` nullable, `totalRideTime`, `notes`, `pickup/dropoffDisplay`), parses the body through the helper, and builds the Prisma `data` object **only** from parsed fields. Unknown/forbidden keys now 400.

**Preserved behavior:** `volunteerId` empty-string → `null` unassign, `scheduledTime`/`pickupTime` Date conversion (null/empty clears `pickupTime`), and the RIDE_COMPLETED / (dead) RIDE_CANCELLED notification side effects — all now read from the validated object.

## Scope

- **Covered:** `PUT /api/put/rides/[id]` (the sharpest instance — the only true mass-assignment sink; `post/rides/index.ts` already whitelists its `data`).
- **Deferred (follow-up):** applying `readValidatedBody` + schemas to `post/rides/index.ts`, `put/clients/[id]`, `put/volunteers/[id]` and other writes for type-level input validation. These do not mass-assign today (they build `data` explicitly), so kept out to preserve reviewability. The new helper makes those a small drop-in.

No changes to the RideStatus enum, prisma schema, auth, CI, docker, or dependencies (zod was already present).

## Verification

New regression test `tests/e2e/ride-input-validation.test.ts`:
- `rejects a forbidden field (mass assignment) with 400 and does not persist it`
- `rejects an unknown/bogus key with 400 instead of an opaque 500`
- `accepts a valid update (status + notes) and returns 200`
- `accepts unassigning a volunteer via empty-string volunteerId (preserved behavior)`

**Before the fix** the two mass-assignment/unknown-key cases failed because the endpoint returned `500 Server Error` instead of `400` (e.g. `expected FetchError: [PUT] ... 500 Server Error to match object { statusCode: 400 }`). **After the fix** all 4 pass.

- `pnpm test` — 6 files, 43 tests green.
- `pnpm build` — succeeds.

Fixes #31