### PR TITLE
Fix #11: reset the create-ride form to its real (nested) state after submit

### DIFF
--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -97,25 +97,7 @@
   })
 
   // --- State ---
-  const state = reactive({
-    clientId: '',
-    pickup: {
-      street: '',
-      city: '',
-      state: '',
-      zip: '',
-    },
-    dropoff: {
-      street: '',
-      city: '',
-      state: '',
-      zip: '',
-    },
-    scheduledTime: '',
-    pickupTime: '',
-    notes: '',
-    volunteerId: undefined as any,
-  })
+  const state = reactive(blankRideForm())
 
   // --- Autocomplete Logic ---
   const pickupSearch = ref('')
@@ -340,16 +322,20 @@
       })
       isCreateModalOpen.value = false
       await refreshRides()
-      // Reset state
-      Object.assign(state, {
-        clientId: '',
-        pickupDisplay: '',
-        dropoffDisplay: '',
-        scheduledTime: '',
-        pickupTime: '',
-        notes: '',
-        volunteerId: undefined,
-      })
+      // Reset state back to a blank form. Assign into the nested pickup/dropoff
+      // objects so the reactive references are preserved and the address fields
+      // actually clear (issue #11 — the old reset used non-existent
+      // `pickupDisplay`/`dropoffDisplay` keys and never cleared the addresses).
+      const blank = blankRideForm()
+      Object.assign(state.pickup, blank.pickup)
+      Object.assign(state.dropoff, blank.dropoff)
+      state.clientId = blank.clientId
+      state.scheduledTime = blank.scheduledTime
+      state.pickupTime = blank.pickupTime
+      state.notes = blank.notes
+      state.volunteerId = blank.volunteerId
+      pickupSearch.value = ''
+      dropoffSearch.value = ''
     } catch (err) {
       console.error('Failed to create ride', err)
     }

--- a/app/utils/rideForm.ts
+++ b/app/utils/rideForm.ts
@@ -1,0 +1,33 @@
+// Shape of the Create Ride modal's form state, with nested pickup/dropoff
+// address objects. Kept as a pure factory so the modal can initialise its
+// reactive state and reset it back to blank from a single source of truth —
+// resetting the actual nested keys instead of the non-existent `*Display` keys
+// that previously left stale address data behind (issue #11).
+export interface RideAddressForm {
+  street: string
+  city: string
+  state: string
+  zip: string
+}
+
+export interface RideForm {
+  clientId: string
+  pickup: RideAddressForm
+  dropoff: RideAddressForm
+  scheduledTime: string
+  pickupTime: string
+  notes: string
+  volunteerId: any
+}
+
+export function blankRideForm(): RideForm {
+  return {
+    clientId: '',
+    pickup: { street: '', city: '', state: '', zip: '' },
+    dropoff: { street: '', city: '', state: '', zip: '' },
+    scheduledTime: '',
+    pickupTime: '',
+    notes: '',
+    volunteerId: undefined,
+  }
+}

--- a/tests/e2e/ride-form-reset.test.ts
+++ b/tests/e2e/ride-form-reset.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { bootShared } from '../utils/harness'
+import { blankRideForm } from '../../app/utils/rideForm'
+
+// Frontend-only regression test for issue #11.
+//
+// The Create Ride modal (app/pages/rides/index.vue) used to reset its form
+// after a successful submit with non-existent `pickupDisplay`/`dropoffDisplay`
+// keys, so the nested `pickup`/`dropoff` address objects were never cleared and
+// the next ride could silently inherit the previous ride's addresses.
+//
+// The reset now derives from a single pure factory, `blankRideForm()`, and
+// re-uses it (assigning into the nested reactive objects). This test pins the
+// factory's contract: a blank form has fully-empty nested address objects and
+// none of the bogus `*Display` keys. If someone reintroduces the old shape
+// (top-level `pickupDisplay`/`dropoffDisplay` and no nested reset), the
+// nested-object assertions below fail.
+//
+// bootShared() is called to satisfy the e2e harness (the vitest config builds
+// and boots one shared Nuxt server for the whole suite); this test itself only
+// exercises the pure form-state factory.
+await bootShared()
+
+describe('Create Ride form reset (issue #11)', () => {
+  it('blankRideForm() produces fully-cleared nested pickup/dropoff objects', () => {
+    const form = blankRideForm()
+
+    // The real defect: nested address objects must exist and be empty.
+    expect(form.pickup).toEqual({ street: '', city: '', state: '', zip: '' })
+    expect(form.dropoff).toEqual({ street: '', city: '', state: '', zip: '' })
+
+    // The bogus keys the old reset used must not exist on the form shape.
+    expect(form).not.toHaveProperty('pickupDisplay')
+    expect(form).not.toHaveProperty('dropoffDisplay')
+
+    // Other real fields are blank too.
+    expect(form.clientId).toBe('')
+    expect(form.scheduledTime).toBe('')
+    expect(form.pickupTime).toBe('')
+    expect(form.notes).toBe('')
+    expect(form.volunteerId).toBeUndefined()
+  })
+
+  it('simulates the post-submit reset clearing stale addresses on nested state', () => {
+    // Mirror how the modal resets: an existing reactive-like state object whose
+    // nested pickup/dropoff carry the previous ride's addresses.
+    const state: Record<string, any> = {
+      clientId: 'client-123',
+      pickup: { street: '123 Old St', city: 'Dallas', state: 'TX', zip: '75001' },
+      dropoff: { street: '999 Prev Ave', city: 'Plano', state: 'TX', zip: '75023' },
+      scheduledTime: '2026-07-09T10:00',
+      pickupTime: '2026-07-09T09:30',
+      notes: 'stale note',
+      volunteerId: 'vol-1',
+    }
+
+    // The exact reset the component performs.
+    const blank = blankRideForm()
+    Object.assign(state.pickup, blank.pickup)
+    Object.assign(state.dropoff, blank.dropoff)
+    state.clientId = blank.clientId
+    state.scheduledTime = blank.scheduledTime
+    state.pickupTime = blank.pickupTime
+    state.notes = blank.notes
+    state.volunteerId = blank.volunteerId
+
+    expect(state.pickup).toEqual({ street: '', city: '', state: '', zip: '' })
+    expect(state.dropoff).toEqual({ street: '', city: '', state: '', zip: '' })
+    expect(state.clientId).toBe('')
+    expect(state.notes).toBe('')
+  })
+})


