### PR TITLE
Add query-count test seam to pin N+1 / unbounded-query regressions (#45)

### DIFF
--- a/server/middleware/zz-test-query-count.ts
+++ b/server/middleware/zz-test-query-count.ts
@@ -1,0 +1,13 @@
+import { queryCounter } from '../utils/prisma'
+
+// Query-count seam (issue #45). Resets the per-request query counter so an e2e
+// test can measure only the handler's queries. Named `zz-` so it runs AFTER
+// `auth.ts` (Nitro runs middleware in alphabetical order) — the auth session
+// lookup's queries happen first and are excluded from the count. No-op unless
+// TEST_HOOKS=1 and the request opts in with `x-test-count-queries`.
+export default defineEventHandler((event) => {
+  if (process.env.TEST_HOOKS !== '1') return
+  if (getHeader(event, 'x-test-count-queries')) {
+    queryCounter.count = 0
+  }
+})

--- a/server/plugins/test-query-count.ts
+++ b/server/plugins/test-query-count.ts
@@ -1,0 +1,15 @@
+import { queryCounter } from '../utils/prisma'
+
+// Query-count seam (issue #45). After the handler runs, expose the number of
+// Prisma queries it issued via the `x-query-count` response header so e2e tests
+// can assert bounds (e.g. topRiders must issue ≤ 2 queries, not N+1). Paired
+// with the zz-test-query-count middleware that resets the counter per request.
+// No-op in production (TEST_HOOKS unset).
+export default defineNitroPlugin((nitro) => {
+  if (process.env.TEST_HOOKS !== '1') return
+  nitro.hooks.hook('beforeResponse', (event) => {
+    if (getHeader(event, 'x-test-count-queries')) {
+      setResponseHeader(event, 'x-query-count', String(queryCounter.count))
+    }
+  })
+})

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -5,6 +5,26 @@ import { PrismaClient } from "../../prisma/generated/client";
 const connectionString = `${process.env.DATABASE_URL}`;
 
 const adapter = new PrismaBetterSqlite3({ url: connectionString });
-const prisma = new PrismaClient({ adapter });
+const base = new PrismaClient({ adapter });
+
+// Query-count seam (issue #45 perf harness). When TEST_HOOKS=1, every Prisma
+// operation (including those inside interactive transactions) increments
+// `queryCounter.count`. A middleware resets it per-request and a Nitro plugin
+// returns it via the `x-query-count` response header, so e2e tests can pin
+// N+1 / unbounded-query regressions (e.g. #24) with a failing test. A complete
+// no-op in production: without TEST_HOOKS the base client is exported unchanged.
+export const queryCounter = { count: 0 };
+
+const prisma =
+  process.env.TEST_HOOKS === "1"
+    ? base.$extends({
+        query: {
+          async $allOperations({ args, query }) {
+            queryCounter.count++;
+            return query(args);
+          },
+        },
+      })
+    : base;
 
 export { prisma };

--- a/server/utils/testHooks.ts
+++ b/server/utils/testHooks.ts
@@ -1,18 +1,16 @@
 import type { H3Event } from 'h3'
 
-// Test-only fault-injection seam (issue #45).
-//
-// Concurrency bugs like the signup TOCTOU (#12) can't be reproduced through the
-// HTTP layer in the e2e harness: the synchronous better-sqlite3 adapter runs a
-// handler's read and write close enough together that a competing request never
-// interleaves between them, so a race test would pass even against buggy code.
-//
-// This seam lets a test deliberately widen that read→write window. It is a
-// complete no-op in production: it does nothing unless BOTH the server was
-// started with `TEST_RACE_HOOKS=1` (only tests/global-setup.ts sets this) AND
-// the request carries a matching `x-test-race-delay: <label>:<ms>` header.
+// Test-only seams (issue #45). All are complete no-ops in production: they do
+// nothing unless the server was started with `TEST_HOOKS=1` (only
+// tests/global-setup.ts sets this) AND the request opts in via a header.
+
+// Fault-injection: widen a handler's read→write window so concurrency bugs
+// (e.g. the signup TOCTOU #12) are reproducible through HTTP. The synchronous
+// better-sqlite3 adapter otherwise runs read and write too close together for a
+// competing request to interleave, so a race test would pass even on buggy code.
+// Enabled per-request via `x-test-race-delay: <label>:<ms>`.
 export async function raceDelay(event: H3Event, label: string): Promise<void> {
-  if (process.env.TEST_RACE_HOOKS !== '1') return
+  if (process.env.TEST_HOOKS !== '1') return
   const header = getHeader(event, 'x-test-race-delay')
   if (!header) return
   const [target, ms] = header.split(':')

--- a/tests/e2e/query-count-seam.test.ts
+++ b/tests/e2e/query-count-seam.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared, fetchWithQueryCount } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Validates the query-count seam (issue #45): a test-only per-request Prisma
+// query counter, exposed via the x-query-count header, that lets e2e tests pin
+// N+1 / unbounded-query regressions. Auth's own session-lookup queries are
+// excluded (the reset middleware runs after auth.ts).
+
+describe('query-count seam (#45)', () => {
+  it('counts exactly the queries a handler runs (addresses = 1 findMany)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const { status, queryCount } = await fetchWithQueryCount('/api/get/addresses?search=a', {
+      headers: { cookie },
+    })
+    expect(status).toBe(200)
+    // The handler does a single prisma.address.findMany; auth queries are reset out.
+    expect(queryCount).toBe(1)
+  })
+
+  it('stays bounded (not proportional to row count) for a batched list with includes', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const { status, queryCount, body } = await fetchWithQueryCount<unknown[]>('/api/get/rides', {
+      headers: { cookie },
+    })
+    expect(status).toBe(200)
+    // Seed has 9+ rides each with nested client/volunteer includes. Prisma loads
+    // includes per-relation-level (a small constant), NOT per row — so the count
+    // must stay bounded regardless of how many rides exist. A per-row N+1 here
+    // would blow past this.
+    expect(Array.isArray(body)).toBe(true)
+    expect(queryCount).toBeLessThanOrEqual(5)
+  })
+
+  it('detects the topRiders N+1 (issue #24): more queries than a batched version would need', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const { status, queryCount } = await fetchWithQueryCount('/api/get/metrics/topRiders', {
+      headers: { cookie },
+    })
+    expect(status).toBe(200)
+    // topRiders currently does groupBy + one findUnique PER grouped client (N+1).
+    // With the seeded COMPLETED rides that is > 2 queries. The batched fix (#24)
+    // will bring this to <= 2 — at which point this assertion should be tightened
+    // to `toBeLessThanOrEqual(2)`. Proves the seam catches a real N+1.
+    expect(queryCount).toBeGreaterThan(2)
+  })
+
+  it('is opt-in: no x-query-count header without the request opt-in', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const res = await appFetch('/api/get/addresses?search=a', { headers: { cookie } })
+    expect(res.headers.get('x-query-count')).toBeNull()
+  })
+})

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -65,10 +65,11 @@ export default async function globalSetup() {
       NITRO_PORT: String(port),
       HOST: '127.0.0.1',
       BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET ?? 'test-secret-not-for-production',
-      // Concurrency-test seam (issue #45): let tests open a TOCTOU window by
-      // injecting an await between read and write in guarded handlers. Off in
-      // normal runs; a test enables it per-request via a header.
-      TEST_RACE_HOOKS: '1',
+      // Enables the test-only seams (issue #45): the concurrency read→write
+      // delay (x-test-race-delay) and the per-request query counter
+      // (x-test-count-queries → x-query-count). Both are per-request opt-in and
+      // strict no-ops without this flag, which only the harness ever sets.
+      TEST_HOOKS: '1',
       DISABLE_RATE_LIMIT: 'true',
     },
     stdio: 'inherit',

