### PR TITLE
Fix #26: add Navigate deep-link to native maps on ride details page

### DIFF
--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -182,6 +182,14 @@
     return `https://www.google.com/maps/embed/v1/directions?key=${apiKey || ''}&origin=${origin}&destination=${destination}`
   })
 
+  // Universal maps directions deep-link: origin = pickup, destination = dropoff.
+  // On a phone the OS hands this off to the native maps app; on desktop it
+  // opens Google Maps directions in the browser.
+  const navigateUrl = computed(() => {
+    if (!ride.value) return ''
+    return buildMapsDeepLink(ride.value.pickupDisplay, ride.value.dropoffDisplay)
+  })
+
   const volunteerOptions = computed(() => {
     if (!volunteers.value) return []
     const list = volunteers.value.map((v: any) => ({
@@ -353,6 +361,19 @@
                 <p class="font-medium">{{ estimate.distance }}</p>
               </div>
             </div>
+
+            <UButton
+              :to="navigateUrl"
+              target="_blank"
+              rel="noopener"
+              label="Navigate"
+              icon="i-lucide-navigation"
+              color="primary"
+              size="lg"
+              block
+              external
+              data-testid="navigate-link"
+            />
 
             <div class="aspect-video w-full overflow-hidden rounded-lg border">
               <iframe

--- a/app/utils/mapsLink.ts
+++ b/app/utils/mapsLink.ts
@@ -1,0 +1,13 @@
+// Builds a universal Google Maps directions deep-link. On phones, this URL is
+// handed off by the OS to the native maps app (Apple Maps / Google Maps / Waze
+// prompt); on desktop it opens Google Maps directions in the browser.
+// See https://developers.google.com/maps/documentation/urls/get-started#directions-action
+export function buildMapsDeepLink(
+  origin: string | null | undefined,
+  destination: string | null | undefined,
+): string {
+  const params = new URLSearchParams({ api: '1' })
+  if (origin) params.set('origin', origin)
+  if (destination) params.set('destination', destination)
+  return `https://www.google.com/maps/dir/?${params.toString()}`
+}

--- a/tests/e2e/ride-navigate-link.test.ts
+++ b/tests/e2e/ride-navigate-link.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+import { buildMapsDeepLink } from '../../app/utils/mapsLink'
+
+await bootShared()
+
+// Issue #26: the ride details page must expose a prominent "Navigate" deep-link
+// near the map/addresses that hands off to the phone's native maps app using a
+// universal Google Maps directions URL (origin = pickup, destination = dropoff,
+// URL-encoded). The ride details page is server-rendered (ride data is fetched
+// via useFetch during SSR), so the anchor + its href appear in the initial HTML.
+
+describe('ride details Navigate deep-link (#26)', () => {
+  it('renders a maps directions deep-link with encoded pickup/dropoff', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const rides = await $fetch<
+      Array<{ id: string; pickupDisplay: string; dropoffDisplay: string }>
+    >('/api/get/rides', { headers: { cookie } })
+    expect(rides.length).toBeGreaterThan(0)
+
+    const ride = rides[0]!
+    const res = await appFetch(`/rides/${ride.id}`, { headers: { cookie } })
+    expect(res.status).toBe(200)
+    const html = await res.text()
+
+    const expectedHref = buildMapsDeepLink(ride.pickupDisplay, ride.dropoffDisplay)
+    // In an HTML attribute the raw "&" query separators are entity-escaped to
+    // "&amp;"; the browser unescapes them back to the exact expectedHref.
+    const escapedHref = expectedHref.replace(/&/g, '&amp;')
+
+    // The universal directions base must be present.
+    expect(html).toContain('https://www.google.com/maps/dir/?')
+    // The full, correctly-built href (with encoded origin/destination) must be
+    // in the server-rendered HTML.
+    expect(html).toContain(escapedHref)
+    // The addresses must actually be encoded (raw spaces would break the link).
+    expect(expectedHref).toContain(encodeURIComponent(ride.pickupDisplay).replace(/%20/g, '+'))
+  })
+
+  it('builds a correct universal directions URL from address components', () => {
+    const url = buildMapsDeepLink('1501 H Ave, Plano, TX', '9 Cowboys Way, Frisco, TX')
+    expect(url.startsWith('https://www.google.com/maps/dir/?')).toBe(true)
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('api')).toBe('1')
+    expect(parsed.searchParams.get('origin')).toBe('1501 H Ave, Plano, TX')
+    expect(parsed.searchParams.get('destination')).toBe('9 Cowboys Way, Frisco, TX')
+    // Raw commas/spaces must be percent/plus-encoded in the wire format.
+    expect(url).not.toContain(' ')
+  })
+
+  it('omits missing origin/destination without emitting empty params', () => {
+    expect(buildMapsDeepLink('A', null)).toBe('https://www.google.com/maps/dir/?api=1&origin=A')
+    expect(buildMapsDeepLink(undefined, 'B')).toBe(
+      'https://www.google.com/maps/dir/?api=1&destination=B',
+    )
+  })
+})


### PR DESCRIPTION
## What was broken

The ride details page (`app/pages/rides/[id].vue`) showed only an embedded Google Maps iframe. There was no way for a volunteer to launch turn-by-turn navigation in their phone's native maps app — they had to retype the addresses by hand.

## What changed

- Added a prominent **Navigate** button to the Route card, right above the map, that deep-links into the OS's maps app using a universal Google Maps directions URL:
  `https://www.google.com/maps/dir/?api=1&origin=<pickup>&destination=<dropoff>`
  Origin = the ride's `pickupDisplay`, destination = `dropoffDisplay`. On a phone the OS hands this off to Apple Maps / Google Maps / Waze; on desktop it opens Google Maps directions.
- The button is a real external anchor (`UButton` with `:to` + `external` + `target="_blank"` + `rel="noopener"`), so the browser/OS performs the hand-off.
- Extracted the URL-building into a small, testable helper `buildMapsDeepLink(origin, destination)` in `app/utils/mapsLink.ts`. It uses `URLSearchParams`, so address components are properly URL-encoded, and it omits missing origin/destination cleanly.

No schema, config, dependency, CI, or auth changes.

## Verification

**Test file:** `tests/e2e/ride-navigate-link.test.ts`

The ride details page is server-rendered (ride data is fetched via `useFetch` during SSR), so the Navigate anchor and its `href` appear in the initial server HTML — giving a real failing-before / passing-after revert-check.

- `ride details Navigate deep-link (#26) > renders a maps directions deep-link with encoded pickup/dropoff` — logs in as ADMIN, reads a real seeded ride via `/api/get/rides`, fetches `/rides/<id>` HTML, and asserts the correctly-built directions href is present (accounting for HTML `&` → `&amp;` attribute escaping).
- `> builds a correct universal directions URL from address components` — unit test of the helper: base URL, `api=1`, encoded origin/destination, no raw spaces.
- `> omits missing origin/destination without emitting empty params` — helper edge cases.

**Pre-fix failing assertion (revert-check, button removed):**
```
AssertionError: expected '<!DOCTYPE html><html><head><meta char…' to contain 'https://www.google.com/maps/dir/?'
   expect(html).toContain('https://www.google.com/maps/dir/?')
 Test Files  1 failed (1)
 Tests  1 failed | 2 passed (3)
```
With the fix restored, all 3 pass.

**Full suite:** `Test Files 27 passed (27)` / `Tests 108 passed (108)`.

Fixes #26