### PR TITLE
Fix #62: reset shared e2e DB to seed snapshot before every test file

### DIFF
--- a/tests/e2e/aaa-order-dependence-mutator.test.ts
+++ b/tests/e2e/aaa-order-dependence-mutator.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+// Order-independence regression, part 1 of 2 (issue #62).
+//
+// Vitest runs files alphabetically with fileParallelism:false, so this `aaa-`
+// file runs BEFORE `zzz-order-dependence-victim.test.ts`. It deliberately
+// destroys seeded rows (deletes every ride) and does NOT clean up after
+// itself — exactly the hostile, poorly-behaved mutating test the harness must
+// tolerate. Before the fix this corruption leaked into every later file; now
+// the per-file reset in tests/setup-reset-db.ts restores the seed snapshot at
+// the start of each file, so no file inherits these deletions.
+
+await bootShared()
+
+describe('order-dependence: hostile mutator', () => {
+  it('deletes every seeded ride and leaves the DB corrupted for the next file', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const before = await $fetch<{ id: string }[]>('/api/get/rides', { headers: { cookie } })
+    expect(before.length).toBeGreaterThanOrEqual(9)
+
+    for (const ride of before) {
+      await $fetch(`/api/delete/rides/${ride.id}`, { method: 'DELETE', headers: { cookie } })
+    }
+
+    const after = await $fetch<unknown[]>('/api/get/rides', { headers: { cookie } })
+    expect(after.length).toBe(0)
+    // Intentionally no cleanup: later files must not depend on our leftovers.
+  })
+})

