### PR TITLE
Fix #23: don't crash (or lose data) when deleting a client with rides

### DIFF
--- a/server/api/delete/clients/[id].ts
+++ b/server/api/delete/clients/[id].ts
@@ -1,3 +1,4 @@
+import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
@@ -10,7 +11,37 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  return await prisma.client.delete({
-    where: { id },
-  })
+  // Issue #23: the ride->client FK is ON DELETE RESTRICT, so deleting a client
+  // who has any rides throws P2003 and used to surface as a 500. We must not
+  // crash, and we must not destroy historical ride data (COMPLETED rides feed
+  // the metrics endpoints — this is the Data-Integrity milestone). Block the
+  // delete with a clear 409 while rides exist; only ride-less clients delete.
+  const rideCount = await prisma.ride.count({ where: { clientId: id } })
+  if (rideCount > 0) {
+    throw createError({
+      statusCode: 409,
+      statusMessage:
+        'Cannot delete a client with existing rides — reassign or archive them first',
+    })
+  }
+
+  try {
+    return await prisma.client.delete({
+      where: { id },
+    })
+  } catch (err) {
+    // Race-safe fallback: a ride could be created between the count and the
+    // delete. Treat the FK violation as the same 409 block, never a 500.
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2003'
+    ) {
+      throw createError({
+        statusCode: 409,
+        statusMessage:
+          'Cannot delete a client with existing rides — reassign or archive them first',
+      })
+    }
+    throw err
+  }
 })

--- a/server/api/delete/volunteers/[id].ts
+++ b/server/api/delete/volunteers/[id].ts
@@ -10,7 +10,20 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  return await prisma.volunteer.delete({
-    where: { id },
+  // Issue #23: volunteerId is optional, so the ride->volunteer FK is ON DELETE
+  // SET NULL — deleting a volunteer doesn't crash, but their ASSIGNED rides
+  // keep status ASSIGNED with no volunteer (the stuck state from #7). Reset
+  // those rides back to CREATED so they return to the available pool, then
+  // delete the volunteer. Do both atomically so we can't leave rides stuck if
+  // the delete fails.
+  return await prisma.$transaction(async (tx) => {
+    await tx.ride.updateMany({
+      where: { volunteerId: id, status: 'ASSIGNED' },
+      data: { status: 'CREATED' },
+    })
+
+    return await tx.volunteer.delete({
+      where: { id },
+    })
   })
 })

