### PR TITLE
Fix #10: require totalRideTime when completing a ride (server-side)

### DIFF
--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -55,6 +55,24 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Issue #10: a ride can only be marked COMPLETED with a valid duration.
+  // The Complete modal (app/pages/rides/[id].vue) already enforces
+  // totalRideTime >= 0.1 via zod, but a direct API call could complete a ride
+  // with no duration — producing "Total Time: N/A" in the admin email and a
+  // completed ride with null hours that skews the metrics (#18). Require a
+  // valid totalRideTime either on this request OR already stored on the ride
+  // (so re-updating an already-completed ride without re-sending it still works).
+  if (body.status === 'COMPLETED') {
+    const effectiveRideTime =
+      body.totalRideTime !== undefined ? body.totalRideTime : existingRide.totalRideTime
+    if (effectiveRideTime == null || effectiveRideTime < 0.1) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'totalRideTime (at least 0.1 hours) is required to complete a ride',
+      })
+    }
+  }
+
   // Build the Prisma update payload only from validated, whitelisted fields.
   const updateData: {
     status?: 'CREATED' | 'ASSIGNED' | 'COMPLETED'

--- a/tests/e2e/complete-requires-ridetime.test.ts
+++ b/tests/e2e/complete-requires-ridetime.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+type Ride = {
+  id: string
+  status: 'CREATED' | 'ASSIGNED' | 'COMPLETED'
+  volunteerId: string | null
+  totalRideTime: number | null
+}
+
+async function getRides(cookie: string): Promise<Ride[]> {
+  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+}
+
+function put(cookie: string, id: string, body: Record<string, unknown>) {
+  return $fetch<Ride>(`/api/put/rides/${id}`, {
+    method: 'PUT',
+    headers: { cookie },
+    body,
+  })
+}
+
+async function aVolunteerId(cookie: string): Promise<string> {
+  const withVolunteer = (await getRides(cookie)).find((r) => r.volunteerId)
+  expect(withVolunteer, 'seed should have a ride with a volunteer').toBeTruthy()
+  return withVolunteer!.volunteerId!
+}
+
+// Rides this file mutated; reset to CREATED/unassigned after each test so the
+// shared seed DB (used by other e2e files) stays intact.
+const touchedRideIds = new Set<string>()
+
+async function freshAssignedRide(cookie: string): Promise<Ride> {
+  const created = (await getRides(cookie)).find(
+    (r) => r.status === 'CREATED' && !touchedRideIds.has(r.id),
+  )
+  expect(created, 'seed should have an untouched CREATED ride').toBeTruthy()
+  touchedRideIds.add(created!.id)
+  const volunteerId = await aVolunteerId(cookie)
+  const ride = await put(cookie, created!.id, { volunteerId, status: 'ASSIGNED' })
+  expect(ride.status).toBe('ASSIGNED')
+  return ride
+}
+
+afterEach(async () => {
+  if (!touchedRideIds.size) return
+  const cookie = await loginAs('reachtusharwani@gmail.com')
+  for (const id of touchedRideIds) {
+    await put(cookie, id, { volunteerId: '', status: 'CREATED' })
+  }
+  touchedRideIds.clear()
+})
+
+describe('PUT /api/put/rides/[id] — completing a ride requires totalRideTime (issue #10)', () => {
+  it('rejects COMPLETED with no totalRideTime (400) and does not complete the ride', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    // Pre-fix this returned 200 and marked the ride COMPLETED with null hours,
+    // yielding "Total Time: N/A" in the admin email and skewing metrics (#18).
+    await expect(put(cookie, assigned.id, { status: 'COMPLETED' })).rejects.toMatchObject({
+      statusCode: 400,
+    })
+
+    // The ride must NOT have been completed.
+    const after = (await getRides(cookie)).find((r) => r.id === assigned.id)
+    expect(after!.status).toBe('ASSIGNED')
+  })
+
+  it('rejects COMPLETED with a totalRideTime below 0.1 (400)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    await expect(
+      put(cookie, assigned.id, { status: 'COMPLETED', totalRideTime: 0 }),
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('accepts COMPLETED with a valid totalRideTime (200)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    const updated = await put(cookie, assigned.id, {
+      status: 'COMPLETED',
+      totalRideTime: 1.5,
+    })
+
+    expect(updated.status).toBe('COMPLETED')
+    expect(updated.totalRideTime).toBe(1.5)
+  })
+
+  it('allows re-updating an already-completed ride without re-sending totalRideTime', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const assigned = await freshAssignedRide(cookie)
+
+    const completed = await put(cookie, assigned.id, {
+      status: 'COMPLETED',
+      totalRideTime: 2,
+    })
+    expect(completed.status).toBe('COMPLETED')
+
+    // Re-sending COMPLETED (e.g. editing notes) with no totalRideTime succeeds
+    // because the existing ride already has a valid stored duration.
+    const edited = await put(cookie, assigned.id, {
+      status: 'COMPLETED',
+      notes: 'edited after completion',
+    })
+    expect(edited.status).toBe('COMPLETED')
+    expect(edited.totalRideTime).toBe(2)
+  })
+})

