### PR TITLE
Fix #22: drop the un-toggleable Cancelled filter and sanitize stale saved filters

### DIFF
--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -3,6 +3,11 @@
   import type { TableColumn, TableRow } from '@nuxt/ui'
   import * as z from 'zod'
   import { authClient } from '../../utils/auth-client'
+  import {
+    BASE_FILTER_OPTIONS,
+    DEFAULT_EXCLUDED_FILTERS,
+    sanitizeSavedFilters,
+  } from '../../utils/rideFilters'
 
   const UBadge = resolveComponent('UBadge')
 
@@ -27,15 +32,22 @@
   const savedExcludedFilters = useCookie<{ label: string; value: string }[]>(
     'ride-excluded-filters',
     {
-      default: () => [
-        { label: 'Completed', value: 'status:COMPLETED' },
-        { label: 'Cancelled', value: 'status:CANCELLED' },
-      ],
-    } // Default exclude
+      default: () => [...DEFAULT_EXCLUDED_FILTERS], // Default exclude (see issue #22)
+    }
   )
 
-  const activeFilters = ref<{ label: string; value: string }[]>(savedActiveFilters.value)
-  const excludedFilters = ref<{ label: string; value: string }[]>(savedExcludedFilters.value)
+  // All values the UI can actually toggle. Includes `assign:ME` because it is a
+  // valid (volunteer-only) filter; base status options are always valid. Any
+  // saved value outside this set (e.g. the stale `status:CANCELLED`) is stripped
+  // on load so existing users aren't stuck with an un-toggleable filter (#22).
+  const knownFilterValues = [...BASE_FILTER_OPTIONS.map((o) => o.value), 'assign:ME']
+
+  const activeFilters = ref<{ label: string; value: string }[]>(
+    sanitizeSavedFilters(savedActiveFilters.value, knownFilterValues)
+  )
+  const excludedFilters = ref<{ label: string; value: string }[]>(
+    sanitizeSavedFilters(savedExcludedFilters.value, knownFilterValues)
+  )
 
   // Use watch to refetch when sort changes
   const {
@@ -67,11 +79,7 @@
   const isCreateModalOpen = ref(false)
 
   const filterOptions = computed(() => {
-    const options = [
-      { label: 'Created', value: 'status:CREATED' },
-      { label: 'Assigned', value: 'status:ASSIGNED' },
-      { label: 'Completed', value: 'status:COMPLETED' },
-    ]
+    const options = [...BASE_FILTER_OPTIONS]
     if (!isAdmin.value) {
       options.push({ label: 'Assigned to Me', value: 'assign:ME' })
     }

--- a/app/utils/rideFilters.ts
+++ b/app/utils/rideFilters.ts
@@ -1,0 +1,45 @@
+// Pure, testable logic for the Rides dashboard status filters (issue #22).
+//
+// Background: the "Exclude Status" dropdown used to default to excluding a
+// `status:CANCELLED` filter, but CANCELLED is not a real RideStatus and is not
+// among the toggleable `filterOptions`. That left the filter active in the
+// dropdown header with no checkbox to turn it off — an un-toggleable, stuck
+// filter. These helpers keep the persisted cookie state in sync with the set of
+// filter values the UI can actually toggle.
+
+export type RideFilter = { label: string; value: string }
+
+/**
+ * The base status filter values that always exist in the UI. Volunteer-only
+ * options (e.g. `assign:ME`) are appended at runtime in the component and are
+ * treated as valid there via the `validValues` argument to sanitize.
+ */
+export const BASE_FILTER_OPTIONS: RideFilter[] = [
+  { label: 'Created', value: 'status:CREATED' },
+  { label: 'Assigned', value: 'status:ASSIGNED' },
+  { label: 'Completed', value: 'status:COMPLETED' },
+]
+
+/**
+ * Default excluded filters for new users. Only excludes Completed rides, which
+ * is a valid, toggleable option. The stale `status:CANCELLED` default has been
+ * removed (issue #22) because there is no CANCELLED status to toggle it off.
+ */
+export const DEFAULT_EXCLUDED_FILTERS: RideFilter[] = [
+  { label: 'Completed', value: 'status:COMPLETED' },
+]
+
+/**
+ * Drop any saved filter whose value is not among the currently toggleable
+ * options. This frees existing users whose `ride-excluded-filters` cookie still
+ * contains `status:CANCELLED` (or any other stale value) so they aren't stuck
+ * with an active-but-unmanageable filter.
+ */
+export function sanitizeSavedFilters(
+  saved: RideFilter[] | null | undefined,
+  validValues: string[]
+): RideFilter[] {
+  if (!Array.isArray(saved)) return []
+  const valid = new Set(validValues)
+  return saved.filter((f) => f && valid.has(f.value))
+}

--- a/tests/e2e/ride-filters.test.ts
+++ b/tests/e2e/ride-filters.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BASE_FILTER_OPTIONS,
+  DEFAULT_EXCLUDED_FILTERS,
+  sanitizeSavedFilters,
+} from '../../app/utils/rideFilters'
+
+// Pure-function unit test for the rides status-filter helpers (issue #22).
+// Intentionally does NOT call setup() — it exercises pure helpers and must not
+// boot the Nuxt app, so it stays fast (mirrors trusted-origins.test.ts).
+describe('ride filter helpers (#22)', () => {
+  const validValues = BASE_FILTER_OPTIONS.map((o) => o.value)
+
+  it('has no default excluded filter that is absent from the toggleable options', () => {
+    // Pins the bug: `status:CANCELLED` was a default exclusion but is not a
+    // toggleable filter option, leaving the UI stuck with an un-removable filter.
+    for (const f of DEFAULT_EXCLUDED_FILTERS) {
+      expect(validValues).toContain(f.value)
+    }
+  })
+
+  it('keeps the sensible Completed default exclusion', () => {
+    expect(DEFAULT_EXCLUDED_FILTERS.map((f) => f.value)).toContain('status:COMPLETED')
+  })
+
+  it('strips the stale status:CANCELLED entry but keeps valid ones', () => {
+    const saved = [
+      { label: 'Completed', value: 'status:COMPLETED' },
+      { label: 'Cancelled', value: 'status:CANCELLED' },
+    ]
+    const result = sanitizeSavedFilters(saved, validValues)
+    expect(result.map((f) => f.value)).toEqual(['status:COMPLETED'])
+    expect(result.map((f) => f.value)).not.toContain('status:CANCELLED')
+  })
+
+  it('keeps runtime-valid values that are passed in validValues (e.g. assign:ME)', () => {
+    const saved = [{ label: 'Assigned to Me', value: 'assign:ME' }]
+    const result = sanitizeSavedFilters(saved, [...validValues, 'assign:ME'])
+    expect(result.map((f) => f.value)).toEqual(['assign:ME'])
+  })
+
+  it('handles null/undefined saved cookie gracefully', () => {
+    expect(sanitizeSavedFilters(null, validValues)).toEqual([])
+    expect(sanitizeSavedFilters(undefined, validValues)).toEqual([])
+  })
+})


### PR DESCRIPTION
## What was broken
On the Rides dashboard (`app/pages/rides/index.vue`), the "Exclude Status" dropdown defaulted to excluding `status:CANCELLED`. But `CANCELLED` is not a real `RideStatus` (only `CREATED | ASSIGNED | COMPLETED` exist) and so is never in the toggleable `filterOptions`. The result: "Cancelled" showed as an active exclusion in the dropdown header with no checkbox to turn it off — a stuck, un-manageable filter. This is **frontend-only** and independent of #5 (whether CANCELLED ever becomes a real status); removing a filter for a nonexistent status is correct today.

## What changed
- New pure helper `app/utils/rideFilters.ts`:
  - `BASE_FILTER_OPTIONS` — the base status options (single source of truth).
  - `DEFAULT_EXCLUDED_FILTERS` — the corrected default, excluding **only** `Completed` (the sensible, toggleable default). The stale `Cancelled` entry is gone.
  - `sanitizeSavedFilters(saved, validValues)` — drops any saved filter whose value isn't among the known/toggleable values.
- `app/pages/rides/index.vue` now:
  - uses `DEFAULT_EXCLUDED_FILTERS` for the `ride-excluded-filters` cookie default (fixes new users), and
  - **sanitizes on load** — initializes `activeFilters`/`excludedFilters` via `sanitizeSavedFilters(...)`, so **existing users** whose `ride-excluded-filters` cookie already contains `status:CANCELLED` are freed, not just new users.
  - reuses `BASE_FILTER_OPTIONS` in `filterOptions` so the option list and the sanitize whitelist can't drift.
- The Created/Assigned/Completed include/exclude filtering, the `assign:ME` volunteer filter, and the "Completed" default exclusion are all preserved (`assign:ME` is included in the known-values whitelist).

## Verification
- New pure unit test `tests/e2e/ride-filters.test.ts` (imports the helper directly; does **not** boot the server, mirroring `trusted-origins.test.ts`):
  - `has no default excluded filter that is absent from the toggleable options` — pins the bug; **fails pre-fix** (default included the un-toggleable `status:CANCELLED`), passes after.
  - `keeps the sensible Completed default exclusion`
  - `strips the stale status:CANCELLED entry but keeps valid ones`
  - `keeps runtime-valid values that are passed in validValues (e.g. assign:ME)`
  - `handles null/undefined saved cookie gracefully`
- Confirmed the pinning test **fails** when the buggy `status:CANCELLED` default is reintroduced, and **passes** after the fix.
- `pnpm test` — 19 files / 84 tests green (including the new ones).
- `pnpm build` — succeeds.

No schema/auth/CI/docker/deps changes. No risk files touched.

Fixes #22