--- a/tests/e2e/safe-delete.test.ts
+++ b/tests/e2e/safe-delete.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #23: deleting a Client who has rides used to throw P2003 (the
+// ride->client FK is ON DELETE RESTRICT) and return a 500, so the admin UI
+// delete failed. Deleting a client must never crash and must never destroy
+// historical ride data — it should be blocked with a clear 409 while rides
+// exist. Deleting a client with no rides still succeeds.
+//
+// It also covers the volunteer side of the same note: after a volunteer is
+// deleted, their rides (volunteerId set to null by the FK) must not stay stuck
+// in ASSIGNED — they should be reset to CREATED.
+
+type Ride = {
+  id: string
+  status: string
+  clientId: string
+  volunteerId: string | null
+}
+type ClientRow = { id: string; user: { email: string | null } }
+type VolunteerRow = { id: string; user: { email: string | null } }
+
+describe('safe deletes (#23)', () => {
+  it('does not crash (500) when deleting a client with rides — blocks with 409 and preserves data', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const clients = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const ridesBefore = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+
+    // martha is seeded with rides.
+    const martha = clients.find((c) => c.user.email === 'martha@example.com')
+    expect(martha, 'martha should be seeded').toBeTruthy()
+    const marthaRides = ridesBefore.filter((r) => r.clientId === martha!.id)
+    expect(marthaRides.length, 'martha should have at least one ride').toBeGreaterThan(0)
+
+    const res = await appFetch(`/api/delete/clients/${martha!.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+
+    // Pre-fix this is a 500 (P2003). Post-fix it is a clean 409 block.
+    expect(res.status, 'deleting a client with rides must not 500').not.toBe(500)
+    expect(res.status).toBe(409)
+
+    // Data preserved: the client and their rides still exist.
+    const clientsAfter = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    expect(clientsAfter.some((c) => c.id === martha!.id), 'client must still exist').toBe(true)
+    const ridesAfter = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    const marthaRidesAfter = ridesAfter.filter((r) => r.clientId === martha!.id)
+    expect(marthaRidesAfter.length, 'client rides must be preserved').toBe(marthaRides.length)
+  })
+
+  it('still deletes a client that has no rides (200)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const created = await $fetch<{ id: string }>('/api/post/clients', {
+      method: 'POST',
+      headers: { cookie },
+      body: {
+        name: 'No-Rides Client',
+        email: `no-rides-${Date.now()}@example.com`,
+        phone: '555-0000',
+        street: '1 Empty St',
+        city: 'Nowhere',
+        state: 'TX',
+        zip: '75000',
+      },
+    })
+    expect(created.id).toBeTruthy()
+
+    const res = await appFetch(`/api/delete/clients/${created.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+    expect(res.status, 'deleting a ride-less client should succeed').toBe(200)
+
+    const clientsAfter = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    expect(clientsAfter.some((c) => c.id === created.id)).toBe(false)
+  })
+
+  it('resets a deleted volunteer\'s ASSIGNED rides back to CREATED (not stuck)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    // Create a throwaway volunteer, assign them a ride, then delete them.
+    const vol = await $fetch<{ id: string }>('/api/post/volunteers', {
+      method: 'POST',
+      headers: { cookie },
+      body: {
+        name: 'Throwaway Volunteer',
+        email: `throwaway-vol-${Date.now()}@example.com`,
+        phone: '555-1111',
+      },
+    })
+    expect(vol.id).toBeTruthy()
+
+    // Grab any existing client to attach a ride to.
+    const clients = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const someClient = clients[0]
+    expect(someClient).toBeTruthy()
+
+    const ride = await $fetch<{ id: string; status: string }>('/api/post/rides', {
+      method: 'POST',
+      headers: { cookie },
+      body: {
+        clientId: someClient!.id,
+        volunteerId: vol.id,
+        pickup: { street: '1 Test St', city: 'Dallas', state: 'TX', zip: '75001' },
+        dropoff: { street: '2 Test Ave', city: 'Dallas', state: 'TX', zip: '75002' },
+        scheduledTime: new Date(Date.now() + 86400000).toISOString(),
+      },
+    })
+    expect(ride.id).toBeTruthy()
+    // volunteerId present -> the endpoint sets status ASSIGNED.
+    expect(ride.status).toBe('ASSIGNED')
+
+    const delRes = await appFetch(`/api/delete/volunteers/${vol.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+    expect(delRes.status, 'deleting a volunteer should succeed').toBe(200)
+
+    const ridesAfter = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    const affected = ridesAfter.find((r) => r.id === ride.id)
+    expect(affected, 'the ride should still exist').toBeTruthy()
+    expect(affected!.volunteerId, 'volunteer link should be cleared').toBeNull()
+    expect(affected!.status, 'ride must not be stuck ASSIGNED').toBe('CREATED')
+  })
+})


### PR DESCRIPTION
## What was broken

The `ride -> client` foreign key is `ON DELETE RESTRICT` (confirmed in the verification comment on #23). Deleting a `Client` who had any rides threw `P2003 Foreign key constraint failed`, which surfaced as a **500** and made the admin UI delete fail. Separately, deleting a `Volunteer` didn't crash (the optional `volunteerId` FK is `ON DELETE SET NULL`), but their rides silently stayed `status: ASSIGNED` with a null volunteer — stuck, never returning to the available pool (the #7 stuck state).

## What changed (endpoint logic only — no schema change)

- `server/api/delete/clients/[id].ts`: count the client's rides first; if any exist, return a clear **409** (`Cannot delete a client with existing rides — reassign or archive them first`) instead of crashing. Ride-less clients still delete normally. A `P2003` catch wraps the delete as a race-safe fallback (a ride created between the count and the delete still yields a 409, never a 500).
- `server/api/delete/volunteers/[id].ts`: in a `$transaction`, reset the volunteer's `ASSIGNED` rides back to `CREATED` before deleting the volunteer, so those rides return to the available pool instead of getting stuck.

### Why block instead of cascade
This is the Data-Integrity milestone. Cascade-deleting a client's rides would wipe `COMPLETED`-ride history that the metrics endpoints depend on. A non-destructive 409 block preserves history and is trivially reversible once soft-delete (#27) lands, which would supersede this. **No Prisma schema change** (which would also need a migration, blocked on #33).

## Verification

New regression test `tests/e2e/safe-delete.test.ts` (`safe deletes (#23)`):
- *does not crash (500) when deleting a client with rides — blocks with 409 and preserves data* — deletes seeded `martha` (has rides); pre-fix returned **500** (P2003), now **409**, and the client + all their rides still exist afterward.
- *still deletes a client that has no rides (200)* — creates a fresh client via `POST /api/post/clients`, deletes it, expects **200**.
- *resets a deleted volunteer's ASSIGNED rides back to CREATED (not stuck)* — creates a volunteer, assigns them a ride (status `ASSIGNED`), deletes the volunteer; pre-fix the ride stayed `ASSIGNED`, now it's `CREATED` with a null volunteer.

Confirmed the two failing assertions pre-fix (500 for client-with-rides; `ASSIGNED` for the volunteer's ride). Full suite green (`pnpm test`: 54 passed) and `pnpm build` succeeds.

## Related (not resolved here)
Overlaps with #7 (stuck ASSIGNED rides) and #27 (soft deletes), and #8 (orphaned users — a deleted client/volunteer's `User` row remains); kept out of scope.

Fixes #23