### PR TITLE
Fix #18: include the full end day in metrics date range

### DIFF
--- a/server/api/get/metrics/completionRate/index.ts
+++ b/server/api/get/metrics/completionRate/index.ts
@@ -6,15 +6,9 @@ export default defineEventHandler(async (event) => {
   requireAdmin(event)
 
   const query = getQuery(event)
-  const startDate = query.startDate ? new Date(String(query.startDate)) : undefined
-  const endDate = query.endDate ? new Date(String(query.endDate)) : undefined
-
-  const dateFilter = startDate || endDate ? {
-    scheduledTime: {
-      ...(startDate && { gte: startDate }),
-      ...(endDate && { lte: endDate })
-    }
-  } : {}
+  // Shared helper makes endDate inclusive of the whole day (issue #18).
+  const range = parseDateRange(query.startDate, query.endDate)
+  const dateFilter = range ? { scheduledTime: range } : {}
 
   const totalRides = await prisma.ride.count({
     where: dateFilter

--- a/server/api/get/metrics/hours/index.ts
+++ b/server/api/get/metrics/hours/index.ts
@@ -6,15 +6,9 @@ export default defineEventHandler(async (event) => {
   requireAdmin(event)
 
   const query = getQuery(event)
-  const startDate = query.startDate ? new Date(String(query.startDate)) : undefined
-  const endDate = query.endDate ? new Date(String(query.endDate)) : undefined
-
-  const dateFilter = startDate || endDate ? {
-    scheduledTime: {
-      ...(startDate && { gte: startDate }),
-      ...(endDate && { lte: endDate })
-    }
-  } : {}
+  // Shared helper makes endDate inclusive of the whole day (issue #18).
+  const range = parseDateRange(query.startDate, query.endDate)
+  const dateFilter = range ? { scheduledTime: range } : {}
 
   const result = await prisma.ride.aggregate({
     _sum: {

--- a/server/api/get/metrics/topRiders/index.ts
+++ b/server/api/get/metrics/topRiders/index.ts
@@ -7,27 +7,31 @@ export default defineEventHandler(async (event) => {
 
   const query = getQuery(event)
 
-  let startFilter: Date
-  let endFilter: Date
+  let scheduledTime: { gte: Date; lt: Date }
 
-  if (query.startDate || query.endDate) {
-    startFilter = query.startDate ? new Date(String(query.startDate)) : new Date(0) // Beginning of time if not set
-    endFilter = query.endDate ? new Date(String(query.endDate)) : new Date(8640000000000000) // Max date if not set
+  const range = parseDateRange(query.startDate, query.endDate)
+  if (range) {
+    // Explicit date(s): the shared helper makes endDate inclusive of the whole
+    // day (issue #18 — previously `lt: endDate` dropped the entire end day).
+    // Open bounds when only one side is given match the prior behavior.
+    scheduledTime = {
+      gte: range.gte ?? new Date(0), // Beginning of time if start not set
+      lt: range.lt ?? new Date(8640000000000000), // Max date if end not set
+    }
   } else {
     // Default to Year to Date
     const currentYear = new Date().getFullYear()
-    startFilter = new Date(currentYear, 0, 1)
-    endFilter = new Date(currentYear + 1, 0, 1)
+    scheduledTime = {
+      gte: new Date(currentYear, 0, 1),
+      lt: new Date(currentYear + 1, 0, 1),
+    }
   }
 
   const topRidersRaw = await prisma.ride.groupBy({
     by: ['clientId'],
     where: {
       status: 'COMPLETED',
-      scheduledTime: {
-        gte: startFilter,
-        lt: endFilter
-      }
+      scheduledTime,
     },
     _count: {
       id: true

--- a/server/utils/dateRange.ts
+++ b/server/utils/dateRange.ts
@@ -1,0 +1,54 @@
+/**
+ * Parse the `startDate` / `endDate` query params used by the dashboard metrics
+ * endpoints into a Prisma `scheduledTime` filter (issue #18).
+ *
+ * The frontend sends plain day strings (`YYYY-MM-DD`). `new Date('2026-12-31')`
+ * is parsed as UTC midnight, so filtering with `lte: endDate` (or `lt: endDate`)
+ * wrongly excludes rides that happen *during* the end day (e.g. 14:00). To make
+ * the end boundary inclusive of the whole day we use `lt: <start of the next
+ * day>`.
+ *
+ * Timezone assumption: boundaries are computed in UTC to match how the plain
+ * `YYYY-MM-DD` strings the frontend sends are already parsed (`new Date(...)`
+ * yields UTC midnight). Start stays start-of-day inclusive; end becomes
+ * end-of-day inclusive. Callers that pass a full ISO timestamp still get the
+ * day-granular window (the time component is normalized away).
+ *
+ * Returns `undefined` when neither param is present so callers can preserve
+ * their existing "no filter" / default behavior.
+ */
+export interface DateRangeFilter {
+  gte?: Date
+  lt?: Date
+}
+
+// Start of the UTC day containing `d`.
+function startOfUtcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+// Start of the UTC day *after* the one containing `d` — an exclusive upper
+// bound that includes every instant of `d`'s day.
+function startOfNextUtcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1))
+}
+
+export function parseDateRange(
+  startDate: unknown,
+  endDate: unknown,
+): DateRangeFilter | undefined {
+  const hasStart = startDate !== undefined && startDate !== null && String(startDate) !== ''
+  const hasEnd = endDate !== undefined && endDate !== null && String(endDate) !== ''
+
+  if (!hasStart && !hasEnd) return undefined
+
+  const range: DateRangeFilter = {}
+  if (hasStart) {
+    range.gte = startOfUtcDay(new Date(String(startDate)))
+  }
+  if (hasEnd) {
+    // Inclusive of the entire end day: next-day-midnight as an exclusive bound.
+    range.lt = startOfNextUtcDay(new Date(String(endDate)))
+  }
+  return range
+}

--- a/tests/e2e/metrics-date-range.test.ts
+++ b/tests/e2e/metrics-date-range.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+type Client = { id: string; user: { email: string } }
+type Ride = { id: string; status: string; totalRideTime: number | null }
+type HoursMetric = { totalHours: number }
+type CompletionMetric = { total: number; completed: number; percentage: number }
+type TopRider = { name: string; completedRides: number }
+
+// A distinct address so we never collide with seeded rides.
+const testAddress = {
+  street: '742 Evergreen Terrace',
+  city: 'Springfield',
+  state: 'TX',
+  zip: '75001',
+}
+
+// Create a COMPLETED ride for `clientId` scheduled at a known afternoon time on
+// `day` (a plain YYYY-MM-DD string) with the given totalRideTime.
+async function createCompletedRide(
+  cookie: string,
+  clientId: string,
+  day: string,
+  totalRideTime: number,
+): Promise<Ride> {
+  // Afternoon local time on the given day. The frontend sends endDate as a
+  // plain day string; a 14:00 ride on that day must be inside the range.
+  const scheduledTime = `${day}T14:00:00`
+  const created = await $fetch<Ride>('/api/post/rides', {
+    method: 'POST',
+    headers: { cookie },
+    body: {
+      clientId,
+      pickup: testAddress,
+      dropoff: testAddress,
+      scheduledTime,
+    },
+  })
+  const completed = await $fetch<Ride>(`/api/put/rides/${created.id}`, {
+    method: 'PUT',
+    headers: { cookie },
+    body: { status: 'COMPLETED', totalRideTime },
+  })
+  expect(completed.status).toBe('COMPLETED')
+  return completed
+}
+
+describe('metrics date range — end day is inclusive (issue #18)', () => {
+  it('counts an afternoon ride scheduled on the endDate day', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const clients = await $fetch<Client[]>('/api/get/clients', { headers: { cookie } })
+    const clientId = clients[0]!.id
+
+    // A fixed day well away from seeded times so nothing else lands here.
+    const day = '2099-06-15'
+    const start = '2099-06-01'
+    const hoursValue = 3.25
+
+    // Baseline before creating our ride.
+    const hoursBefore = await $fetch<HoursMetric>(
+      `/api/get/metrics/hours?startDate=${start}&endDate=${day}`,
+      { headers: { cookie } },
+    )
+    const rateBefore = await $fetch<CompletionMetric>(
+      `/api/get/metrics/completionRate?startDate=${start}&endDate=${day}`,
+      { headers: { cookie } },
+    )
+
+    await createCompletedRide(cookie, clientId, day, hoursValue)
+
+    const hoursAfter = await $fetch<HoursMetric>(
+      `/api/get/metrics/hours?startDate=${start}&endDate=${day}`,
+      { headers: { cookie } },
+    )
+    const rateAfter = await $fetch<CompletionMetric>(
+      `/api/get/metrics/completionRate?startDate=${start}&endDate=${day}`,
+      { headers: { cookie } },
+    )
+
+    // Pre-fix, a 14:00 ride on the endDate day is excluded (lte UTC-midnight),
+    // so these deltas would be 0. Post-fix the ride is included.
+    expect(hoursAfter.totalHours - hoursBefore.totalHours).toBeCloseTo(hoursValue, 5)
+    expect(rateAfter.completed - rateBefore.completed).toBe(1)
+    expect(rateAfter.total - rateBefore.total).toBe(1)
+  })
+
+  it('includes the endDate day for topRiders (explicit-endDate path, lt bug)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const clients = await $fetch<Client[]>('/api/get/clients', { headers: { cookie } })
+    // Use a distinct client so its completed-ride count is unambiguous.
+    const client = clients[1] ?? clients[0]!
+
+    const day = '2099-07-20'
+    const start = '2099-07-01'
+
+    const before = await $fetch<TopRider[]>(
+      `/api/get/metrics/topRiders?startDate=${start}&endDate=${day}`,
+      { headers: { cookie } },
+    )
+    const beforeCount = before.length
+
+    await createCompletedRide(cookie, client.id, day, 1)
+
+    const after = await $fetch<TopRider[]>(
+      `/api/get/metrics/topRiders?startDate=${start}&endDate=${day}`,
+      { headers: { cookie } },
+    )
+
+    // Pre-fix, lt: endFilter (UTC-midnight of the endDate day) drops the whole
+    // end day, so the new completed ride would not appear at all in this narrow
+    // window -> the list stays empty. Post-fix at least one rider is returned.
+    expect(after.length).toBeGreaterThanOrEqual(1)
+    expect(after.length).toBeGreaterThanOrEqual(beforeCount)
+  })
+})


### PR DESCRIPTION
## What was broken

The dashboard metrics endpoints receive `endDate` as a plain `YYYY-MM-DD` day string from the frontend. `new Date('2026-12-31')` parses to UTC midnight, and the queries filtered with `lte: endDate` (`completionRate`, `hours`) or `lt: endDate` (`topRiders`), so any ride happening *during* the end day (e.g. 14:00) was wrongly excluded — the whole final day was silently dropped from the metrics. (issue #18; the verification comment flagged `topRiders` as having the same class of bug via `lt: endFilter`.)

## What changed

- New auto-imported helper `server/utils/dateRange.ts` → `parseDateRange(startDate, endDate)`, which returns a `{ gte, lt }` Prisma `scheduledTime` filter. Start stays start-of-day inclusive; the end boundary is bumped to **start of the next day** and compared with `lt`, so the entire end day is included. Returns `undefined` when both params are absent so callers keep their existing no-filter / default behavior.
- All three metrics endpoints (`completionRate`, `hours`, `topRiders`) now share this single implementation. `topRiders`' year-to-date default and its open-bound behavior (beginning-of-time / max-date when only one side is passed) are preserved.

**Timezone assumption (documented in the helper):** boundaries are computed in UTC to match how the plain `YYYY-MM-DD` strings are already parsed (`new Date('YYYY-MM-DD')` yields UTC midnight). This keeps parse and filter consistent.

## Verification

Regression test: `tests/e2e/metrics-date-range.test.ts`
- `counts an afternoon ride scheduled on the endDate day` — creates a COMPLETED ride at 14:00 on the `endDate` day, asserts the delta in `hours` and `completionRate` includes it.
- `includes the endDate day for topRiders (explicit-endDate path, lt bug)` — asserts the same ride appears in `topRiders` for a narrow explicit-endDate window.

**Pre-fix failing assertions (observed):**
- `expected +0 to be close to 3.25, received difference is 3.25, but expected 0.000005` (hours delta was 0 — the afternoon ride on `endDate` was excluded).
- `expected 0 to be greater than or equal to 1` (topRiders returned an empty list — `lt: endDate` dropped the whole end day).

Both pass after the fix. Full suite green (15 files / 71 tests); `pnpm build` succeeds.

Fixes #18