### PR TITLE
Fix #32: dispatch ride-created broadcast without blocking the response

### DIFF
--- a/server/api/post/rides/index.ts
+++ b/server/api/post/rides/index.ts
@@ -54,13 +54,17 @@ export default defineEventHandler(async (event) => {
   // Notify all volunteers
   const scheduledTime = new Date(body.scheduledTime)
 
-  await broadcastNotification('RIDE_CREATED', {
+  // Fire-and-forget the broadcast (issue #32): the ride is created, so return it
+  // immediately instead of blocking the response on N sequential SMTP sends. A
+  // slow or failing broadcast must not delay or fail ride creation, so we don't
+  // await it and swallow any error in the background (mirrors signup.ts).
+  broadcastNotification('RIDE_CREATED', {
     pickup: pickupDisplay,
     dropoff: dropoffDisplay,
     date: formatNotificationDate(scheduledTime),
     time: formatNotificationTime(scheduledTime),
     link: `${process.env.APP_URL || 'http://localhost:3000'}/rides/${ride.id}`,
-  })
+  }, event).catch(console.error)
 
   return ride
 })

--- a/server/utils/notification.ts
+++ b/server/utils/notification.ts
@@ -1,3 +1,4 @@
+import type { H3Event } from 'h3'
 import { prisma } from './prisma'
 import { sendEmail } from './email'
 
@@ -68,15 +69,21 @@ export async function sendNotification(
 
 export async function broadcastNotification(
   type: NotificationType,
-  context: NotificationContext
+  context: NotificationContext,
+  event?: H3Event
 ) {
+  // Test-only seam (issue #45): throw here so e2e can pin the non-blocking fix
+  // for #32. No-op in production (see maybeFault).
+  maybeFault('ride-broadcast', event)
+
   // Fetch all available volunteers
   const volunteers = await prisma.volunteer.findMany({
     where: { status: 'AVAILABLE' },
   })
 
-  // Send to all (sendNotification handles individual preferences)
-  for (const vol of volunteers) {
-    await sendNotification(type, vol.id, context)
-  }
+  // Send to all in parallel (sendNotification handles individual preferences).
+  // allSettled so one failed send doesn't abort the rest of the broadcast.
+  await Promise.allSettled(
+    volunteers.map((vol) => sendNotification(type, vol.id, context))
+  )
 }

--- a/tests/e2e/ride-broadcast-nonblocking.test.ts
+++ b/tests/e2e/ride-broadcast-nonblocking.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Regression coverage for issue #32: POST /api/post/rides used to `await` the
+// RIDE_CREATED broadcast before returning, so the HTTP response blocked on N
+// sequential SMTP sends and a broadcast failure failed the whole create. The
+// fix dispatches the broadcast fire-and-forget: the ride is created and returned
+// immediately, and a broadcast error is swallowed in the background.
+//
+// Pinned via the fault-injection seam (#67): `x-test-fault: ride-broadcast`
+// throws inside broadcastNotification.
+//   - Pre-fix (awaited broadcast): the fault propagates -> create returns 500.
+//   - Post-fix (fire-and-forget):  the fault is caught by .catch -> 200 + ride.
+
+async function adminCookie() {
+  return loginAs('reachtusharwani@gmail.com')
+}
+
+async function firstClientId(cookie: string): Promise<string> {
+  const clients = await $fetch<Array<{ id: string }>>('/api/get/clients', {
+    headers: { cookie },
+  })
+  expect(clients.length).toBeGreaterThan(0)
+  return clients[0]!.id
+}
+
+function rideBody(clientId: string) {
+  // Distinct street keeps the created rows easy to identify in the shared DB.
+  const stamp = Date.now()
+  return {
+    clientId,
+    pickup: {
+      street: `${stamp} Broadcast Test Ave`,
+      city: 'Richardson',
+      state: 'TX',
+      zip: '75080',
+    },
+    dropoff: {
+      street: `${stamp} Broadcast Test Blvd`,
+      city: 'Dallas',
+      state: 'TX',
+      zip: '75201',
+    },
+    scheduledTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    notes: 'ride-broadcast-nonblocking regression',
+  }
+}
+
+async function createRide(
+  cookie: string,
+  clientId: string,
+  opts: { fault?: string } = {},
+) {
+  const headers: Record<string, string> = { cookie, 'content-type': 'application/json' }
+  if (opts.fault) headers['x-test-fault'] = opts.fault
+  const res = await appFetch('/api/post/rides', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(rideBody(clientId)),
+  })
+  const body = (await res.json().catch(() => null)) as { id?: string } | null
+  return { status: res.status, body }
+}
+
+describe('POST /api/post/rides non-blocking broadcast (#32)', () => {
+  it('a broadcast fault does not fail ride creation (200 + ride created)', async () => {
+    const cookie = await adminCookie()
+    const clientId = await firstClientId(cookie)
+
+    const { status, body } = await createRide(cookie, clientId, {
+      fault: 'ride-broadcast',
+    })
+
+    // Pre-fix the awaited broadcast propagates the injected fault -> 500.
+    // Post-fix the fire-and-forget broadcast swallows it -> 200 with the ride.
+    expect(status).toBe(200)
+    expect(body?.id).toBeTruthy()
+  })
+
+  it('a normal create (no fault) still returns 200 and creates the ride', async () => {
+    const cookie = await adminCookie()
+    const clientId = await firstClientId(cookie)
+
+    const { status, body } = await createRide(cookie, clientId)
+    expect(status).toBe(200)
+    expect(body?.id).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What was broken

`POST /api/post/rides` `await`ed `broadcastNotification('RIDE_CREATED', ...)` before returning, so the HTTP response blocked until every AVAILABLE volunteer had been emailed via N sequential synchronous SMTP round-trips. With N volunteers, the admin's "Create Ride" waited on N sends, and a single broadcast failure failed/blocked the whole create even though the ride row had already been written.

## What changed

- `server/api/post/rides/index.ts`: dispatch the broadcast **fire-and-forget** — the ride is created and returned to the client immediately, and the un-awaited broadcast's errors are swallowed with `.catch(console.error)` (mirrors the existing `Promise.allSettled(...).catch(...)` pattern in `signup.ts`). Response shape unchanged.
- `server/utils/notification.ts`: `broadcastNotification` now takes an optional `event?: H3Event` and calls `maybeFault('ride-broadcast', event)` at the start (the fault-injection seam from #67; no-op in production). Also parallelizes the per-volunteer sends with `Promise.allSettled` instead of a sequential `await` loop, so one failed send no longer aborts the rest.

No schema/auth/CI/docker/deps changes. `event` is optional so other `broadcastNotification` callers are unaffected.

## Verification

Regression test: `tests/e2e/ride-broadcast-nonblocking.test.ts`
- `a broadcast fault does not fail ride creation (200 + ride created)` — sends `POST /api/post/rides` with header `x-test-fault: ride-broadcast`.
- `a normal create (no fault) still returns 200 and creates the ride` — no-regression check.

**Revert-check (pinned via the #67 fault seam):**
- Pre-fix (awaited broadcast): the injected fault propagates out of the awaited call → create returns **500**. Observed failing assertion:
  `AssertionError: expected 500 to be 200` at `expect(status).toBe(200)`.
- Post-fix (fire-and-forget): the fault throws in the un-awaited broadcast, is caught by `.catch(console.error)`, and the request already returned **200** with the created ride.

Full suite green: **25 files / 100 tests passed**. `pnpm build` succeeds.

Fixes #32