### PR TITLE
Fix #24: batch topRiders client lookup to remove N+1

### DIFF
--- a/server/api/get/metrics/topRiders/index.ts
+++ b/server/api/get/metrics/topRiders/index.ts
@@ -44,16 +44,23 @@ export default defineEventHandler(async (event) => {
     take: 5
   })
 
-  const topRiders = await Promise.all(topRidersRaw.map(async (item) => {
-    const client = await prisma.client.findUnique({
-      where: { id: item.clientId },
-      include: { user: true }
-    })
+  // Batch the client lookups into a single query to avoid an N+1 (issue #24):
+  // resolve every grouped clientId at once, then map by id to preserve the
+  // existing output shape and the count-desc ordering from the groupBy above.
+  const clientIds = topRidersRaw.map((item) => item.clientId)
+  const clients = await prisma.client.findMany({
+    where: { id: { in: clientIds } },
+    include: { user: true }
+  })
+  const clientsById = new Map(clients.map((client) => [client.id, client]))
+
+  const topRiders = topRidersRaw.map((item) => {
+    const client = clientsById.get(item.clientId)
     return {
       name: client?.user?.name || 'Unknown',
       completedRides: item._count.id
     }
-  }))
+  })
 
   return topRiders
 })

--- a/tests/e2e/query-count-seam.test.ts
+++ b/tests/e2e/query-count-seam.test.ts
@@ -35,17 +35,17 @@ describe('query-count seam (#45)', () => {
     expect(queryCount).toBeLessThanOrEqual(5)
   })
 
-  it('detects the topRiders N+1 (issue #24): more queries than a batched version would need', async () => {
+  it('keeps topRiders batched (issue #24): groupBy + one findMany, not an N+1', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
     const { status, queryCount } = await fetchWithQueryCount('/api/get/metrics/topRiders', {
       headers: { cookie },
     })
     expect(status).toBe(200)
-    // topRiders currently does groupBy + one findUnique PER grouped client (N+1).
-    // With the seeded COMPLETED rides that is > 2 queries. The batched fix (#24)
-    // will bring this to <= 2 — at which point this assertion should be tightened
-    // to `toBeLessThanOrEqual(2)`. Proves the seam catches a real N+1.
-    expect(queryCount).toBeGreaterThan(2)
+    // topRiders does groupBy + a single batched findMany for the grouped clients
+    // (issue #24 fix). Previously it ran one findUnique PER grouped client (N+1,
+    // > 2 queries with the seeded COMPLETED rides). The batched version stays at
+    // <= 2 regardless of how many clients are returned.
+    expect(queryCount).toBeLessThanOrEqual(2)
   })
 
   it('is opt-in: no x-query-count header without the request opt-in', async () => {

--- a/tests/e2e/topRiders-n1.test.ts
+++ b/tests/e2e/topRiders-n1.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared, fetchWithQueryCount } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Regression test for issue #24: the topRiders metric endpoint did a groupBy
+// followed by one prisma.client.findUnique PER grouped client (a classic N+1).
+// The fix batches those lookups into a single findMany, so the whole handler
+// runs in <= 2 Prisma queries (groupBy + findMany) and the output shape/order
+// is unchanged.
+//
+// Query count is pinned via the query-count seam (issue #45): pre-fix the
+// handler ran groupBy + N findUnique (> 2); post-fix it stays <= 2.
+//
+// Output correctness is proven against data this test creates itself, in a
+// far-future date window with dedicated clients, so it is immune to the shared
+// e2e server's concurrent mutations of the seeded rides.
+
+interface TopRider {
+  name: string
+  completedRides: number
+}
+
+type Client = { id: string; user: { email: string } }
+type Ride = { id: string; status: string }
+
+// A ride far in the future so it never overlaps the seeded rides or rides other
+// e2e files create; the query below restricts to exactly this window.
+const WINDOW_START = '2090-01-01'
+const WINDOW_END = '2090-12-31'
+const SCHEDULED_DAY = '2090-06-15'
+
+const testAddress = {
+  street: '742 Evergreen Terrace',
+  city: 'Springfield',
+  state: 'TX',
+  zip: '75001',
+}
+
+async function completeRideFor(cookie: string, clientId: string): Promise<void> {
+  const created = await $fetch<Ride>('/api/post/rides', {
+    method: 'POST',
+    headers: { cookie },
+    body: {
+      clientId,
+      pickup: testAddress,
+      dropoff: testAddress,
+      scheduledTime: `${SCHEDULED_DAY}T14:00:00`,
+    },
+  })
+  const completed = await $fetch<Ride>(`/api/put/rides/${created.id}`, {
+    method: 'PUT',
+    headers: { cookie },
+    body: { status: 'COMPLETED', totalRideTime: 1 },
+  })
+  expect(completed.status).toBe('COMPLETED')
+}
+
+describe('topRiders N+1 (issue #24)', () => {
+  it('resolves grouped clients in a single batched query (<= 2 total)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const { status, queryCount } = await fetchWithQueryCount(
+      '/api/get/metrics/topRiders',
+      { headers: { cookie } },
+    )
+    expect(status).toBe(200)
+    // groupBy + one batched findMany == 2. Anything more means the per-client
+    // findUnique loop (N+1) is still present.
+    expect(queryCount).toBeLessThanOrEqual(2)
+  })
+
+  it('returns real client names + correct counts, ordered desc (batching unchanged)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const clients = await $fetch<Client[]>('/api/get/clients', { headers: { cookie } })
+    const [clientA, clientB] = clients
+    expect(clientA, 'seed should provide at least two clients').toBeTruthy()
+    expect(clientB, 'seed should provide at least two clients').toBeTruthy()
+
+    const nameOf = (email: string) =>
+      ({
+        'martha@example.com': 'Martha Jenkins',
+        'george@example.com': 'George Miller',
+        'sarah@example.com': 'Sarah Connor',
+      })[email] ?? email
+
+    // clientA gets two completed rides, clientB gets one — in an isolated window.
+    await completeRideFor(cookie, clientA!.id)
+    await completeRideFor(cookie, clientA!.id)
+    await completeRideFor(cookie, clientB!.id)
+
+    const qs = `startDate=${WINDOW_START}&endDate=${WINDOW_END}`
+    const { status, body } = await fetchWithQueryCount<TopRider[]>(
+      `/api/get/metrics/topRiders?${qs}`,
+      { headers: { cookie } },
+    )
+    expect(status).toBe(200)
+    expect(Array.isArray(body)).toBe(true)
+
+    // Only our two clients have completed rides in this window. Names must be
+    // resolved (never the 'Unknown' fallback) with the exact counts, and the
+    // higher-count client must come first (desc ordering preserved by the map).
+    expect(body).toEqual([
+      { name: nameOf(clientA!.user.email), completedRides: 2 },
+      { name: nameOf(clientB!.user.email), completedRides: 1 },
+    ])
+  })
+})


