### PR TITLE
Fix #21: derive trusted origins from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 DATABASE_URL=file:./dev.db
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3000
+# Optional: extra comma-separated origins trusted for CSRF/Origin validation.
+# BETTER_AUTH_URL (and APP_URL, if set) are trusted automatically.
+# TRUSTED_ORIGINS=https://rides.example.org
 EMAIL_USER=
 EMAIL_PASS=""
 NUXT_PUBLIC_GOOGLE_MAPS_API_KEY=

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -6,6 +6,40 @@ import nodemailer from 'nodemailer'
 import { createAuthMiddleware, APIError } from 'better-auth/api'
 import { sendEmail } from './email'
 
+/**
+ * Resolve the list of origins better-auth trusts for CSRF/Origin validation.
+ *
+ * Derives the list from the environment instead of hardcoding a value, so a
+ * production deployment trusts its real domain (issue #21):
+ *   - BETTER_AUTH_URL / APP_URL — the app's own origin(s), already used
+ *     elsewhere in this project.
+ *   - TRUSTED_ORIGINS — optional comma-separated list of extra origins.
+ * `http://localhost:3000` is always included so local dev and the e2e harness
+ * keep working.
+ *
+ * Pure and env-injected so it can be unit-tested without booting better-auth.
+ */
+export function resolveTrustedOrigins(
+  env: Record<string, string | undefined>,
+): string[] {
+  const origins = ['http://localhost:3000']
+
+  for (const key of ['BETTER_AUTH_URL', 'APP_URL']) {
+    const value = env[key]?.trim()
+    if (value) origins.push(value)
+  }
+
+  const extra = env.TRUSTED_ORIGINS
+  if (extra) {
+    for (const origin of extra.split(',')) {
+      const trimmed = origin.trim()
+      if (trimmed) origins.push(trimmed)
+    }
+  }
+
+  return [...new Set(origins)]
+}
+
 const transporter = nodemailer.createTransport({
   service: 'gmail',
   auth: {
@@ -18,7 +52,7 @@ export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: 'sqlite',
   }),
-  trustedOrigins: ['http://localhost:3000', 'http://192.168.4.240:3000'],
+  trustedOrigins: resolveTrustedOrigins(process.env),
   // Disabled only in the e2e suite (production build ⇒ rate limiting on by
   // default, which throttles a test that logs in many times from one IP).
   rateLimit: {

--- a/tests/e2e/trusted-origins.test.ts
+++ b/tests/e2e/trusted-origins.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTrustedOrigins } from '../../server/utils/auth'
+
+// Pure-function unit test for the trusted-origins resolver (issue #21).
+// Intentionally does NOT call setup() — it exercises a pure helper and must
+// not boot the Nuxt app, so it stays fast.
+describe('resolveTrustedOrigins', () => {
+  it('falls back to the localhost dev default when no relevant env is set', () => {
+    const origins = resolveTrustedOrigins({})
+    expect(origins).toContain('http://localhost:3000')
+  })
+
+  it('never includes the old hardcoded LAN IP by default', () => {
+    const origins = resolveTrustedOrigins({})
+    expect(origins).not.toContain('http://192.168.4.240:3000')
+  })
+
+  it('includes BETTER_AUTH_URL when set', () => {
+    const origins = resolveTrustedOrigins({
+      BETTER_AUTH_URL: 'https://rides.example.org',
+    })
+    expect(origins).toContain('https://rides.example.org')
+  })
+
+  it('includes APP_URL when set', () => {
+    const origins = resolveTrustedOrigins({
+      APP_URL: 'https://app.example.org',
+    })
+    expect(origins).toContain('https://app.example.org')
+  })
+
+  it('includes both BETTER_AUTH_URL and APP_URL when both are set', () => {
+    const origins = resolveTrustedOrigins({
+      BETTER_AUTH_URL: 'https://auth.example.org',
+      APP_URL: 'https://app.example.org',
+    })
+    expect(origins).toContain('https://auth.example.org')
+    expect(origins).toContain('https://app.example.org')
+  })
+
+  it('includes every origin from a comma-separated TRUSTED_ORIGINS', () => {
+    const origins = resolveTrustedOrigins({
+      TRUSTED_ORIGINS: 'https://a.com,https://b.com',
+    })
+    expect(origins).toContain('https://a.com')
+    expect(origins).toContain('https://b.com')
+  })
+
+  it('trims whitespace and ignores blank entries in TRUSTED_ORIGINS', () => {
+    const origins = resolveTrustedOrigins({
+      TRUSTED_ORIGINS: ' https://a.com ,  , https://b.com , ',
+    })
+    expect(origins).toContain('https://a.com')
+    expect(origins).toContain('https://b.com')
+    expect(origins).not.toContain('')
+    expect(origins).not.toContain(' ')
+  })
+
+  it('does not produce duplicate origins', () => {
+    const origins = resolveTrustedOrigins({
+      BETTER_AUTH_URL: 'http://localhost:3000',
+      APP_URL: 'http://localhost:3000',
+    })
+    const unique = new Set(origins)
+    expect(unique.size).toBe(origins.length)
+  })
+})


### PR DESCRIPTION
## What was broken
`server/utils/auth.ts` hardcoded `trustedOrigins: ['http://localhost:3000', 'http://192.168.4.240:3000']`. In production, better-auth's CSRF/Origin validation would reject logins from the real production domain (it isn't in the list), while a stale LAN IP was trusted.

