### PR TITLE
Fix #16: normalize addresses before upsert to prevent duplicates

### DIFF
--- a/server/api/post/clients/index.ts
+++ b/server/api/post/clients/index.ts
@@ -39,15 +39,15 @@ export default defineEventHandler(async (event) => {
   }
 
   // 2. Upsert Address
-  // Using findFirst because unique constraint might not match perfectly if we don't normalize
-  // But strictly, we should use upsert or findUnique if strictly defined
-  // The schema has @@unique([street, city, state, zip])
-  const addressData = {
+  // Normalize first so case/whitespace-variant addresses collapse onto the
+  // @@unique([street, city, state, zip]) key instead of spawning duplicate
+  // rows (issue #16).
+  const addressData = normalizeAddress({
     street: body.street,
     city: body.city,
     state: body.state,
     zip: body.zip,
-  }
+  })
 
   const address = await prisma.address.upsert({
     where: {

--- a/server/api/post/rides/index.ts
+++ b/server/api/post/rides/index.ts
@@ -18,22 +18,15 @@ export default defineEventHandler(async (event) => {
     state: string
     zip: string
   }) => {
+    // Normalize before the upsert so case/whitespace-variant addresses collapse
+    // onto the @@unique([street, city, state, zip]) key (issue #16).
+    const normalized = normalizeAddress(addr)
     return await prisma.address.upsert({
       where: {
-        street_city_state_zip: {
-          street: addr.street,
-          city: addr.city,
-          state: addr.state,
-          zip: addr.zip,
-        },
+        street_city_state_zip: normalized,
       },
       update: {},
-      create: {
-        street: addr.street,
-        city: addr.city,
-        state: addr.state,
-        zip: addr.zip,
-      },
+      create: normalized,
     })
   }
 

--- a/server/api/put/clients/[id].ts
+++ b/server/api/put/clients/[id].ts
@@ -37,12 +37,14 @@ export default defineEventHandler(async (event) => {
 
     // Update Address (Link to new/existing address)
     if (body.street && body.city && body.state && body.zip) {
-      const addressData = {
+      // Normalize first so case/whitespace-variant addresses collapse onto the
+      // @@unique([street, city, state, zip]) key (issue #16).
+      const addressData = normalizeAddress({
         street: body.street,
         city: body.city,
         state: body.state,
         zip: body.zip,
-      }
+      })
 
       const address = await tx.address.upsert({
         where: {

--- a/server/utils/address.ts
+++ b/server/utils/address.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalizes the fields of an address before it is upserted on the
+ * `@@unique([street, city, state, zip])` key (issue #16).
+ *
+ * Without normalization, "123 Main st", "123 Main St" and " 123 Main St "
+ * miss the unique constraint and each spawn a near-duplicate Address row,
+ * bloating the table and defeating the constraint's intent.
+ *
+ * We deliberately do NOT lowercase (the issue's literal suggestion). The
+ * Address row backs `Client.homeAddress`, which is rendered on the people
+ * page, so lowercasing would be a visible UI regression. Instead we trim,
+ * collapse internal whitespace and Title-Case each field: equivalent
+ * addresses collapse to one row while staying presentable. `state` is
+ * upper-cased (postal abbreviations like "TX") and `zip` is only
+ * trimmed/whitespace-collapsed so any format is preserved.
+ */
+
+interface AddressFields {
+  street: string
+  city: string
+  state: string
+  zip: string
+}
+
+function collapse(value: string): string {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function titleCase(value: string): string {
+  return collapse(value)
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export function normalizeAddress(addr: AddressFields): AddressFields {
+  return {
+    street: titleCase(addr.street),
+    city: titleCase(addr.city),
+    state: collapse(addr.state).toUpperCase(),
+    zip: collapse(addr.zip),
+  }
+}

--- a/tests/e2e/address-normalization.test.ts
+++ b/tests/e2e/address-normalization.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Regression coverage for issue #16: address upserts did not normalize casing
+// or whitespace, so "123 Main St", "123 main st " etc. missed the
+// @@unique([street, city, state, zip]) constraint and each spawned a
+// near-duplicate Address row. The fix normalizes fields before the upsert so
+// equivalent addresses collapse to a single row.
+
+async function adminCookie() {
+  return loginAs('reachtusharwani@gmail.com')
+}
+
+// Unique street token per run so we never collide with seeded addresses.
+function uniqueStreet(): string {
+  return `${Math.floor(Math.random() * 1e9)} Norm Test Ave`
+}
+
+async function createRide(cookie: string, street: string) {
+  return $fetch<{ pickupAddressId: string }>('/api/post/rides', {
+    method: 'POST',
+    headers: { cookie },
+    body: {
+      clientId: (
+        await $fetch<Array<{ id: string }>>('/api/get/clients', {
+          headers: { cookie },
+        })
+      )[0]!.id,
+      pickup: { street, city: 'Dallas', state: 'TX', zip: '75080' },
+      dropoff: { street: '999 Dropoff Rd', city: 'Dallas', state: 'TX', zip: '75080' },
+      scheduledTime: new Date(Date.now() + 86_400_000).toISOString(),
+    },
+  })
+}
+
+describe('address normalization on upsert (#16)', () => {
+  it('collapses case/whitespace-variant pickup addresses to a single Address row', async () => {
+    const cookie = await adminCookie()
+    const baseStreet = uniqueStreet()
+
+    // Same address typed two different ways: mixed case + trailing whitespace.
+    const rideA = await createRide(cookie, baseStreet) // e.g. "123 Norm Test Ave"
+    const rideB = await createRide(cookie, `  ${baseStreet.toLowerCase()}  `) // "  123 norm test ave  "
+
+    // Both rides must resolve to the SAME Address row (pre-fix: two distinct ids).
+    expect(rideB.pickupAddressId).toBe(rideA.pickupAddressId)
+
+    // And the addresses search endpoint must find exactly one matching row.
+    const searchToken = baseStreet.split(' ')[0]! // the numeric prefix, unique to this run
+    const matches = await $fetch<Array<{ id: string }>>(
+      `/api/get/addresses?search=${encodeURIComponent(searchToken)}`,
+      { headers: { cookie } }
+    )
+    expect(matches.length).toBe(1)
+    expect(matches[0]!.id).toBe(rideA.pickupAddressId)
+  })
+})


### PR DESCRIPTION
## What was broken
`prisma.address.upsert` on the `@@unique([street, city, state, zip])` key ran on the raw request body, so `"123 Main St"`, `"123 main st "` and `" 123 Main St "` each missed the constraint and spawned near-duplicate `Address` rows — bloating the table and defeating the constraint's intent. This affected all three upsert sites: ride-create (`resolveAddress`), client-create, and client-update.

## What changed
Added a shared, auto-imported `normalizeAddress()` helper in `server/utils/address.ts` and applied it before all three upserts. Normalization trims each field, collapses internal whitespace, **Title-Cases** street/city, upper-cases `state`, and trims `zip`.

### Casing choice + client-display tradeoff
The issue literally suggested `trim().toLowerCase()`, but the `Address` row backs `Client.homeAddress`, which is **rendered on the people page** — lowercasing would be a visible UI regression (`123 main st, dallas, tx`). I chose **trim + collapse whitespace + Title Case** instead: it dedups equivalent addresses onto one row while staying presentable. `Ride.pickupDisplay`/`dropoffDisplay` are separate snapshot strings built from the raw body, so they are unaffected either way.

## Verification
- **Regression test:** `tests/e2e/address-normalization.test.ts` → `address normalization on upsert (#16) > collapses case/whitespace-variant pickup addresses to a single Address row`. Creates two rides as admin with case/whitespace-variant pickup streets (`"<n> Norm Test Ave"` and `"  <n> norm test ave  "`) and asserts both resolve to the same `Address` id and the addresses search endpoint returns exactly one row.
- **Pre-fix failing assertion (observed):** `AssertionError: expected '0d199ed0-19e7-4486-bd6c-4a9fbc15b06d' to be '63f4d6b3-299c-4622-b0b1-3a244a440247'` at `expect(rideB.pickupAddressId).toBe(rideA.pickupAddressId)` — i.e. two distinct rows pre-fix.
- **Post-fix:** the test passes (one shared row).
- **Suite:** `pnpm test` — 14 files, 69 tests pass. `pnpm build` succeeds.

## Scope / risk
No schema, auth, CI, docker, or dependency changes. No risk files touched. Net +117 / -19 lines across 3 API routes + 1 new util + 1 new test.

Fixes #16