--- a/tests/e2e/zzz-order-dependence-victim.test.ts
+++ b/tests/e2e/zzz-order-dependence-victim.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+// Order-independence regression, part 2 of 2 (issue #62).
+//
+// This `zzz-` file runs AFTER `aaa-order-dependence-mutator.test.ts`, which
+// deletes every seeded ride and does not clean up. Its assertions depend on the
+// seeded rows still being present.
+//
+// PRE-FIX (no per-file reset): the mutator's deletions persist and this file
+// sees 0 rides — `toBeGreaterThanOrEqual(9)` fails, proving the suite is
+// order-dependent (the pre-existing smoke.test.ts fails the same way).
+//
+// POST-FIX: the per-file reset in tests/setup-reset-db.ts restores the seed
+// snapshot before this file runs, so the seeded rows are back regardless of
+// what earlier files did.
+
+await bootShared()
+
+describe('order-dependence: seed-dependent victim', () => {
+  it('still sees the seeded rides even though an earlier file deleted them all', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const rides = await $fetch<unknown[]>('/api/get/rides', { headers: { cookie } })
+    expect(rides.length).toBeGreaterThanOrEqual(9)
+  })
+
+  it('restores seeded clients and volunteers too', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const clients = await $fetch<unknown[]>('/api/get/clients', { headers: { cookie } })
+    const volunteers = await $fetch<unknown[]>('/api/get/volunteers', { headers: { cookie } })
+    expect(clients.length).toBeGreaterThanOrEqual(3)
+    expect(volunteers.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -2,6 +2,7 @@ import { execSync, spawn, type ChildProcess } from 'node:child_process'
 import { createServer } from 'node:net'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
+import { captureSeedSnapshot } from './utils/reset-db'
 
 // One-time e2e setup (issue #45): build the Nuxt app ONCE, seed a fresh SQLite
 // DB, and start a SINGLE server that every test file connects to (via
@@ -50,6 +51,11 @@ export default async function globalSetup() {
   const dbEnv = { ...process.env, DATABASE_URL: `file:${dbPath}` }
   execSync('npx prisma db push', { cwd: root, env: dbEnv, stdio: 'inherit' })
   execSync('npx tsx prisma/seed.ts', { cwd: root, env: dbEnv, stdio: 'inherit' })
+
+  // Snapshot the freshly-seeded rows so each test file can cheaply restore them
+  // and stay order-independent (issue #62). Point resetDb() at the same file.
+  process.env.DATABASE_URL = `file:${dbPath}`
+  captureSeedSnapshot()
 
   // Build the production server once.
   execSync('npx nuxt build', { cwd: root, env: dbEnv, stdio: 'inherit' })

--- a/tests/setup-reset-db.ts
+++ b/tests/setup-reset-db.ts
@@ -1,0 +1,13 @@
+import { beforeAll } from 'vitest'
+import { resetDb } from './utils/reset-db'
+
+// Per-file DB reset for order-independence (issue #62).
+//
+// vitest runs this setup file once inside every test worker, before the test
+// module is evaluated. Restoring the seed snapshot here means every
+// `tests/e2e/*.test.ts` file starts from an identical, freshly-seeded DB no
+// matter what earlier files did to the shared SQLite database — killing the
+// order-dependence that made the shared-DB harness flaky.
+beforeAll(() => {
+  resetDb()
+})

--- a/tests/utils/auth.ts
+++ b/tests/utils/auth.ts
@@ -10,6 +10,14 @@ const sessionCache = new Map<string, string>()
 let ipCounter = 0
 
 /**
+ * Drop all cached login cookies. Called by resetDb() (issue #62): a DB reset
+ * wipes the `session` rows those cookies reference, so they must be re-minted.
+ */
+export function clearSessionCache(): void {
+  sessionCache.clear()
+}
+
+/**
  * Logs in through the real better-auth email-OTP flow without SMTP.
  * The app swallows email-send failures, but better-auth stores the OTP in the
  * `verification` table first — so we request an OTP, read it straight from the

--- a/tests/utils/reset-db.ts
+++ b/tests/utils/reset-db.ts
@@ -1,0 +1,111 @@
+import Database from 'better-sqlite3'
+import { fileURLToPath } from 'node:url'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { clearSessionCache } from './auth'
+
+// Order-independence for the shared-DB e2e harness (issue #62).
+//
+// The suite boots ONE server against ONE seeded SQLite file and runs every
+// `tests/e2e/*.test.ts` sequentially. Mutating tests (create/complete/delete
+// rides, clear phones, …) can corrupt seeded rows that later files assert
+// against, making the suite order-dependent and flaky.
+//
+// Rather than re-run the (slow, ~1.6s) `tsx prisma/seed.ts` subprocess per
+// file, we snapshot every table's rows ONCE — right after the initial seed —
+// into a JSON file, then restore that snapshot in-process before each file
+// runs. Restore is a fast, generic delete-all + bulk re-insert over the same
+// better-sqlite3 connection the app uses; SQLite serializes writes across
+// connections and the reset runs in `beforeAll` with no concurrent requests
+// in flight, so overwriting the live file is safe.
+
+const SNAPSHOT_PATH_ENV = 'NUXT_TEST_DB_SNAPSHOT'
+
+function dbPath(): string {
+  const url = process.env.DATABASE_URL ?? ''
+  const path = url.replace(/^file:/, '')
+  if (!path) throw new Error('DATABASE_URL is not set — cannot locate the test DB')
+  return path
+}
+
+function snapshotPath(): string {
+  if (process.env[SNAPSHOT_PATH_ENV]) return process.env[SNAPSHOT_PATH_ENV]!
+  const root = fileURLToPath(new URL('../..', import.meta.url))
+  return resolve(root, '.data/test-seed-snapshot.json')
+}
+
+function userTables(db: Database.Database): string[] {
+  const rows = db
+    .prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'table'
+         AND name NOT LIKE 'sqlite_%'
+         AND name NOT LIKE '_prisma_%'`
+    )
+    .all() as { name: string }[]
+  return rows.map((r) => r.name)
+}
+
+type Snapshot = Record<string, Record<string, unknown>[]>
+
+/**
+ * Capture the current contents of every user table. Call once, immediately
+ * after the initial seed, from global setup.
+ */
+export function captureSeedSnapshot(): void {
+  const db = new Database(dbPath())
+  try {
+    const snapshot: Snapshot = {}
+    for (const table of userTables(db)) {
+      snapshot[table] = db.prepare(`SELECT * FROM "${table}"`).all() as Record<string, unknown>[]
+    }
+    writeFileSync(snapshotPath(), JSON.stringify(snapshot))
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Restore every table to its post-seed snapshot. Call from a `beforeAll` in
+ * each mutating test file (see tests/e2e/*.test.ts) so no file inherits another
+ * file's mutations. Cheap: one transaction of deletes + bulk inserts.
+ */
+export function resetDb(): void {
+  const path = snapshotPath()
+  if (!existsSync(path)) {
+    throw new Error(
+      `Seed snapshot missing at ${path}; global setup must call captureSeedSnapshot() first`
+    )
+  }
+  const snapshot = JSON.parse(readFileSync(path, 'utf8')) as Snapshot
+
+  const db = new Database(dbPath())
+  try {
+    const tables = userTables(db)
+    const restore = db.transaction(() => {
+      // Defer FK checks until COMMIT: we wipe every table and re-insert the full
+      // consistent snapshot, so intermediate states violate FKs. `PRAGMA
+      // foreign_keys` is a no-op inside a transaction, but `defer_foreign_keys`
+      // works and auto-resets after the transaction.
+      db.pragma('defer_foreign_keys = ON')
+      for (const table of tables) db.prepare(`DELETE FROM "${table}"`).run()
+      for (const table of tables) {
+        const rows = snapshot[table] ?? []
+        if (rows.length === 0) continue
+        const columns = Object.keys(rows[0]!)
+        const placeholders = columns.map((c) => `@${c}`).join(', ')
+        const insert = db.prepare(
+          `INSERT INTO "${table}" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES (${placeholders})`
+        )
+        for (const row of rows) insert.run(row)
+      }
+    })
+    restore()
+  } finally {
+    db.close()
+  }
+
+  // Cached login cookies point at `session` rows that we just wiped; drop them
+  // so the next `loginAs` re-runs the OTP flow against the restored DB.
+  clearSessionCache()
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   test: {
     include: ['tests/e2e/**/*.test.ts'],
     globalSetup: ['tests/global-setup.ts'],
+    // Reset the shared SQLite DB to its seed snapshot before every test file so
+    // the suite is order-independent (issue #62). Runs once per worker/file.
+    setupFiles: ['tests/setup-reset-db.ts'],
     // The e2e suite boots one Nuxt server against one shared SQLite file,
     // so test files must not run in parallel.
     fileParallelism: false,


### PR DESCRIPTION
## What was broken

The e2e harness (`tests/global-setup.ts`, `vitest.config.ts`) boots ONE Nuxt server against ONE seeded SQLite DB and runs `tests/e2e/*.test.ts` sequentially (`fileParallelism: false`). Mutating tests (create/complete/delete rides, clear phones, …) that don't fully clean up can corrupt seeded rows that later files assert against, making the suite **order-dependent** and prone to intermittent flakes — which would mislead the auto-merge gate.

## What changed (test harness only)

- `tests/utils/reset-db.ts` (new): `captureSeedSnapshot()` snapshots every user table's rows into `.data/test-seed-snapshot.json` (gitignored) once, right after the initial seed. `resetDb()` restores that snapshot in-process — a generic delete-all + bulk re-insert in a single transaction with `PRAGMA defer_foreign_keys = ON` over the same better-sqlite3 file the app uses — then clears cached login cookies (the wiped `session` rows).
- `tests/global-setup.ts`: calls `captureSeedSnapshot()` after seeding (before the app build).
- `tests/setup-reset-db.ts` (new) + `vitest.config.ts`: registered as a `setupFile`, so a `beforeAll(resetDb)` runs once per worker/file. Every test file now starts from an identical, freshly-seeded DB regardless of what earlier files did.
- `tests/utils/auth.ts`: adds `clearSessionCache()` (called by `resetDb`).

Chosen over re-running `tsx prisma/seed.ts` per file (~1.6s × 26 files ≈ +40s). The snapshot restore adds ~42ms/file (setup total ~1.2s across 28 files), so suite runtime stays ~28s.

## Verification

Regression tests (new): `tests/e2e/aaa-order-dependence-mutator.test.ts` deletes every seeded ride and does **not** clean up; `tests/e2e/zzz-order-dependence-victim.test.ts` (runs later, alphabetical) asserts the seed is still intact.

**Pre-fix** (confirmed by neutering `resetDb()` to a no-op to simulate `main`, then running the full suite): the mutator's deletions leaked forward and both the new victim file **and the pre-existing `smoke.test.ts`** failed with:

```
AssertionError: expected 0 to be greater than or equal to 9
 ❯ tests/e2e/zzz-order-dependence-victim.test.ts:30:26
     expect(rides.length).toBeGreaterThanOrEqual(9)
```

**Post-fix**: `pnpm test` → **Test Files 28 passed (28) / Tests 108 passed (108)**, ~28s.

Fixes #62