### PR DESCRIPTION
## What was broken
The create-ride modal's post-submit reset in `app/pages/rides/index.vue` used non-existent `pickupDisplay`/`dropoffDisplay` keys instead of the nested `pickup: { street, city, state, zip }` / `dropoff: {...}` objects that actually exist in the form state. So after creating a ride the pickup/dropoff address fields were never cleared (and two junk `*Display` keys got added to the reactive state), letting the next ride an admin created silently inherit the previous ride's addresses.

## What changed
- Added `app/utils/rideForm.ts` exporting a pure `blankRideForm()` factory that returns the form's initial shape with fully-empty nested `pickup`/`dropoff` objects — a single source of truth for both init and reset.
- `app/pages/rides/index.vue`: initialise `state` from `blankRideForm()`, and on successful submit reset by `Object.assign`-ing into the nested `state.pickup`/`state.dropoff` (preserving their reactive references) plus clearing the other real fields (`clientId`, `scheduledTime`, `pickupTime`, `notes`, `volunteerId`) and the autocomplete search refs (`pickupSearch`/`dropoffSearch`). Removed the bogus `pickupDisplay`/`dropoffDisplay` keys.

No server, schema, auth, CI, docker, or dependency changes.

## Verification

**This is a frontend-only issue** (client-side Vue reactivity). The API/SSR e2e harness can't observe a component's post-submit local state, so a pure API revert-check isn't possible here. I also could not drive a real browser in this environment (the Chrome automation extension was not connected, and the dev server's better-auth OTP endpoint 404'd under a file-watcher `EMFILE` fault), so there is **no browser before/after screenshot** — I'm being explicit about that per the fix-issue skill.

Instead I factored the reset into the pure `blankRideForm()` factory and added a **regression test**: `tests/e2e/ride-form-reset.test.ts`
- `blankRideForm() produces fully-cleared nested pickup/dropoff objects` — asserts `form.pickup`/`form.dropoff` deep-equal `{ street:'', city:'', state:'', zip:'' }`, that the form has **no** `pickupDisplay`/`dropoffDisplay` keys, and that the other fields are blank.
- `simulates the post-submit reset clearing stale addresses on nested state` — builds a state object carrying a previous ride's addresses, applies the exact reset the component performs, and asserts the nested address objects are emptied.

**Revert-check (done manually):** I temporarily replaced `blankRideForm()` with the original buggy shape (top-level `pickupDisplay`/`dropoffDisplay`, no nested objects) and ran the test — it failed on precisely the issue's defect:
- `expected undefined to deeply equal { street: '', city: '', … }` (nested `pickup` object missing), and
- `expected { street: '123 Old St', … } to deeply equal { street: '', … }` (stale address not cleared).

Then restored the correct factory and the suite is green again. Note this is a helper/reset-shape revert-check, not an API revert-check — the gate should weigh it as such.

- `pnpm test`: **18 files, 79 tests passed** (one run showed a flaky failure in the unrelated `complete-requires-ridetime.test.ts` (issue #10) from shared-DB test ordering; it passes in isolation and on re-run, and my change touches no server/DB code).
- `pnpm build`: **success**.

Fixes #11