### PR TITLE
Fix #12: atomic ride signup to close signup race

### DIFF
--- a/server/api/post/rides/[id]/signup.ts
+++ b/server/api/post/rides/[id]/signup.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '../../../../../prisma/generated/client'
 import { prisma } from '../../../../utils/prisma'
 import { auth } from '../../../../utils/auth'
 import { sendEmail } from '../../../../utils/email'
@@ -71,14 +72,35 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // 3. Assign Volunteer
-  const updatedRide = await prisma.ride.update({
-    where: { id },
-    data: {
-      volunteerId: volunteer.id,
-      status: 'ASSIGNED'
+  // 3. Assign Volunteer (atomic — issue #12)
+  // The pre-checks above give good error messages, but they are a read
+  // separate from the write below: two volunteers can both pass the in-memory
+  // `ride.status === 'CREATED'` check and then race to update, with the second
+  // silently overwriting the first (TOCTOU). Put the precondition inside the
+  // WHERE clause so the assignment only succeeds while the ride is still
+  // unclaimed. If it was taken in between, Prisma throws P2025 (record to
+  // update not found) and we reject cleanly instead of overwriting.
+  let updatedRide
+  try {
+    updatedRide = await prisma.ride.update({
+      where: { id, status: 'CREATED', volunteerId: null },
+      data: {
+        volunteerId: volunteer.id,
+        status: 'ASSIGNED'
+      }
+    })
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2025'
+    ) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'Ride is no longer available',
+      })
     }
-  })
+    throw err
+  }
 
   // 4. Notifications
   const admins = await prisma.user.findMany({

--- a/server/api/post/rides/[id]/unsignup.ts
+++ b/server/api/post/rides/[id]/unsignup.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '../../../../../prisma/generated/client'
 import { prisma } from '../../../../utils/prisma'
 import { auth } from '../../../../utils/auth'
 import { sendEmail } from '../../../../utils/email'
@@ -63,14 +64,32 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // 3. Unassign Volunteer
-  const updatedRide = await prisma.ride.update({
-    where: { id },
-    data: {
-      volunteerId: null,
-      status: 'CREATED'
+  // 3. Unassign Volunteer (atomic — issue #12, same check-then-act shape)
+  // Guard the update on the state we validated above so a concurrent unsignup
+  // (or a reassignment) can't cause a redundant/incorrect unassign. If the ride
+  // is no longer this volunteer's ASSIGNED ride, Prisma throws P2025 and we
+  // reject cleanly.
+  let updatedRide
+  try {
+    updatedRide = await prisma.ride.update({
+      where: { id, status: 'ASSIGNED', volunteerId: volunteer.id },
+      data: {
+        volunteerId: null,
+        status: 'CREATED'
+      }
+    })
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2025'
+    ) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'Ride is no longer available',
+      })
     }
-  })
+    throw err
+  }
 
   // 4. Notifications
   const admins = await prisma.user.findMany({

--- a/tests/e2e/signup-race.test.ts
+++ b/tests/e2e/signup-race.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #12 (TOCTOU race): signup.ts read the ride, checked status in memory,
+// then updated with `where: { id }` only. Two volunteers signing up at the same
+// time could both pass the in-memory check, and the second would silently
+// overwrite the first. The fix moves the precondition into the update's WHERE
+// clause (`{ id, status: 'CREATED', volunteerId: null }`) and treats Prisma's
+// P2025 as "already taken" (409).
+//
+// Caveat: the test DB uses the synchronous better-sqlite3 adapter, which
+// serializes writes and does not yield mid-handler, so through the HTTP layer
+// the pre-fix code never actually double-assigns (the loser's separate read
+// already sees ASSIGNED and the in-memory pre-check returns 400). These tests
+// therefore pin the *invariant* — exactly one winner, assignment never
+// overwritten — which the WHERE-clause guard guarantees under any adapter that
+// does interleave. See the PR body for the revert-check / code-review evidence.
+
+type Ride = {
+  id: string
+  status: string
+  volunteerId: string | null
+}
+
+async function rawSignup(rideId: string, cookie: string): Promise<number> {
+  const res = await appFetch(`/api/post/rides/${rideId}/signup`, {
+    method: 'POST',
+    headers: { cookie },
+  })
+  return res.status
+}
+
+async function findCreatedRideId(adminCookie: string): Promise<string> {
+  const rides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+  const created = rides.find((r) => r.status === 'CREATED' && r.volunteerId === null)
+  expect(created, 'seed should contain an available (CREATED) ride').toBeTruthy()
+  return created!.id
+}
+
+describe('issue #12 — atomic ride signup', () => {
+  it('two concurrent signups for the same ride: exactly one wins, no overwrite', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bobCookie = await loginAs('bob@example.com')
+    const aliceCookie = await loginAs('alice@example.com')
+
+    const rideId = await findCreatedRideId(adminCookie)
+
+    // Fire two genuinely concurrent signups from two AVAILABLE volunteers.
+    const results = await Promise.allSettled([
+      rawSignup(rideId, bobCookie),
+      rawSignup(rideId, aliceCookie),
+    ])
+
+    const statuses = results.map((r) => (r.status === 'fulfilled' ? r.value : 500))
+    const okCount = statuses.filter((s) => s === 200).length
+    const rejectedCount = statuses.filter((s) => s === 409 || s === 400).length
+
+    // Exactly one winner; the loser must be cleanly rejected (not silently
+    // overwriting the winner). The invariant that must hold no matter how the
+    // two requests interleave: never two winners, never an overwrite.
+    expect(okCount, `expected exactly one 200, got statuses ${statuses.join(',')}`).toBe(1)
+    expect(rejectedCount, `expected exactly one 409/400, got statuses ${statuses.join(',')}`).toBe(1)
+
+    // The final assignment must belong to whichever request returned 200, and
+    // must never have been overwritten by the loser.
+    const bobStatus = statuses[0]
+    const winnerCookie = bobStatus === 200 ? bobCookie : aliceCookie
+    const winnerVol = await $fetch<{ id: string }>('/api/get/volunteers/bySession', {
+      headers: { cookie: winnerCookie },
+    })
+
+    const ride = await $fetch<Ride>(`/api/get/rides/byId/${rideId}`, {
+      headers: { cookie: adminCookie },
+    })
+    expect(ride.status).toBe('ASSIGNED')
+    expect(ride.volunteerId).toBe(winnerVol.id)
+  })
+
+  it('signing up for an already-ASSIGNED ride is rejected (deterministic guard)', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bobCookie = await loginAs('bob@example.com')
+    const aliceCookie = await loginAs('alice@example.com')
+
+    const rideId = await findCreatedRideId(adminCookie)
+
+    // Bob claims it first (deterministically).
+    const first = await rawSignup(rideId, bobCookie)
+    expect(first).toBe(200)
+
+    // Alice now tries to claim the already-ASSIGNED ride — must be rejected,
+    // never overwriting Bob's assignment.
+    const second = await rawSignup(rideId, aliceCookie)
+    expect(second === 409 || second === 400, `expected 409/400, got ${second}`).toBe(true)
+
+    const bob = await $fetch<{ id: string }>('/api/get/volunteers/bySession', {
+      headers: { cookie: bobCookie },
+    })
+    const ride = await $fetch<Ride>(`/api/get/rides/byId/${rideId}`, {
+      headers: { cookie: adminCookie },
+    })
+    expect(ride.status).toBe('ASSIGNED')
+    expect(ride.volunteerId).toBe(bob.id)
+  })
+})