--- a/tests/utils/harness.ts
+++ b/tests/utils/harness.ts
@@ -1,4 +1,4 @@
-import { setup } from '@nuxt/test-utils/e2e'
+import { setup, fetch as appFetch } from '@nuxt/test-utils/e2e'
 import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -20,4 +20,29 @@ export async function bootShared() {
     rootDir: fileURLToPath(new URL('../..', import.meta.url)),
     host: sharedHost(),
   })
+}
+
+// Query-count seam (issue #45). Issues a request with the count opt-in header
+// and returns how many Prisma queries the handler ran (post-auth) alongside the
+// parsed JSON body, so tests can pin N+1 / unbounded-query regressions.
+//
+// IMPORTANT: the counter is a module-level global on the server, so the caller
+// must AWAIT this (one measured request in flight at a time) — do not fire
+// concurrent counted requests, or the counts will interleave.
+export async function fetchWithQueryCount<T = unknown>(
+  path: string,
+  opts: { headers?: Record<string, string>; method?: string; body?: unknown } = {},
+): Promise<{ status: number; queryCount: number; body: T }> {
+  const res = await appFetch(path, {
+    method: opts.method ?? 'GET',
+    headers: { ...opts.headers, 'x-test-count-queries': '1' },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+  const header = res.headers.get('x-query-count')
+  const body = (await res.json().catch(() => null)) as T
+  return {
+    status: res.status,
+    queryCount: header === null ? NaN : Number(header),
+    body,
+  }
 }


### PR DESCRIPTION
Extends the test harness so **performance** issues become gate-verifiable — the capability gap that was forcing every Milestone-3 issue to flag.

## Why
N+1 fixes (#24) and unbounded-query fixes (#13) change **no observable output** — topRiders returns identical data whether it does N+1 queries or one batched query. So a regression test passes with or without the fix and the loop's revert-check is inconclusive. This is the same limitation that blocked #12 until the race seam; this adds the analogous seam for query counts.

## What
A **test-only** per-request Prisma query counter (all strict no-ops in production):
- `server/utils/prisma.ts` — when `TEST_HOOKS=1`, a `$extends` query hook increments `queryCounter.count` on every operation (incl. inside transactions). Without the flag, the **base client is exported unchanged**.
- `server/middleware/zz-test-query-count.ts` — resets the counter per request when `x-test-count-queries` is sent. Named `zz-` so it runs **after** `auth.ts`, excluding the session-lookup queries from the count.
- `server/plugins/test-query-count.ts` — returns the count via the `x-query-count` response header (opt-in only).
- `tests/utils/harness.ts` — `fetchWithQueryCount()` helper returning `{ status, queryCount, body }`.
- Unifies the test-hooks flag: `TEST_RACE_HOOKS` → `TEST_HOOKS` (raceDelay + global-setup), so the race seam and query seam share one gate.

## Verification (`tests/e2e/query-count-seam.test.ts`)
- `get/addresses?search` issues **exactly 1** query (precise counting; auth excluded).
- `get/rides` stays **≤ 5** despite nested client/volunteer includes over many rows (bounded, not per-row N+1).
- `get/metrics/topRiders` is detected as **> 2** queries — proving the seam catches the real #24 N+1. (When #24 lands, that assertion tightens to `≤ 2`.)
- Header is **absent** without the opt-in.
- Full suite: **90/90 green**; `pnpm build` succeeds; race seam unaffected under the renamed flag.

## Production safety
Without `TEST_HOOKS` (i.e. always, outside the harness): the base Prisma client is used, the middleware and plugin return immediately, and a hostile client sending `x-test-count-queries`/`x-query-count` gets nothing. The only prod-file change is `prisma.ts` (guarded ternary) — behavior identical when the flag is unset.

## Unlocks
#24 (assert topRiders ≤ 2), and the query-efficiency aspect of #13, plus any future N+1 — now with a genuine failing-pre-fix test that clears the revert-check.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)