### PR TITLE
Add fault-injection test seam to unlock #17 and #32 (#45)

### DIFF
--- a/server/api/_test/run-reminders.post.ts
+++ b/server/api/_test/run-reminders.post.ts
@@ -1,0 +1,31 @@
+import { processReminders } from '../../utils/scheduler'
+import { armFault, disarmFault, maybeFault } from '../../utils/testHooks'
+
+// Test-only endpoint (issue #45). The reminder job runs on a cron timer, so an
+// e2e test can't otherwise invoke it. This lets a test drive processReminders()
+// on demand and optionally arm a fault (e.g. simulate a crash between the email
+// send and the SentReminder write) to pin the crash-recovery fix (#17).
+//
+// Hard-gated: returns 404 unless TEST_HOOKS=1 (only the harness sets it), so it
+// does not exist in production. Still behind the global auth middleware (admin).
+//
+// Body: { fault?: string } — arms that fault label for the duration of the run.
+export default defineEventHandler(async (event) => {
+  if (process.env.TEST_HOOKS !== '1') {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  // Validates the request-scoped fault path (x-test-fault: run-reminders).
+  maybeFault('run-reminders', event)
+
+  const body = await readBody(event).catch(() => ({}))
+  const fault = typeof body?.fault === 'string' ? body.fault : undefined
+
+  if (fault) armFault(fault)
+  try {
+    await processReminders()
+    return { ok: true }
+  } finally {
+    if (fault) disarmFault(fault)
+  }
+})

--- a/server/utils/scheduler.ts
+++ b/server/utils/scheduler.ts
@@ -1,8 +1,14 @@
 import { prisma } from './prisma'
 import { sendNotification } from './notification'
+import { maybeFault } from './testHooks'
 
 export async function processReminders() {
   const now = new Date()
+
+  // Test-only fault point (issue #45): a test can arm 'reminders-scan' (via the
+  // _test/run-reminders endpoint) to simulate the job crashing mid-run. No-op in
+  // production. #17 can add a finer point between send and the SentReminder write.
+  maybeFault('reminders-scan')
 
   // 1. Fetch upcoming rides that are assigned but not completed
   const rides = await prisma.ride.findMany({

--- a/server/utils/testHooks.ts
+++ b/server/utils/testHooks.ts
@@ -2,13 +2,15 @@ import type { H3Event } from 'h3'
 
 // Test-only seams (issue #45). All are complete no-ops in production: they do
 // nothing unless the server was started with `TEST_HOOKS=1` (only
-// tests/global-setup.ts sets this) AND the request opts in via a header.
+// tests/global-setup.ts sets this) AND the caller opts in (a request header, or
+// an explicitly armed fault). This lets e2e tests pin bugs whose fix changes no
+// observable output — concurrency (#12), and crash-recovery / non-blocking
+// behavior (#17, #32).
 
-// Fault-injection: widen a handler's read→write window so concurrency bugs
-// (e.g. the signup TOCTOU #12) are reproducible through HTTP. The synchronous
-// better-sqlite3 adapter otherwise runs read and write too close together for a
-// competing request to interleave, so a race test would pass even on buggy code.
-// Enabled per-request via `x-test-race-delay: <label>:<ms>`.
+// --- Concurrency: widen a handler's read→write window ------------------------
+// The synchronous better-sqlite3 adapter runs read and write too close together
+// for a competing request to interleave, so a race test would pass even on buggy
+// code. Enabled per-request via `x-test-race-delay: <label>:<ms>`.
 export async function raceDelay(event: H3Event, label: string): Promise<void> {
   if (process.env.TEST_HOOKS !== '1') return
   const header = getHeader(event, 'x-test-race-delay')
@@ -16,4 +18,30 @@ export async function raceDelay(event: H3Event, label: string): Promise<void> {
   const [target, ms] = header.split(':')
   if (target !== label) return
   await new Promise((resolve) => setTimeout(resolve, Number(ms) || 0))
+}
+
+// --- Fault injection: throw at a labeled point -------------------------------
+// Lets a test simulate a mid-operation failure so it can prove crash-recovery /
+// non-blocking fixes. Two trigger modes:
+//   - request-scoped: pass the `event`; fires when `x-test-fault: <label>` matches
+//     (for handlers/utils reachable from a request, e.g. the ride-create broadcast, #32).
+//   - context-free: no `event`; fires when the label was armed via armFault()
+//     (for code with no request, e.g. the cron scheduler, #17 — armed by the
+//     test-only reminder-trigger endpoint).
+const armedFaults = new Set<string>()
+
+export function armFault(label: string): void {
+  armedFaults.add(label)
+}
+
+export function disarmFault(label: string): void {
+  armedFaults.delete(label)
+}
+
+export function maybeFault(label: string, event?: H3Event): void {
+  if (process.env.TEST_HOOKS !== '1') return
+  const headerMatch = event ? getHeader(event, 'x-test-fault') === label : false
+  if (headerMatch || armedFaults.has(label)) {
+    throw createError({ statusCode: 500, statusMessage: `injected test fault: ${label}` })
+  }
 }

--- a/tests/e2e/fault-injection-seam.test.ts
+++ b/tests/e2e/fault-injection-seam.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Validates the fault-injection seam (issue #45): a test-only way to make a
+// handler/util throw at a labeled point so crash-recovery / non-blocking fixes
+// (#17, #32) can be pinned. Exercised through the gated _test/run-reminders
+// endpoint (which also gives #17 an on-demand trigger for the cron job).
+
+async function runReminders(
+  cookie: string,
+  opts: { fault?: string; header?: string } = {},
+): Promise<number> {
+  const headers: Record<string, string> = { cookie, 'content-type': 'application/json' }
+  if (opts.header) headers['x-test-fault'] = opts.header
+  const res = await appFetch('/api/_test/run-reminders', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(opts.fault ? { fault: opts.fault } : {}),
+  })
+  return res.status
+}
+
+describe('fault-injection seam (#45)', () => {
+  it('runs the reminder job on demand with no fault (200)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    expect(await runReminders(cookie)).toBe(200)
+  })
+
+  it('request-scoped fault fires on a matching x-test-fault header (500)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    expect(await runReminders(cookie, { header: 'run-reminders' })).toBe(500)
+  })
+
+  it('does not fire on a non-matching fault label (200)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    expect(await runReminders(cookie, { header: 'some-other-label' })).toBe(200)
+  })
+
+  it('context-free (armed) fault fires inside the cron job when armed via body (500)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    // Arms 'reminders-scan', which processReminders() checks with maybeFault()
+    // (no request event) — proving the cron-context path works for #17.
+    expect(await runReminders(cookie, { fault: 'reminders-scan' })).toBe(500)
+  })
+
+  it('the fault is disarmed after the run (a subsequent run succeeds)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    await runReminders(cookie, { fault: 'reminders-scan' })
+    // If armFault leaked, this second run would 500. The endpoint disarms in finally.
+    expect(await runReminders(cookie)).toBe(200)
+  })
+})


