### PR TITLE
Fix #7: reset ride to CREATED when volunteer is unassigned

### DIFF
--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -85,6 +85,15 @@ export default defineEventHandler(async (event) => {
   if (body.volunteerId !== undefined) {
     updateData.volunteerId =
       body.volunteerId && body.volunteerId.trim() !== '' ? body.volunteerId : null
+
+    // Issue #7: unassigning a volunteer must also return the ride to the
+    // available pool, otherwise it is left ASSIGNED with no volunteer — a stuck
+    // state. Mirror the unsignup endpoint (volunteerId: null, status: 'CREATED').
+    // Only auto-set CREATED when the caller didn't explicitly request a status
+    // (e.g. a deliberate COMPLETED must be respected).
+    if (updateData.volunteerId === null && body.status === undefined) {
+      updateData.status = 'CREATED'
+    }
   }
 
   const ride = await prisma.ride.update({

--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -89,9 +89,15 @@ export default defineEventHandler(async (event) => {
     // Issue #7: unassigning a volunteer must also return the ride to the
     // available pool, otherwise it is left ASSIGNED with no volunteer — a stuck
     // state. Mirror the unsignup endpoint (volunteerId: null, status: 'CREATED').
-    // Only auto-set CREATED when the caller didn't explicitly request a status
-    // (e.g. a deliberate COMPLETED must be respected).
-    if (updateData.volunteerId === null && body.status === undefined) {
+    // Only auto-set CREATED when (a) the caller didn't explicitly request a
+    // status (a deliberate COMPLETED must be respected), and (b) the ride was
+    // actually ASSIGNED — never silently un-complete a COMPLETED ride, which
+    // would drop it from completion metrics while leaving its totalRideTime.
+    if (
+      updateData.volunteerId === null &&
+      body.status === undefined &&
+      existingRide.status === 'ASSIGNED'
+    ) {
       updateData.status = 'CREATED'
     }
   }

--- a/tests/e2e/unassign-status.test.ts
+++ b/tests/e2e/unassign-status.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+type Ride = {
+  id: string
+  status: 'CREATED' | 'ASSIGNED' | 'COMPLETED'
+  volunteerId: string | null
+}
+
+async function getRides(cookie: string): Promise<Ride[]> {
+  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+}
+
+function put(cookie: string, id: string, body: Record<string, unknown>) {
+  return $fetch<Ride>(`/api/put/rides/${id}`, {
+    method: 'PUT',
+    headers: { cookie },
+    body,
+  })
+}
+
+// A volunteer id present in the seed data (some rides are seeded ASSIGNED).
+async function aVolunteerId(cookie: string): Promise<string> {
+  const withVolunteer = (await getRides(cookie)).find((r) => r.volunteerId)
+  expect(withVolunteer, 'seed should have a ride with a volunteer').toBeTruthy()
+  return withVolunteer!.volunteerId!
+}
+
+// Rides this file mutated; restored to CREATED/unassigned after each test so the
+// shared seed DB (used by other e2e files, e.g. pii-scoping) stays intact.
+const touchedRideIds = new Set<string>()
+
+// Set up a fresh ASSIGNED ride for a test by assigning a volunteer to a
+// CREATED ride. Self-contained so tests don't depend on run order or on the
+// finite pool of seeded ASSIGNED rides.
+async function freshAssignedRide(cookie: string): Promise<Ride> {
+  const created = (await getRides(cookie)).find(
+    (r) => r.status === 'CREATED' && !touchedRideIds.has(r.id),
+  )
+  expect(created, 'seed should have an untouched CREATED ride').toBeTruthy()
+  touchedRideIds.add(created!.id)
+  const volunteerId = await aVolunteerId(cookie)
+  const ride = await put(cookie, created!.id, { volunteerId, status: 'ASSIGNED' })
+  expect(ride.status).toBe('ASSIGNED')
+  expect(ride.volunteerId).toBe(volunteerId)
+  return ride
+}
+
+afterEach(async () => {
+  if (!touchedRideIds.size) return
+  const cookie = await loginAs('reachtusharwani@gmail.com')
+  for (const id of touchedRideIds) {
+    // Directly reset to CREATED/unassigned (bypass the auto-CREATED behavior by
+    // sending an explicit status alongside the cleared volunteer).
+    await put(cookie, id, { volunteerId: '', status: 'CREATED' })
+  }
+  touchedRideIds.clear()
+})
+
+describe('PUT /api/put/rides/[id] — unassigning a volunteer (issue #7)', () => {
+  it('resets an ASSIGNED ride to CREATED when the volunteer is cleared', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    const updated = await put(cookie, assigned.id, { volunteerId: '' })
+
+    // Bug #7: previously the ride stayed ASSIGNED with volunteerId=null (a stuck
+    // state). It must return to the available pool.
+    expect(updated.volunteerId).toBeNull()
+    expect(updated.status).toBe('CREATED')
+  })
+
+  it('respects an explicit status when unassigning (does not force CREATED)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    const updated = await put(cookie, assigned.id, {
+      volunteerId: '',
+      status: 'COMPLETED',
+    })
+
+    expect(updated.volunteerId).toBeNull()
+    expect(updated.status).toBe('COMPLETED')
+  })
+
+  it('leaves status untouched on an edit that does not change the volunteer', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    const updated = await put(cookie, assigned.id, {
+      notes: 'edited note, volunteer unchanged',
+    })
+
+    expect(updated.status).toBe('ASSIGNED')
+    expect(updated.volunteerId).toBe(assigned.volunteerId)
+  })
+
+  it('assigning a volunteer still works', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const created = (await getRides(cookie)).find(
+      (r) => r.status === 'CREATED' && !touchedRideIds.has(r.id),
+    )
+    expect(created).toBeTruthy()
+    touchedRideIds.add(created!.id)
+    const volunteerId = await aVolunteerId(cookie)
+
+    const updated = await put(cookie, created!.id, {
+      volunteerId,
+      status: 'ASSIGNED',
+    })
+
+    expect(updated.volunteerId).toBe(volunteerId)
+    expect(updated.status).toBe('ASSIGNED')
+  })
+})

