### PR TITLE
Fix #53: store blank admin phone numbers as null

### DIFF
--- a/server/api/post/admins/index.ts
+++ b/server/api/post/admins/index.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
       data: {
         role: 'ADMIN',
         name: body.name,
-        phone: body.phone,
+        phone: emptyToNull(body.phone),
       },
     })
   } else {
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
       data: {
         name: body.name,
         email: body.email,
-        phone: body.phone,
+        phone: emptyToNull(body.phone),
         role: 'ADMIN',
       },
     })

--- a/server/api/put/admins/[id].ts
+++ b/server/api/put/admins/[id].ts
@@ -16,7 +16,7 @@ export default defineEventHandler(async (event) => {
     data: {
       name: body.name,
       email: body.email,
-      phone: body.phone,
+      phone: emptyToNull(body.phone),
     },
   })
 })

--- a/tests/e2e/admin-empty-phone.test.ts
+++ b/tests/e2e/admin-empty-phone.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Issue #53 (#15 sibling): the admin create/update endpoints
+// (server/api/post/admins/index.ts, server/api/put/admins/[id].ts) still passed
+// phone: body.phone unsanitized. Clearing a second admin's phone (sending "")
+// stores a duplicate "" and trips the User.phone @unique constraint -> P2002 ->
+// 500. Blank phones must be stored as null so any number of admins can have "no
+// phone". #15 fixed this for volunteers/clients but not admins.
+//
+// Uses throwaway unique emails and deletes them again so the shared seeded DB
+// isn't disturbed (cleanup runs inside each test, not afterAll — Nuxt's test
+// context is torn down before afterAll hooks fire).
+
+type AdminUser = { id: string; email: string; phone: string | null }
+
+async function getAdmin(cookie: string, email: string): Promise<AdminUser> {
+  const admins = await $fetch<AdminUser[]>('/api/get/admins', {
+    headers: { cookie },
+  })
+  const a = admins.find((a) => a.email === email)
+  expect(a, `admin ${email} should exist`).toBeTruthy()
+  return a!
+}
+
+async function deleteAdmin(cookie: string, id: string): Promise<void> {
+  await $fetch(`/api/delete/admins/${id}`, {
+    method: 'DELETE',
+    headers: { cookie },
+  }).catch(() => {})
+}
+
+describe('issue #53 — blank admin phone numbers must be stored as null', () => {
+  it('clearing phone ("") on two different admins both succeed and store null', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+
+    // Two throwaway admins with unique emails, each seeded with a phone.
+    const stamp = Date.now()
+    const emailA = `throwaway-admin-a-${stamp}@example.com`
+    const emailB = `throwaway-admin-b-${stamp}@example.com`
+    const ids: string[] = []
+
+    try {
+      const a = await $fetch<AdminUser>('/api/post/admins', {
+        method: 'POST',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Throwaway Admin A', email: emailA, phone: '4695551111' },
+      })
+      ids.push(a.id)
+      const b = await $fetch<AdminUser>('/api/post/admins', {
+        method: 'POST',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Throwaway Admin B', email: emailB, phone: '4695552222' },
+      })
+      ids.push(b.id)
+
+      // First clear via PUT: succeeds even pre-fix ("" is unique so far).
+      await $fetch(`/api/put/admins/${a.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Throwaway Admin A', email: emailA, phone: '' },
+      })
+
+      // Second clear via PUT: pre-fix this stores another "" and trips @unique ->
+      // P2002 -> 500. Post-fix it stores null and succeeds.
+      await $fetch(`/api/put/admins/${b.id}`, {
+        method: 'PUT',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Throwaway Admin B', email: emailB, phone: '' },
+      })
+
+      const aAfter = await getAdmin(adminCookie, emailA)
+      const bAfter = await getAdmin(adminCookie, emailB)
+      expect(aAfter.phone).toBeNull()
+      expect(bAfter.phone).toBeNull()
+    } finally {
+      for (const id of ids) await deleteAdmin(adminCookie, id)
+    }
+  })
+
+  it('creating an admin with a blank phone stores null (POST create branch)', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+
+    const email = `throwaway-admin-c-${Date.now()}@example.com`
+    let id: string | undefined
+
+    try {
+      const created = await $fetch<AdminUser>('/api/post/admins', {
+        method: 'POST',
+        headers: { cookie: adminCookie, 'content-type': 'application/json' },
+        body: { name: 'Throwaway Admin C', email, phone: '' },
+      })
+      id = created.id
+
+      const after = await getAdmin(adminCookie, email)
+      expect(after.phone).toBeNull()
+    } finally {
+      if (id) await deleteAdmin(adminCookie, id)
+    }
+  })
+})


### PR DESCRIPTION
## What was broken

The admin create/update endpoints (`server/api/post/admins/index.ts`, `server/api/put/admins/[id].ts`) still wrote `phone: body.phone` unsanitized — the sibling of #15. Clearing a second admin's phone (the frontend sends `""`) stores a duplicate blank string, which trips the `User.phone @unique` constraint (SQLite treats `""` as a distinct value), returning P2002 → 500. #15 fixed this for the client/volunteer endpoints but not admins.

## What changed

Applied the existing `emptyToNull()` helper (`server/utils/sanitize.ts`, added in #52) to every phone write in the two admin endpoints — the create branch, the existing-user upgrade branch, and the PUT update. Blank/whitespace phones are now stored as `null`, so any number of admins can have "no phone". No schema/auth/deps/CI changes.

## Verification

New regression test `tests/e2e/admin-empty-phone.test.ts`:
- Creates two throwaway admins (unique emails), clears both their phones via the admin PUT endpoint; the second clear 500s pre-fix (P2002), both succeed post-fix and store `null` (asserted `null`, not `""`).
- Creates an admin with a blank phone via POST; 500s pre-fix, stores `null` post-fix.
- Cleans up via `/api/delete/admins/<id>` so the shared seeded DB is undisturbed.

Confirmed FAIL pre-fix (both cases 500), PASS post-fix. Full suite green (`pnpm test` → 20 files, 86 tests) and `pnpm build` succeeds.

Fixes #53