### PR DESCRIPTION
## What was broken

`server/api/get/metrics/topRiders/index.ts` ran a `prisma.ride.groupBy` and then a `Promise.all` of one `prisma.client.findUnique` **per grouped client** — a classic N+1. Capped at `take: 5` today, but still N round-trips against the connection pool per request.

## What changed

Extract the grouped `clientId`s and resolve them in a **single** `prisma.client.findMany({ where: { id: { in: clientIds } }, include: { user: true } })`, then map each grouped row back to its client via a `Map` by id. Output shape, the `Unknown` fallback, and the count-desc ordering are all preserved — behavior is identical. The whole handler now runs in exactly 2 Prisma queries (groupBy + findMany).

Scope: `topRiders/index.ts` + the two tests. No schema/auth/CI/docker/deps changes.

## Verification

- **New regression test** `tests/e2e/topRiders-n1.test.ts`:
  - `resolves grouped clients in a single batched query (<= 2 total)` — pins the N+1 via the query-count seam (#45): asserts `queryCount <= 2`.
  - `returns real client names + correct counts, ordered desc (batching unchanged)` — creates its own COMPLETED rides for two dedicated clients (counts 2 and 1) in an isolated far-future date window (2090) and asserts the exact `[{name, completedRides:2}, {name, completedRides:1}]` output. The isolated window makes it immune to the shared e2e server's concurrent mutation of the seeded rides.
- **Updated** `tests/e2e/query-count-seam.test.ts`: the existing topRiders assertion was `expect(queryCount).toBeGreaterThan(2)` (proving the N+1). Batching makes that false, so it is tightened to `expect(queryCount).toBeLessThanOrEqual(2)` — a direct consequence of this fix.
- **Pre-fix failing assertion (revert-check):** with the original handler restored, both query-count assertions fail with `AssertionError: expected 3 to be less than or equal to 2` (groupBy + 3 findUnique = 3). With the fix, `queryCount` is 2. The content test passes both before and after (batching does not change behavior).
- **Suite:** `pnpm test` → 22 files, 92 tests passing; run 5x to confirm no flakiness. `pnpm build` succeeds.

Fixes #24