--- a/tests/e2e/unassign-status.test.ts
+++ b/tests/e2e/unassign-status.test.ts
@@ -81,6 +81,9 @@ describe('PUT /api/put/rides/[id] — unassigning a volunteer (issue #7)', () =>
     const updated = await put(cookie, assigned.id, {
       volunteerId: '',
       status: 'COMPLETED',
+      // totalRideTime required to complete (issue #10); the #7 behavior under
+      // test here is the status/volunteer handling, not the duration check.
+      totalRideTime: 1.5,
     })
 
     expect(updated.volunteerId).toBeNull()


### PR DESCRIPTION
## What was broken

`PUT /api/put/rides/[id]` accepted `status: 'COMPLETED'` with no `totalRideTime`. The Complete modal in `app/pages/rides/[id].vue` already enforces `totalRideTime >= 0.1` via zod, so the normal UI flow is safe — but a direct API call (or any future UI path) could complete a ride with null hours, producing "Total Time: N/A" in the admin completion email and a completed ride with a null duration that skews the metrics from #18.

## What changed

In `server/api/put/rides/[id].ts`, after fetching `existingRide`, when the update sets `status: 'COMPLETED'` the endpoint now requires a valid `totalRideTime` (>= 0.1, matching the frontend rule) — taken from the request body if present, otherwise from the value already stored on the ride. If neither is a valid positive duration, it rejects with **400** and a clear message.

**Rule for already-completed rides:** re-updating a ride that is already COMPLETED (e.g. editing its notes) without re-sending `totalRideTime` is allowed, because the existing stored duration satisfies the requirement. Only a completion with no valid duration anywhere is rejected.

No changes to the volunteerId/#7 logic, notifications, or date formatting. No schema/auth/CI/docker/deps changes.

## Verification

New regression test: `tests/e2e/complete-requires-ridetime.test.ts`
- `rejects COMPLETED with no totalRideTime (400) and does not complete the ride` — asserts 400 and that the ride stays ASSIGNED.
- `rejects COMPLETED with a totalRideTime below 0.1 (400)`
- `accepts COMPLETED with a valid totalRideTime (200)` — the normal complete flow still succeeds.
- `allows re-updating an already-completed ride without re-sending totalRideTime` — documents the stored-value rule.

**Pre-fix failing assertion (observed before the fix):** `AssertionError: promise resolved "{ …(16) }" instead of rejecting` on `rejects.toMatchObject({ statusCode: 400 })` — i.e. completing with no duration returned 200 and marked the ride COMPLETED. Both rejection tests pass after the fix.

Also updated one assertion in `tests/e2e/unassign-status.test.ts` ("respects an explicit status when unassigning") to send `totalRideTime: 1.5` — it previously completed a ride with no duration, which the new server rule correctly forbids; the #7 behavior it tests is unchanged.

Suite: 77 passed (17 files), stable across two runs. `pnpm build` succeeds.

Fixes #10