### PR TITLE
Fix #45: shared single test server + concurrency-testing capability

### DIFF
--- a/server/api/post/rides/[id]/signup.ts
+++ b/server/api/post/rides/[id]/signup.ts
@@ -72,6 +72,10 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Test-only seam (issue #45): widen the read→write window so the signup race
+  // is reproducible through HTTP in e2e. No-op in production (see raceDelay).
+  await raceDelay(event, 'ride-signup')
+
   // 3. Assign Volunteer (atomic — issue #12)
   // The pre-checks above give good error messages, but they are a read
   // separate from the write below: two volunteers can both pass the in-memory

--- a/server/utils/testHooks.ts
+++ b/server/utils/testHooks.ts
@@ -1,0 +1,21 @@
+import type { H3Event } from 'h3'
+
+// Test-only fault-injection seam (issue #45).
+//
+// Concurrency bugs like the signup TOCTOU (#12) can't be reproduced through the
+// HTTP layer in the e2e harness: the synchronous better-sqlite3 adapter runs a
+// handler's read and write close enough together that a competing request never
+// interleaves between them, so a race test would pass even against buggy code.
+//
+// This seam lets a test deliberately widen that read→write window. It is a
+// complete no-op in production: it does nothing unless BOTH the server was
+// started with `TEST_RACE_HOOKS=1` (only tests/global-setup.ts sets this) AND
+// the request carries a matching `x-test-race-delay: <label>:<ms>` header.
+export async function raceDelay(event: H3Event, label: string): Promise<void> {
+  if (process.env.TEST_RACE_HOOKS !== '1') return
+  const header = getHeader(event, 'x-test-race-delay')
+  if (!header) return
+  const [target, ms] = header.split(':')
+  if (target !== label) return
+  await new Promise((resolve) => setTimeout(resolve, Number(ms) || 0))
+}

--- a/tests/e2e/admin-delete.test.ts
+++ b/tests/e2e/admin-delete.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #6: server/api/delete/admins/[id].ts read the route param with
 // getRouterParam(event, '') (empty name), so `id` was always undefined and the

--- a/tests/e2e/auth-middleware.test.ts
+++ b/tests/e2e/auth-middleware.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #1: every core CRUD endpoint must require an authenticated session.
 // Issue #2: only admins may create/promote admins.

--- a/tests/e2e/empty-phone.test.ts
+++ b/tests/e2e/empty-phone.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #15: clearing a phone number sends "" from the frontend. SQLite treats
 // "" as a distinct value, so the User.phone @unique constraint lets the first

--- a/tests/e2e/orphaned-users.test.ts
+++ b/tests/e2e/orphaned-users.test.ts
@@ -1,11 +1,9 @@
 import { afterAll, describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #8: deleting a Client/Volunteer profile used to leave the parent User
 // row behind — an orphaned User with role CLIENT/VOLUNTEER but no profile,

--- a/tests/e2e/pii-scoping.test.ts
+++ b/tests/e2e/pii-scoping.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #3: a VOLUNTEER used to receive the entire ride/people database (full
 // PII) and the app filtered it client-side. The server must instead scope the

--- a/tests/e2e/record-scoping.test.ts
+++ b/tests/e2e/record-scoping.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #41: #3 scoped the *list* endpoints, but single-record and other
 // authenticated endpoints still returned full data to any logged-in non-admin.

--- a/tests/e2e/ride-input-validation.test.ts
+++ b/tests/e2e/ride-input-validation.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Regression coverage for issue #31: PUT /api/put/rides/[id] spread the raw
 // request body straight into prisma.ride.update, allowing mass assignment of

--- a/tests/e2e/route-guard.test.ts
+++ b/tests/e2e/route-guard.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #4: the global route middleware must guard internal pages per role,
 // not only special-case VOLUNTEER. A logged-in CLIENT (or any unmapped role)

--- a/tests/e2e/safe-delete.test.ts
+++ b/tests/e2e/safe-delete.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #23: deleting a Client who has rides used to throw P2003 (the
 // ride->client FK is ON DELETE RESTRICT) and return a 500, so the admin UI

--- a/tests/e2e/signup-race.test.ts
+++ b/tests/e2e/signup-race.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, fetch as appFetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 // Issue #12 (TOCTOU race): signup.ts read the ride, checked status in memory,
 // then updated with `where: { id }` only. Two volunteers signing up at the same
@@ -14,13 +12,14 @@ await setup({
 // clause (`{ id, status: 'CREATED', volunteerId: null }`) and treats Prisma's
 // P2025 as "already taken" (409).
 //
-// Caveat: the test DB uses the synchronous better-sqlite3 adapter, which
-// serializes writes and does not yield mid-handler, so through the HTTP layer
-// the pre-fix code never actually double-assigns (the loser's separate read
-// already sees ASSIGNED and the in-memory pre-check returns 400). These tests
-// therefore pin the *invariant* — exactly one winner, assignment never
-// overwritten — which the WHERE-clause guard guarantees under any adapter that
-// does interleave. See the PR body for the revert-check / code-review evidence.
+// The synchronous better-sqlite3 adapter normally runs the handler's read and
+// write too close together for a competing request to interleave, so a naive
+// race test would pass even against the buggy code. We use the test-only
+// `x-test-race-delay` seam (issue #45, server/utils/testHooks.ts) to widen the
+// read→write window: both requests pass the in-memory pre-check, then race the
+// update. With the atomic WHERE guard exactly one wins (the other gets P2025 →
+// 409); WITHOUT it both updates land and the second overwrites the first — so
+// this test genuinely FAILS on the pre-fix code, not just pins an invariant.
 
 type Ride = {
   id: string
@@ -28,10 +27,14 @@ type Ride = {
   volunteerId: string | null
 }
 
-async function rawSignup(rideId: string, cookie: string): Promise<number> {
+// `raceDelayMs` opens the TOCTOU window via the test-only seam so concurrent
+// signups actually interleave through HTTP.
+async function rawSignup(rideId: string, cookie: string, raceDelayMs?: number): Promise<number> {
+  const headers: Record<string, string> = { cookie }
+  if (raceDelayMs) headers['x-test-race-delay'] = `ride-signup:${raceDelayMs}`
   const res = await appFetch(`/api/post/rides/${rideId}/signup`, {
     method: 'POST',
-    headers: { cookie },
+    headers,
   })
   return res.status
 }
@@ -51,10 +54,11 @@ describe('issue #12 — atomic ride signup', () => {
 
     const rideId = await findCreatedRideId(adminCookie)
 
-    // Fire two genuinely concurrent signups from two AVAILABLE volunteers.
+    // Fire two genuinely concurrent signups from two AVAILABLE volunteers, both
+    // holding the read→write window open (100ms) so they truly interleave.
     const results = await Promise.allSettled([
-      rawSignup(rideId, bobCookie),
-      rawSignup(rideId, aliceCookie),
+      rawSignup(rideId, bobCookie, 100),
+      rawSignup(rideId, aliceCookie, 100),
     ])
 
     const statuses = results.map((r) => (r.status === 'fulfilled' ? r.value : 500))

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 describe('test harness smoke test', () => {
   it('boots the app and serves seeded data (authenticated)', async () => {

--- a/tests/e2e/unassign-status.test.ts
+++ b/tests/e2e/unassign-status.test.ts
@@ -1,11 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
-import { fileURLToPath } from 'node:url'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
-await setup({
-  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-})
+await bootShared()
 
 type Ride = {
   id: string

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,19 +1,87 @@
-import { execSync } from 'node:child_process'
-import { mkdirSync, rmSync } from 'node:fs'
+import { execSync, spawn, type ChildProcess } from 'node:child_process'
+import { createServer } from 'node:net'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 
-// Creates a fresh, seeded SQLite database for the e2e suite.
-// Must compute the same path as vitest.config.ts `env.DATABASE_URL`.
-export default function globalSetup() {
+// One-time e2e setup (issue #45): build the Nuxt app ONCE, seed a fresh SQLite
+// DB, and start a SINGLE server that every test file connects to (via
+// `setup({ host })`). Previously each test file called @nuxt/test-utils
+// `setup()`, which built + booted the app per file (~12 builds → slow, and the
+// first cold build could blow past the 120s per-file hook timeout).
+
+async function freePort(): Promise<number> {
+  return await new Promise((res, rej) => {
+    const srv = createServer()
+    srv.once('error', rej)
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as { port: number }).port
+      srv.close(() => res(port))
+    })
+  })
+}
+
+function waitForReady(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((res, rej) => {
+    const tick = async () => {
+      try {
+        // Any HTTP response (even 401/404) means the server is up.
+        await fetch(url)
+        res()
+      } catch {
+        if (Date.now() > deadline) rej(new Error(`server not ready after ${timeoutMs}ms: ${url}`))
+        else setTimeout(tick, 250)
+      }
+    }
+    tick()
+  })
+}
+
+export default async function globalSetup() {
   const root = resolve(import.meta.dirname, '..')
   const dbPath = resolve(root, '.data/test.db')
 
+  // Fresh, seeded database.
   for (const suffix of ['', '-journal', '-wal', '-shm']) {
     rmSync(dbPath + suffix, { force: true })
   }
   mkdirSync(dirname(dbPath), { recursive: true })
 
-  const env = { ...process.env, DATABASE_URL: `file:${dbPath}` }
-  execSync('npx prisma db push', { cwd: root, env, stdio: 'inherit' })
-  execSync('npx tsx prisma/seed.ts', { cwd: root, env, stdio: 'inherit' })
+  const dbEnv = { ...process.env, DATABASE_URL: `file:${dbPath}` }
+  execSync('npx prisma db push', { cwd: root, env: dbEnv, stdio: 'inherit' })
+  execSync('npx tsx prisma/seed.ts', { cwd: root, env: dbEnv, stdio: 'inherit' })
+
+  // Build the production server once.
+  execSync('npx nuxt build', { cwd: root, env: dbEnv, stdio: 'inherit' })
+
+  // Start the single shared server the whole suite talks to.
+  const port = await freePort()
+  const host = `http://127.0.0.1:${port}`
+  const server: ChildProcess = spawn('node', ['.output/server/index.mjs'], {
+    cwd: root,
+    env: {
+      ...dbEnv,
+      PORT: String(port),
+      NITRO_PORT: String(port),
+      HOST: '127.0.0.1',
+      BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET ?? 'test-secret-not-for-production',
+      // Concurrency-test seam (issue #45): let tests open a TOCTOU window by
+      // injecting an await between read and write in guarded handlers. Off in
+      // normal runs; a test enables it per-request via a header.
+      TEST_RACE_HOOKS: '1',
+      DISABLE_RATE_LIMIT: 'true',
+    },
+    stdio: 'inherit',
+  })
+
+  await waitForReady(host, 120_000)
+
+  // Expose the shared host to worker processes. Env is inherited by forks
+  // spawned after globalSetup; the file is a robust fallback the harness reads.
+  process.env.NUXT_TEST_SHARED_HOST = host
+  writeFileSync(resolve(root, '.data/test-host.txt'), host)
+
+  return async () => {
+    server.kill('SIGTERM')
+  }
 }

--- a/tests/utils/harness.ts
+++ b/tests/utils/harness.ts
@@ -1,0 +1,23 @@
+import { setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// The single shared server is built + started once by tests/global-setup.ts.
+// It publishes its URL via env (inherited by worker forks) and a file fallback.
+export function sharedHost(): string {
+  if (process.env.NUXT_TEST_SHARED_HOST) return process.env.NUXT_TEST_SHARED_HOST
+  const root = fileURLToPath(new URL('../..', import.meta.url))
+  return readFileSync(resolve(root, '.data/test-host.txt'), 'utf8').trim()
+}
+
+// Every e2e test file calls this instead of @nuxt/test-utils `setup()` directly.
+// Passing `host` makes @nuxt/test-utils connect to the already-running shared
+// server rather than building + booting its own (issue #45), while keeping
+// `$fetch`/`fetch`/`url` from '@nuxt/test-utils/e2e' pointed at that host.
+export async function bootShared() {
+  await setup({
+    rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+    host: sharedHost(),
+  })
+}


### PR DESCRIPTION
Overhauls the e2e harness to remove the two problems that were slowing and blocking the review loop.

## Problem 1 — per-file rebuild/boot (slow + flaky timeout)
Each `tests/e2e/*.test.ts` called `@nuxt/test-utils` `setup()`, which built **and** booted the app independently — **12 server boots** per run. A full `pnpm test` took ~223s, and the first cold build could exceed `@nuxt/test-utils`' 120s per-file `beforeAll` timeout, producing spurious failures that forced manual re-runs.

**Fix:** `tests/global-setup.ts` now builds the app **once**, seeds the DB, and starts **one** server; every test file connects to it via a shared `bootShared()` helper (`setup({ host })`). The build runs inside `globalSetup`, which has no per-file hook timeout.

| | before | after |
|---|---|---|
| server boots | 12 | **1** |
| full suite (cold `pnpm test`) | ~223s | **~28s** |
| 120s per-file build timeout | possible | gone |

All 13 files / 68 tests pass (cold and warm).

## Problem 2 — concurrency was untestable (this is why #47's test couldn't fail pre-fix)
The synchronous better-sqlite3 adapter runs a handler's read and write too close together for a competing HTTP request to interleave, so a race test passed even against buggy code — #12/#47's regression test could only pin an invariant, never fail on the pre-fix code.

**Fix:** a **test-only** fault-injection seam, `server/utils/testHooks.ts` `raceDelay(event, label)`, that widens the read→write window. It is a strict **no-op in production** — it does nothing unless BOTH the server was started with `TEST_RACE_HOOKS=1` (set only by `tests/global-setup.ts`) AND the request carries a matching `x-test-race-delay: <label>:<ms>` header. Wired into the signup TOCTOU point.

`tests/e2e/signup-race.test.ts` now uses it and **genuinely fails on the pre-fix non-atomic code** — verified by reverting the guard to `where: { id }`: the concurrent test fails ("expected exactly one 200"), and passes again with the atomic guard restored. Future concurrency fixes can now satisfy the loop's revert-check honestly.

## Verification
- `pnpm test` — 13 files, 68 tests green (cold-cache run included).
- `pnpm build` — succeeds.
- Revert-check of the seam: guard removed → `signup-race` fails; guard restored → passes.

## Risk / scope
- Test infrastructure + one guarded no-op line in `signup.ts`. No schema/auth/CI/docker/dependency changes.
- The production behavior of `signup.ts` is unchanged when `TEST_RACE_HOOKS` is unset (i.e. always, outside the harness).

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)