--- a/tests/e2e/unassign-status.test.ts
+++ b/tests/e2e/unassign-status.test.ts
@@ -89,6 +89,26 @@ describe('PUT /api/put/rides/[id] — unassigning a volunteer (issue #7)', () =>
     expect(updated.status).toBe('COMPLETED')
   })
 
+  it('does NOT un-complete a COMPLETED ride when the volunteer is cleared', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    // Complete the ride (as the mark-complete flow would).
+    const completed = await put(cookie, assigned.id, {
+      status: 'COMPLETED',
+      totalRideTime: 1.5,
+    })
+    expect(completed.status).toBe('COMPLETED')
+
+    // Clearing the volunteer with no explicit status must NOT silently flip a
+    // COMPLETED ride back to CREATED — that would drop it from completion
+    // metrics while leaving its totalRideTime (issue #7 hardening).
+    const updated = await put(cookie, assigned.id, { volunteerId: '' })
+
+    expect(updated.volunteerId).toBeNull()
+    expect(updated.status).toBe('COMPLETED')
+  })
+
   it('leaves status untouched on an edit that does not change the volunteer', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
     const assigned = await freshAssignedRide(cookie)


### PR DESCRIPTION
## What was broken

When an admin edited a ride and cleared the volunteer (`volunteerId` empty string → `updateData.volunteerId = null`), the endpoint left `status` untouched. The ride stayed **ASSIGNED with no volunteer** — a stuck state where the ride never returned to the available pool. Confirmed present on `main`; the verification comment (2026-07-04) noted `server/api/post/rides/[id]/unsignup.ts` already handles this correctly (`volunteerId: null, status: 'CREATED'` in one update) and that the fix is to mirror that pattern.

## What changed

`server/api/put/rides/[id].ts` — in the volunteer assignment/unassignment block, when the update resolves `volunteerId` to `null` **and** the caller did not send an explicit `status`, set `status = 'CREATED'`. If the caller sent an explicit status (e.g. a deliberate `COMPLETED`), it is respected and not overridden. Validation schema, notifications, and date handling are unchanged. Net +9 lines in the endpoint.

## Verification

New regression suite `tests/e2e/unassign-status.test.ts`:

- **resets an ASSIGNED ride to CREATED when the volunteer is cleared** — PUT `{ volunteerId: '' }` on an ASSIGNED ride; asserts `status: 'CREATED'` and `volunteerId: null`. This is the assertion that **failed pre-fix** (`expected 'ASSIGNED' to be 'CREATED'`).
- **respects an explicit status when unassigning (does not force CREATED)** — PUT `{ volunteerId: '', status: 'COMPLETED' }`; asserts the explicit `COMPLETED` wins.
- **leaves status untouched on an edit that does not change the volunteer** — PUT `{ notes: ... }`; asserts status stays `ASSIGNED` (no accidental reset).
- **assigning a volunteer still works** — PUT `{ volunteerId, status: 'ASSIGNED' }` on a CREATED ride.

Confirmed the core test fails before the fix and passes after. Full suite green (61 passed / 11 files) and `pnpm build` succeeds. Tests restore mutated rides to seed state in `afterEach` so they don't disturb the shared-DB `pii-scoping` suite.

Fixes #7