## What changed
- Added `resolveTrustedOrigins(env)` — a pure, env-injected helper in `server/utils/auth.ts` that builds the trusted-origins list from:
  - `BETTER_AUTH_URL` and/or `APP_URL` (env vars already used elsewhere in this project),
  - an optional comma-separated `TRUSTED_ORIGINS` for extra origins (trimmed; blanks ignored),
  - always including `http://localhost:3000` so local dev and the e2e harness keep working.
  - Duplicates are de-duplicated.
- Dropped the hardcoded `192.168.4.240` LAN IP (add it back via `TRUSTED_ORIGINS` only if needed).
- Passed the helper result into `betterAuth({ trustedOrigins: resolveTrustedOrigins(process.env) })`.
- Documented the optional `TRUSTED_ORIGINS` var in `.env.example`.

No other auth behavior (OTP, hooks, session, rate limit) was touched.

## Verification
- New regression test `tests/e2e/trusted-origins.test.ts` (`describe('resolveTrustedOrigins')`) — a pure-function unit test that does **not** call `setup()`, so it does not boot the Nuxt app and stays fast. It asserts: no-env → includes `http://localhost:3000` and **not** the old `http://192.168.4.240:3000`; `BETTER_AUTH_URL`/`APP_URL` set → that origin is included; `TRUSTED_ORIGINS="https://a.com,https://b.com"` → both included; whitespace trimmed / blanks ignored; no duplicates.
- **Pre-fix**: the new test failed with `TypeError: resolveTrustedOrigins is not a function` (helper did not exist / origins were hardcoded). **Post-fix**: passes.
- **Full suite green**: `pnpm test` → `Test Files 7 passed (7)`, `Tests 51 passed (51)`. This confirms `loginAs()`/OTP login still works end-to-end against localhost with the new default.
- **Build**: `pnpm build` succeeds.

## NOTE — needs human review (auth config change)
This changes authentication configuration. For login to work in production after this change, the deployment **must set at least one** of:
- `BETTER_AUTH_URL` = the production origin (e.g. `https://rides.example.org`), and/or
- `APP_URL` = the production origin.

Optionally set `TRUSTED_ORIGINS` (comma-separated) for any additional trusted origins. If neither `BETTER_AUTH_URL` nor `APP_URL` is set in production, only `http://localhost:3000` is trusted and production logins will fail — so this env config is required at deploy time.

Fixes #21