### PR DESCRIPTION
## What was broken

`server/api/post/rides/[id]/signup.ts` performed a classic check-then-act (TOCTOU) race: it read the ride with `findUnique`, checked `ride.status === 'CREATED'` in memory, then issued a **separate** `prisma.ride.update({ where: { id }, ... })` setting `volunteerId` + `status: 'ASSIGNED'`. Two volunteers signing up at the same time could both pass the in-memory check, and the second update would silently overwrite the first — the losing volunteer's assignment vanishes with no error.

## What changed

- **`signup.ts`** — moved the precondition into the update's WHERE clause: `where: { id, status: 'CREATED', volunteerId: null }`. The assignment now only succeeds while the ride is still unclaimed. If the ride was taken in the meantime, Prisma throws `P2025` (record to update not found); we catch it and return a clean **409 "Ride is no longer available"** instead of overwriting. The existing pre-checks (volunteer exists, AVAILABLE, ride exists/CREATED) are kept for good error messages, but the WHERE-clause guard is the real fix. Winner-only notification side effects are preserved — they run only after a successful guarded update, so a lost race sends no "you signed up" email.
- **`unsignup.ts`** — same check-then-act shape (lower stakes), given the identical atomic guard (`where: { id, status: 'ASSIGNED', volunteerId: volunteer.id }` + P2025 → 409). Small and clearly-correct; kept in this PR per the issue's verification comment.

No schema/auth/CI/docker/deps changes.

## Verification

- **Regression test:** `tests/e2e/signup-race.test.ts`
  - `two concurrent signups for the same ride: exactly one wins, no overwrite` — fires two genuinely concurrent signups (bob + alice, both seeded AVAILABLE) via `Promise.allSettled` of raw signup requests, each with its own `loginAs` cookie. Asserts exactly one 200, exactly one 409/400, and that the ride ends up ASSIGNED to whichever request returned 200 (never overwritten).
  - `signing up for an already-ASSIGNED ride is rejected (deterministic guard)` — bob claims the ride, then alice's attempt is rejected and bob's assignment is unchanged.
- `pnpm test` — full suite green: **8 files, 53 tests passed** (SMTP "Missing credentials" logs are the expected swallowed email failures, issue #25).
- `pnpm build` — succeeds.

### Note on forcing the race pre-fix
The test DB uses the synchronous **better-sqlite3** adapter, which serializes writes and does not yield mid-handler. Through the HTTP layer the pre-fix code therefore never actually double-assigns — even under a 20-way concurrent probe it consistently produced exactly `1×200, 19×400` (the loser's separate read already sees ASSIGNED and the in-memory pre-check returns 400). The regression tests consequently pin the **invariant** (exactly one winner, assignment never overwritten), which the WHERE-clause guard guarantees under any adapter that does interleave. The fix itself is the canonical, verified solution named in the issue's 2026-07-04 verification comment, confirmed present by the diff.

Fixes #12