### PR TITLE
Fix #8: delete the User when its client/volunteer profile is removed

### DIFF
--- a/server/api/delete/clients/[id].ts
+++ b/server/api/delete/clients/[id].ts
@@ -25,16 +25,36 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Issue #8: deleting only the Client profile left an orphaned User (role
+  // CLIENT, no profile) that crashes frontend queries reading user.client.id.
+  // Delete the underlying User instead — Client.user is onDelete: Cascade, so
+  // this removes the client row too, leaving no orphan. (Roles are singular in
+  // this app, so a User won't also hold a volunteer profile.)
+  const client = await prisma.client.findUnique({
+    where: { id },
+    select: { userId: true },
+  })
+  if (!client) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Client not found',
+    })
+  }
+
   try {
-    return await prisma.client.delete({
-      where: { id },
+    return await prisma.user.delete({
+      where: { id: client.userId },
     })
   } catch (err) {
     // Race-safe fallback: a ride could be created between the count and the
-    // delete. Treat the FK violation as the same 409 block, never a 500.
+    // delete. We now delete the User, whose cascade to the client row is what
+    // trips the ride->client RESTRICT FK. Empirically (better-sqlite3 adapter)
+    // this surfaces as P2003; we also accept P2014 (required-relation
+    // violation) defensively so a driver quirk can't leak a 500. Treat both as
+    // the same 409 block.
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&
-      err.code === 'P2003'
+      (err.code === 'P2003' || err.code === 'P2014')
     ) {
       throw createError({
         statusCode: 409,

--- a/server/api/delete/volunteers/[id].ts
+++ b/server/api/delete/volunteers/[id].ts
@@ -16,14 +16,33 @@ export default defineEventHandler(async (event) => {
   // those rides back to CREATED so they return to the available pool, then
   // delete the volunteer. Do both atomically so we can't leave rides stuck if
   // the delete fails.
+  //
+  // Issue #8: deleting only the Volunteer profile left an orphaned User (role
+  // VOLUNTEER, no profile) that crashes frontend queries reading
+  // user.volunteer.id. Delete the underlying User instead — Volunteer.user is
+  // onDelete: Cascade, so this removes the volunteer row too, leaving no
+  // orphan. The reset rides keep pointing at null (ride->volunteer FK is SET
+  // NULL), so historical/available rides are unaffected. (Roles are singular in
+  // this app, so a User won't also hold a client profile.)
   return await prisma.$transaction(async (tx) => {
+    const volunteer = await tx.volunteer.findUnique({
+      where: { id },
+      select: { userId: true },
+    })
+    if (!volunteer) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: 'Volunteer not found',
+      })
+    }
+
     await tx.ride.updateMany({
       where: { volunteerId: id, status: 'ASSIGNED' },
       data: { status: 'CREATED' },
     })
 
-    return await tx.volunteer.delete({
-      where: { id },
+    return await tx.user.delete({
+      where: { id: volunteer.userId },
     })
   })
 })

--- a/tests/e2e/orphaned-users.test.ts
+++ b/tests/e2e/orphaned-users.test.ts
@@ -1,0 +1,170 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #8: deleting a Client/Volunteer profile used to leave the parent User
+// row behind — an orphaned User with role CLIENT/VOLUNTEER but no profile,
+// which crashes frontend queries that read `user.volunteer.id` / `user.client.id`.
+// The fix deletes the underlying User (which cascades the profile away), and
+// must preserve #23's ride safety (409 block for clients with rides, and the
+// transactional ASSIGNED->CREATED reset for volunteers).
+
+const uniq = () => Math.random().toString(36).slice(2, 10)
+
+async function getUsers(cookie: string) {
+  return await $fetch<Array<{ id: string; email: string | null }>>(
+    '/api/get/users',
+    { headers: { cookie } }
+  )
+}
+
+describe('issue #8 — deletion removes the parent User (no orphans)', () => {
+  const createdEmails: string[] = []
+
+  afterAll(async () => {
+    // Best-effort cleanup so we don't disturb the shared seeded DB.
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const users = await getUsers(cookie).catch(() => [])
+    for (const u of users) {
+      if (u.email && createdEmails.includes(u.email)) {
+        await $fetch(`/api/delete/admins/${u.id}`, {
+          method: 'DELETE',
+          headers: { cookie },
+        }).catch(() => {})
+      }
+    }
+  })
+
+  it('deleting a fresh volunteer removes its User (no orphan)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const email = `orphan-vol-${uniq()}@example.com`
+    createdEmails.push(email)
+
+    const volunteer = await $fetch<{ id: string; userId: string }>(
+      '/api/post/volunteers',
+      {
+        method: 'POST',
+        headers: { cookie },
+        body: { name: 'Orphan Vol', email, status: 'AVAILABLE' },
+      }
+    )
+
+    await $fetch(`/api/delete/volunteers/${volunteer.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+
+    const users = await getUsers(cookie)
+    const stillThere = users.find((u) => u.id === volunteer.userId)
+    expect(stillThere, 'parent User should be deleted, not orphaned').toBeUndefined()
+    expect(users.some((u) => u.email === email)).toBe(false)
+  })
+
+  it('deleting a fresh ride-less client removes its User (no orphan)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const email = `orphan-cli-${uniq()}@example.com`
+    createdEmails.push(email)
+
+    const client = await $fetch<{ id: string; userId: string }>(
+      '/api/post/clients',
+      {
+        method: 'POST',
+        headers: { cookie },
+        body: {
+          name: 'Orphan Cli',
+          email,
+          street: '1 Test St',
+          city: 'Dallas',
+          state: 'TX',
+          zip: '75001',
+        },
+      }
+    )
+
+    await $fetch(`/api/delete/clients/${client.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+
+    const users = await getUsers(cookie)
+    const stillThere = users.find((u) => u.id === client.userId)
+    expect(stillThere, 'parent User should be deleted, not orphaned').toBeUndefined()
+    expect(users.some((u) => u.email === email)).toBe(false)
+  })
+
+  it('deleting a client WITH rides still 409s and leaves client + user intact (#23)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const clients = await $fetch<
+      Array<{ id: string; userId: string; user: { email: string | null } }>
+    >('/api/get/clients', { headers: { cookie } })
+    const martha = clients.find((c) => c.user.email === 'martha@example.com')
+    expect(martha, 'seeded client martha should exist').toBeDefined()
+
+    await expect(
+      $fetch(`/api/delete/clients/${martha!.id}`, {
+        method: 'DELETE',
+        headers: { cookie },
+      })
+    ).rejects.toMatchObject({ statusCode: 409 })
+
+    // Both the client profile and its user remain.
+    const clientsAfter = await $fetch<Array<{ id: string }>>(
+      '/api/get/clients',
+      { headers: { cookie } }
+    )
+    expect(clientsAfter.some((c) => c.id === martha!.id)).toBe(true)
+    const users = await getUsers(cookie)
+    expect(users.some((u) => u.id === martha!.userId)).toBe(true)
+  })
+
+  it('deleting a volunteer resets its ASSIGNED rides to CREATED AND removes the User (#23)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const email = `orphan-vol-rides-${uniq()}@example.com`
+    createdEmails.push(email)
+
+    const volunteer = await $fetch<{ id: string; userId: string }>(
+      '/api/post/volunteers',
+      {
+        method: 'POST',
+        headers: { cookie },
+        body: { name: 'Vol With Rides', email, status: 'AVAILABLE' },
+      }
+    )
+
+    // Grab a seeded CREATED ride and assign it to this volunteer.
+    const rides = await $fetch<Array<{ id: string; status: string }>>(
+      '/api/get/rides',
+      { headers: { cookie } }
+    )
+    const openRide = rides.find((r) => r.status === 'CREATED')
+    expect(openRide, 'a CREATED ride should exist to assign').toBeDefined()
+
+    await $fetch(`/api/put/rides/${openRide!.id}`, {
+      method: 'PUT',
+      headers: { cookie },
+      body: { volunteerId: volunteer.id, status: 'ASSIGNED' },
+    })
+
+    await $fetch(`/api/delete/volunteers/${volunteer.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+
+    // Ride reset back to CREATED (available pool), User gone.
+    const ridesAfter = await $fetch<Array<{ id: string; status: string }>>(
+      '/api/get/rides',
+      { headers: { cookie } }
+    )
+    const ride = ridesAfter.find((r) => r.id === openRide!.id)
+    expect(ride?.status).toBe('CREATED')
+
+    const users = await getUsers(cookie)
+    expect(users.some((u) => u.id === volunteer.userId)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was broken

Deleting a `Client` or `Volunteer` profile removed only the profile row and left the parent `User` intact — an orphaned User with role `CLIENT`/`VOLUNTEER` but no profile. Frontend queries that read `user.client.id` / `user.volunteer.id` crash on such orphans.

## What changed

Both delete endpoints now delete the underlying **User** instead of just the profile. Because `Client.user` and `Volunteer.user` are `onDelete: Cascade`, deleting the User removes the profile row too, leaving no orphan. No schema change.

- `server/api/delete/clients/[id].ts` — keep #23's "409 if the client has rides" pre-check and the FK-violation fallback; when deletion proceeds, `prisma.user.delete({ where: { id: client.userId } })` cascades the client away. Added a 404 for a missing client id (was a P2025 500).
- `server/api/delete/volunteers/[id].ts` — keep #23's transactional `ASSIGNED → CREATED` ride reset, then delete the User inside the same transaction (the `ride → volunteer` FK is `SET NULL`, so reset rides keep pointing at null). Added a 404 for a missing volunteer id.

**FK error code:** deleting the User cascades to the client row, which trips the `ride → client` RESTRICT FK in the race window between the ride-count check and the delete. I verified empirically (better-sqlite3 adapter) that this surfaces as **P2003**; the fallback now catches **P2003 or P2014** defensively so a driver quirk can't leak a 500. Everything else is rethrown.

**Dual-profile edge:** roles are singular in this app, so a User won't hold both a client and a volunteer profile. Deleting the User is therefore safe; I proceed with User deletion and note the assumption in code comments rather than adding special-case handling.

## Verification

New regression test `tests/e2e/orphaned-users.test.ts`:
- `deleting a fresh volunteer removes its User (no orphan)`
- `deleting a fresh ride-less client removes its User (no orphan)`
- `deleting a client WITH rides still 409s and leaves client + user intact (#23)`
- `deleting a volunteer resets its ASSIGNED rides to CREATED AND removes the User (#23)`

Revert-check (source stashed, test kept) — orphan tests fail pre-fix with:
```
AssertionError: parent User should be deleted, not orphaned: expected { …(8) } to be undefined
+ Received: { "email": "orphan-vol-...@example.com", "role": "VOLUNTEER", ... }
```
With the fix restored, all pass.

- `pnpm test` — **66 passed (12 files)**, including the 4 new tests.
- `pnpm build` — succeeds.

Fixes #8