### PR TITLE
Fix #15: store blank phone numbers as null to avoid unique-constraint crash

### DIFF
--- a/server/api/post/clients/index.ts
+++ b/server/api/post/clients/index.ts
@@ -23,7 +23,7 @@ export default defineEventHandler(async (event) => {
       data: {
         name: body.name,
         email: body.email || null,
-        phone: body.phone,
+        phone: emptyToNull(body.phone),
         role: 'CLIENT'
       }
     })
@@ -32,7 +32,7 @@ export default defineEventHandler(async (event) => {
       where: { id: user.id },
       data: {
         name: body.name,
-        phone: body.phone,
+        phone: emptyToNull(body.phone),
         // Don't downgrade ADMIN/VOLUNTEER
       }
     })

--- a/server/api/post/volunteers/index.ts
+++ b/server/api/post/volunteers/index.ts
@@ -23,7 +23,7 @@ export default defineEventHandler(async (event) => {
       data: {
         name: body.name,
         email: body.email,
-        phone: body.phone,
+        phone: emptyToNull(body.phone),
         role: 'VOLUNTEER'
       }
     })
@@ -35,7 +35,7 @@ export default defineEventHandler(async (event) => {
       where: { id: user.id },
       data: {
         name: body.name,
-        phone: body.phone, // Update phone
+        phone: emptyToNull(body.phone), // Update phone
         role: user.role === 'CLIENT' ? 'VOLUNTEER' : user.role // Upgrade CLIENT to VOLUNTEER
       }
     })

--- a/server/api/put/clients/[id].ts
+++ b/server/api/put/clients/[id].ts
@@ -30,7 +30,7 @@ export default defineEventHandler(async (event) => {
         data: {
           name: body.name,
           email: body.email || null,
-          phone: body.phone,
+          phone: emptyToNull(body.phone),
         },
       })
     }

--- a/server/api/put/volunteers/[id].ts
+++ b/server/api/put/volunteers/[id].ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
         data: {
           name: body.name,
           email: body.email,
-          phone: body.phone,
+          phone: emptyToNull(body.phone),
         },
       })
     }

--- a/server/utils/sanitize.ts
+++ b/server/utils/sanitize.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalizes an optional string that may arrive as an empty (or whitespace-only)
+ * string from the frontend into `null` (issue #15).
+ *
+ * Optional-unique columns like `User.phone` are `String? @unique`. SQLite treats
+ * `""` as a distinct value, so storing a blank `""` works for the first record
+ * but a second blank trips the unique constraint (P2002) and 500s the request.
+ * Storing blanks as `null` lets any number of records have "no value".
+ */
+export function emptyToNull(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}

--- a/tests/e2e/empty-phone.test.ts
+++ b/tests/e2e/empty-phone.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { loginAs } from '../utils/auth'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+// Issue #15: clearing a phone number sends "" from the frontend. SQLite treats
+// "" as a distinct value, so the User.phone @unique constraint lets the first
+// blank through but rejects the SECOND with P2002 (a 500). Blank phones must be
+// stored as null so any number of users can have "no phone".
+
+type VolunteerWithUser = {
+  id: string
+  user: { id: string; email: string; phone: string | null }
+}
+
+async function getVolunteer(cookie: string, email: string): Promise<VolunteerWithUser> {
+  const volunteers = await $fetch<VolunteerWithUser[]>('/api/get/volunteers', {
+    headers: { cookie },
+  })
+  const v = volunteers.find((v) => v.user.email === email)
+  expect(v, `seeded volunteer ${email} should exist`).toBeTruthy()
+  return v!
+}
+
+describe('issue #15 — blank phone numbers must be stored as null', () => {
+  it('clearing phone (phone: "") on two different volunteers both succeed and store null', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+
+    const bob = await getVolunteer(adminCookie, 'bob@example.com')
+    const alice = await getVolunteer(adminCookie, 'alice@example.com')
+
+    try {
+      // First clear: succeeds even pre-fix ("" is unique so far).
+      await $fetch(`/api/put/volunteers/${bob.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: bob.user.email, email: bob.user.email, phone: '' },
+      })
+
+      // Second clear: pre-fix this stores another "" and trips the @unique
+      // constraint -> P2002 -> 500. Post-fix it stores null and succeeds.
+      await $fetch(`/api/put/volunteers/${alice.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: alice.user.email, email: alice.user.email, phone: '' },
+      })
+
+      // Both phones must now be null (not "").
+      const bobAfter = await getVolunteer(adminCookie, 'bob@example.com')
+      const aliceAfter = await getVolunteer(adminCookie, 'alice@example.com')
+      expect(bobAfter.user.phone).toBeNull()
+      expect(aliceAfter.user.phone).toBeNull()
+    } finally {
+      // Restore seeded phones (shared DB) so other suites aren't disturbed.
+      await $fetch(`/api/put/volunteers/${bob.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Bob Tester', email: 'bob@example.com', phone: '4695550202' },
+      }).catch(() => {})
+      await $fetch(`/api/put/volunteers/${alice.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Alice Springs', email: 'alice@example.com', phone: '2145550404' },
+      }).catch(() => {})
+    }
+  })
+
+  it('whitespace-only phone is also stored as null', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bob = await getVolunteer(adminCookie, 'bob@example.com')
+
+    try {
+      await $fetch(`/api/put/volunteers/${bob.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Bob Tester', email: 'bob@example.com', phone: '   ' },
+      })
+      const after = await getVolunteer(adminCookie, 'bob@example.com')
+      expect(after.user.phone).toBeNull()
+    } finally {
+      await $fetch(`/api/put/volunteers/${bob.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Bob Tester', email: 'bob@example.com', phone: '4695550202' },
+      }).catch(() => {})
+    }
+  })
+})


### PR DESCRIPTION
## What was broken

The client/volunteer create and update endpoints wrote `body.phone` straight to `User.phone`. When the frontend clears a phone it sends `""`, and `User.phone` is `String? @unique`. SQLite treats `""` as a distinct value, so the first blank saves fine but clearing a **second** user's phone stores another `""` and trips the unique constraint — a `P2002` error that 500s the request.

## What changed

- Added `emptyToNull(value)` in `server/utils/sanitize.ts` (auto-imported by Nitro): normalizes empty / whitespace-only strings to `null`.
- Applied it to every site that writes `phone`:
  - `server/api/put/volunteers/[id].ts`
  - `server/api/put/clients/[id].ts`
  - `server/api/post/volunteers/index.ts` (create + update branches)
  - `server/api/post/clients/index.ts` (create + update branches)

No schema change — the `@unique` constraint stays; the fix is input sanitization, mirroring the existing `email: body.email || null` pattern.

## Verification

Regression test: `tests/e2e/empty-phone.test.ts`
- `clearing phone (phone: "") on two different volunteers both succeed and store null` — pre-fix the **second** clear failed with `500 Server Error` (`P2002 Unique constraint failed`); post-fix both succeed and the stored phone is `null`.
- `whitespace-only phone is also stored as null` — pre-fix stored `"   "`; post-fix `null`.
- Test restores seeded phone values in a `finally` block (shared DB).

Confirmed the test FAILS against unmodified source and PASSES after the fix.

- `pnpm test` — 13 files, **68 tests passed**.
- `pnpm build` — success.

Fixes #15