### PR TITLE
Fix #6: correct route param name in admin delete endpoint

### DIFF
--- a/server/api/delete/admins/[id].ts
+++ b/server/api/delete/admins/[id].ts
@@ -1,12 +1,12 @@
 import { prisma } from '../../../utils/prisma'
 
 export default defineEventHandler(async (event) => {
-  const id = getRouterParam(event, '')
+  const id = getRouterParam(event, 'id')
 
   if (!id) {
     throw createError({
       statusCode: 400,
-      statusMessage: '',
+      statusMessage: 'Admin ID is required',
     })
   }
 

--- a/tests/e2e/admin-delete.test.ts
+++ b/tests/e2e/admin-delete.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #6: server/api/delete/admins/[id].ts read the route param with
+// getRouterParam(event, '') (empty name), so `id` was always undefined and the
+// handler always threw 400 — admin deletion never worked. This test creates a
+// throwaway admin and deletes it, which requires the param to be read as 'id'.
+//
+// Pre-fix this fails: the DELETE returns 400 regardless of the real id, so the
+// "delete succeeds" assertion never passes and the admin is never removed.
+
+describe('admin delete route param (#6)', () => {
+  it('deletes an admin by id and the record is gone afterward', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    // Create a throwaway admin (do NOT touch seeded accounts, keep idempotent).
+    const email = `throwaway-admin-${Date.now()}@example.com`
+    const created = await $fetch<{ id: string; email: string }>('/api/post/admins', {
+      method: 'POST',
+      headers: { cookie },
+      body: { name: 'Throwaway Admin', email },
+    })
+    expect(created.id).toBeTruthy()
+    expect(created.email).toBe(email)
+
+    // Delete it — this is the assertion that fails pre-fix (endpoint returns 400).
+    const deleted = await $fetch<{ id: string }>(`/api/delete/admins/${created.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+    expect(deleted.id).toBe(created.id)
+
+    // Confirm it is actually gone: it must no longer appear in the roster and a
+    // second delete must fail (record not found).
+    const admins = await $fetch<Array<{ id: string }>>('/api/get/admins', {
+      headers: { cookie },
+    })
+    expect(admins.some((a) => a.id === created.id)).toBe(false)
+
+    await expect(
+      $fetch(`/api/delete/admins/${created.id}`, { method: 'DELETE', headers: { cookie } })
+    ).rejects.toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

`server/api/delete/admins/[id].ts` extracted the route param with `getRouterParam(event, '')` — an empty param name — so `id` was always `undefined`. The handler therefore always threw `createError({ statusCode: 400, statusMessage: '' })`, meaning **admin deletion never worked** and the error message was empty.

Fix:
- Read the param as `getRouterParam(event, 'id')` (the route file is `[id].ts`).
- Give the 400 a descriptive `statusMessage: 'Admin ID is required'`, consistent with the sibling `delete/clients/[id].ts` endpoint.

Behavior is otherwise identical (`prisma.user.delete({ where: { id } })`). The global auth middleware already restricts this route to ADMIN, so no auth changes were made.

## Verification

New regression test `tests/e2e/admin-delete.test.ts` — `admin delete route param (#6) > deletes an admin by id and the record is gone afterward`:
- As admin, creates a throwaway admin via `POST /api/post/admins` (unique email), grabs the returned user `id`.
- `DELETE /api/delete/admins/<id>` → expects success and the returned record's id.
- Confirms removal: the admin no longer appears in `GET /api/get/admins`, and a second DELETE rejects (record not found).
- Uses a fresh throwaway id (not a seeded account) so it is idempotent and never deletes accounts other tests rely on.

Pre-fix this test **fails**: the DELETE returns `400` regardless of the real id (empty param name), so the "delete succeeds" assertion never passes. Post-fix it passes.

- `pnpm test`: **9 files, 55 tests passed** (full suite green).
- `pnpm build`: succeeds.

No schema/auth/CI/docker/deps or risk files touched — only the endpoint one-liner fix and the new test.

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)