### PR DESCRIPTION
Third harness capability (after the race seam #12 and query-count seam #65) — this one unlocks the two remaining Milestone-3 issues whose fixes change **no observable output**.

## Why
- **#17** (cron notification race): the fix (write `SentReminder` before/with the send) only matters if the process crashes between send and DB-write — the happy path is already idempotent, so an output test passes either way.
- **#32** (broadcast blocking): fire-and-forget vs `await` returns the same response; only latency/error-propagation differ.

Neither can clear the revert-check without a way to inject a mid-operation failure. This adds that.

## What
- `server/utils/testHooks.ts` — `maybeFault(label, event?)` with two triggers, both **no-ops in production** (require `TEST_HOOKS=1`):
  - **request-scoped**: fires when `x-test-fault: <label>` matches (for request-reachable code, e.g. #32's broadcast).
  - **context-free**: fires when `armFault(label)` was called (for code with no request event, e.g. the cron scheduler #17). `armFault`/`disarmFault` bracket a run.
- `server/api/_test/run-reminders.post.ts` — **hard-gated (404 unless `TEST_HOOKS=1`)** endpoint that invokes `processReminders()` on demand (the job otherwise only runs on a cron timer, unreachable from a test) and can arm a fault via `{ fault }` body.
- `server/utils/scheduler.ts` — one `maybeFault('reminders-scan')` hook (no-op in prod); #17 can add a finer point between send and the SentReminder write.

## Verification (`tests/e2e/fault-injection-seam.test.ts`, 5 cases)
- on-demand reminder run with no fault → 200
- request-header fault (`x-test-fault: run-reminders`) → 500
- non-matching label → 200
- armed cron fault (`{ fault: 'reminders-scan' }`) fires inside `processReminders` → 500 (proves the context-free path)
- fault disarmed after the run → next run 200
- Full suite: **97/97**; `pnpm build` clean.

## Production safety
Without `TEST_HOOKS` (always, outside the harness): the `_test/run-reminders` endpoint 404s, `maybeFault` returns immediately, and `armFault` is never reachable. Prod files touched are `scheduler.ts` (one guarded no-op line) and `testHooks.ts` (test-only) — no behavior change when the flag is unset.

## Unlocks
#17 (arm a fault between send and SentReminder-write; assert no re-send after the fix) and #32 (inject a broadcast fault; pre-fix `await` → 500, post-fix fire-and-forget → 200). Both become clean, revert-checkable auto-merges.

Fixes #45 (final harness capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)