### PR TITLE
Fix #5: build real ride cancellation (CANCELLED status)

### DIFF
--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -14,6 +14,7 @@
   const isEditModalOpen = ref(false)
   const isCompleteModalOpen = ref(false)
   const isDeleteModalOpen = ref(false)
+  const isCancelModalOpen = ref(false)
 
   const isAdmin = computed(() => session.value?.user?.role === 'ADMIN')
   const isVolunteer = computed(() => session.value?.user?.role === 'VOLUNTEER')
@@ -138,6 +139,20 @@
     }
   }
 
+  async function handleCancel() {
+    try {
+      await $fetch(`/api/put/rides/${id}`, {
+        method: 'PUT',
+        body: { status: 'CANCELLED' },
+      })
+      toast.add({ title: 'Success', description: 'Ride cancelled', color: 'success' })
+      isCancelModalOpen.value = false
+      await refreshRide()
+    } catch (err) {
+      toast.add({ title: 'Error', description: 'Failed to cancel ride', color: 'error' })
+    }
+  }
+
   async function handleVolunteerAction(action: 'signup' | 'unsignup' | 'complete') {
     if (action === 'signup') {
       try {
@@ -222,7 +237,16 @@
           <template #header>
             <div class="flex items-center justify-between">
               <h2 class="text-xl font-bold">Ride Information</h2>
-              <UBadge :color="ride.status === 'COMPLETED' ? 'success' : 'info'" variant="subtle">
+              <UBadge
+                :color="
+                  ride.status === 'COMPLETED'
+                    ? 'success'
+                    : ride.status === 'CANCELLED'
+                      ? 'error'
+                      : 'info'
+                "
+                variant="subtle"
+              >
                 {{ ride.status }}
               </UBadge>
             </div>
@@ -285,6 +309,14 @@
                 variant="subtle"
                 class="flex-1 justify-center"
                 @click="isEditModalOpen = true"
+              />
+              <UButton
+                v-if="isAdmin && ride.status !== 'CANCELLED' && ride.status !== 'COMPLETED'"
+                label="Cancel Ride"
+                icon="i-lucide-ban"
+                color="warning"
+                variant="subtle"
+                @click="isCancelModalOpen = true"
               />
               <UButton
                 v-if="isAdmin"
@@ -524,6 +556,27 @@
               @click="isDeleteModalOpen = false"
             />
             <UButton label="Delete" color="error" @click="handleDelete" />
+          </div>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Cancel Ride Confirmation Modal -->
+    <UModal v-model:open="isCancelModalOpen" title="Cancel Ride">
+      <template #content>
+        <div class="space-y-4 p-4">
+          <p>
+            Are you sure you want to cancel this ride? The assigned volunteer (if any) will be
+            notified.
+          </p>
+          <div class="flex justify-end gap-2">
+            <UButton
+              label="Keep Ride"
+              color="neutral"
+              variant="ghost"
+              @click="isCancelModalOpen = false"
+            />
+            <UButton label="Cancel Ride" color="warning" @click="handleCancel" />
           </div>
         </div>
       </template>

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -297,6 +297,7 @@
             CREATED: 'info' as const,
             ASSIGNED: 'warning' as const,
             COMPLETED: 'success' as const,
+            CANCELLED: 'error' as const,
           }[row.getValue('status') as string] || 'neutral'
 
         return h(UBadge, { class: 'capitalize', variant: 'subtle', color }, () =>

--- a/app/utils/rideFilters.ts
+++ b/app/utils/rideFilters.ts
@@ -18,15 +18,18 @@ export const BASE_FILTER_OPTIONS: RideFilter[] = [
   { label: 'Created', value: 'status:CREATED' },
   { label: 'Assigned', value: 'status:ASSIGNED' },
   { label: 'Completed', value: 'status:COMPLETED' },
+  { label: 'Cancelled', value: 'status:CANCELLED' },
 ]
 
 /**
- * Default excluded filters for new users. Only excludes Completed rides, which
- * is a valid, toggleable option. The stale `status:CANCELLED` default has been
- * removed (issue #22) because there is no CANCELLED status to toggle it off.
+ * Default excluded filters for new users. Excludes finished rides (Completed and
+ * Cancelled) so the dashboard defaults to active work. Both are valid, toggleable
+ * options in BASE_FILTER_OPTIONS, so a user can always turn the exclusion off
+ * (unlike the pre-#5 stale `status:CANCELLED` default, which had no toggle — #22).
  */
 export const DEFAULT_EXCLUDED_FILTERS: RideFilter[] = [
   { label: 'Completed', value: 'status:COMPLETED' },
+  { label: 'Cancelled', value: 'status:CANCELLED' },
 ]
 
 /**

--- a/prisma/schema/enum.prisma
+++ b/prisma/schema/enum.prisma
@@ -8,4 +8,5 @@ enum RideStatus {
   CREATED
   ASSIGNED
   COMPLETED
+  CANCELLED
 }

--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -11,7 +11,7 @@ import { readValidatedBody } from '../../../utils/validation'
 // totalRideTime) still work; unknown keys are rejected via .strict().
 const updateRideSchema = z
   .object({
-    status: z.enum(['CREATED', 'ASSIGNED', 'COMPLETED']).optional(),
+    status: z.enum(['CREATED', 'ASSIGNED', 'COMPLETED', 'CANCELLED']).optional(),
     // Empty string means "unassign"; handled below into null.
     volunteerId: z.string().nullable().optional(),
     scheduledTime: z.string().min(1).optional(),
@@ -75,7 +75,7 @@ export default defineEventHandler(async (event) => {
 
   // Build the Prisma update payload only from validated, whitelisted fields.
   const updateData: {
-    status?: 'CREATED' | 'ASSIGNED' | 'COMPLETED'
+    status?: 'CREATED' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED'
     volunteerId?: string | null
     scheduledTime?: Date
     pickupTime?: Date | null
@@ -177,11 +177,10 @@ export default defineEventHandler(async (event) => {
   }
 
   // 2. RIDE_CANCELLED
-  // (Currently no CANCELLED status in RideStatus enum, handling for future proofing or custom status strings)
-  if ((body.status as string) === 'CANCELLED' && (existingRide.status as string) !== 'CANCELLED') {
-    // Notify the volunteer who WAS assigned (even if unassigned in this update, though unlikely for cancellation)
-    // Assuming volunteer is still attached or was attached in existingRide
-    const volunteerToNotify = existingRide.volunteer // Notify the volunteer who was assigned before cancellation
+  // Fires when an admin cancels a ride (status -> CANCELLED). Notify the
+  // volunteer who was assigned before cancellation so they know the ride is off.
+  if (body.status === 'CANCELLED' && existingRide.status !== 'CANCELLED') {
+    const volunteerToNotify = existingRide.volunteer
 
     if (volunteerToNotify) {
       await sendNotification('RIDE_CANCELLED', volunteerToNotify.id, {

--- a/tests/e2e/ride-cancel.test.ts
+++ b/tests/e2e/ride-cancel.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+type Ride = {
+  id: string
+  status: 'CREATED' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED'
+  volunteerId: string | null
+}
+
+async function getRides(cookie: string): Promise<Ride[]> {
+  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+}
+
+async function getRideById(cookie: string, id: string): Promise<Ride> {
+  return await $fetch<Ride>(`/api/get/rides/byId/${id}`, { headers: { cookie } })
+}
+
+// Rides mutated here are restored to CREATED after each test so the shared seed
+// DB (used by other e2e files) stays intact.
+const touchedRideIds = new Set<string>()
+
+async function anUntouchedCreatedRide(cookie: string): Promise<Ride> {
+  const created = (await getRides(cookie)).find(
+    (r) => r.status === 'CREATED' && !touchedRideIds.has(r.id),
+  )
+  expect(created, 'seed should have an untouched CREATED ride').toBeTruthy()
+  touchedRideIds.add(created!.id)
+  return created!
+}
+
+afterEach(async () => {
+  if (!touchedRideIds.size) return
+  const cookie = await loginAs('reachtusharwani@gmail.com')
+  for (const id of touchedRideIds) {
+    await appFetch(`/api/put/rides/${id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ volunteerId: '', status: 'CREATED' }),
+    })
+  }
+  touchedRideIds.clear()
+})
+
+describe('PUT /api/put/rides/[id] — ride cancellation (issue #5)', () => {
+  it('accepts status: CANCELLED (200) and persists it', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const ride = await anUntouchedCreatedRide(cookie)
+
+    // Pre-fix, the zod schema only allowed CREATED|ASSIGNED|COMPLETED, so this
+    // returned 400 and the status was never persisted.
+    const res = await appFetch(`/api/put/rides/${ride.id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'CANCELLED' }),
+    })
+
+    expect(res.status).toBe(200)
+
+    // Persisted: GET it back and confirm the stored status is CANCELLED.
+    const fetched = await getRideById(cookie, ride.id)
+    expect(fetched.status).toBe('CANCELLED')
+  })
+
+  it('cancelling an ASSIGNED ride keeps the volunteer and fires the RIDE_CANCELLED path', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const ride = await anUntouchedCreatedRide(cookie)
+
+    // Assign a volunteer first so the RIDE_CANCELLED notification branch (which
+    // notifies the previously-assigned volunteer) is exercised.
+    const withVolunteer = (await getRides(cookie)).find((r) => r.volunteerId)
+    expect(withVolunteer, 'seed should have a ride with a volunteer').toBeTruthy()
+    const volunteerId = withVolunteer!.volunteerId!
+
+    const assigned = await $fetch<Ride>(`/api/put/rides/${ride.id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: { volunteerId, status: 'ASSIGNED' },
+    })
+    expect(assigned.status).toBe('ASSIGNED')
+
+    // Cancel it. The handler runs sendNotification('RIDE_CANCELLED', ...) inline;
+    // email sends are swallowed in the test env, so we assert the observable
+    // outcome — a 200 and the persisted CANCELLED status.
+    const cancelled = await $fetch<Ride>(`/api/put/rides/${ride.id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: { status: 'CANCELLED' },
+    })
+
+    expect(cancelled.status).toBe('CANCELLED')
+    expect(cancelled.volunteerId).toBe(volunteerId)
+  })
+})

--- a/tests/e2e/ride-filters.test.ts
+++ b/tests/e2e/ride-filters.test.ts
@@ -23,14 +23,26 @@ describe('ride filter helpers (#22)', () => {
     expect(DEFAULT_EXCLUDED_FILTERS.map((f) => f.value)).toContain('status:COMPLETED')
   })
 
-  it('strips the stale status:CANCELLED entry but keeps valid ones', () => {
+  it('keeps status:CANCELLED now that it is a real, toggleable status (#5)', () => {
+    // CANCELLED became a first-class RideStatus in #5, so it is a valid filter
+    // value and must survive sanitize (it is no longer the stuck-filter bug #22).
+    expect(validValues).toContain('status:CANCELLED')
     const saved = [
       { label: 'Completed', value: 'status:COMPLETED' },
       { label: 'Cancelled', value: 'status:CANCELLED' },
     ]
     const result = sanitizeSavedFilters(saved, validValues)
+    expect(result.map((f) => f.value)).toEqual(['status:COMPLETED', 'status:CANCELLED'])
+  })
+
+  it('strips a genuinely stale/unknown saved filter but keeps valid ones', () => {
+    const saved = [
+      { label: 'Completed', value: 'status:COMPLETED' },
+      { label: 'Bogus', value: 'status:BOGUS' },
+    ]
+    const result = sanitizeSavedFilters(saved, validValues)
     expect(result.map((f) => f.value)).toEqual(['status:COMPLETED'])
-    expect(result.map((f) => f.value)).not.toContain('status:CANCELLED')
+    expect(result.map((f) => f.value)).not.toContain('status:BOGUS')
   })
 
   it('keeps runtime-valid values that are passed in validValues (e.g. assign:ME)', () => {


### PR DESCRIPTION
## What was broken
`CANCELLED` was referenced throughout the code (notification type, seed template, settings toggle, a `RIDE_CANCELLED` branch in the ride PUT handler) but was **not** a member of the `RideStatus` enum, and after #31 the PUT validation only allowed `CREATED|ASSIGNED|COMPLETED`. So `PUT /api/put/rides/:id {status:'CANCELLED'}` returned **400** and the `RIDE_CANCELLED` notification branch was dead/unreachable. Per the owner's decision on #5, this builds a **real cancellation feature** (Option B), not dead-code removal.

## What changed
- **`prisma/schema/enum.prisma`** — add `CANCELLED` to `RideStatus`. *(risk file — schema; see migration note below.)*
- **`server/api/put/rides/[id].ts`** — allow `CANCELLED` in the #31 zod whitelist and the `updateData` type, so cancellation returns 200. This makes the existing `RIDE_CANCELLED` branch reachable; it fires `sendNotification('RIDE_CANCELLED', ...)` for the volunteer who was assigned before cancellation. Removed the obsolete `as string` casts and the stale "no CANCELLED status" comment.
- **`app/pages/rides/[id].vue`** — admin-gated **Cancel Ride** button + confirmation modal (mirrors the Delete flow), hidden once a ride is already `CANCELLED`/`COMPLETED`; `CANCELLED` gets an `error`-colored status badge.
- **`app/pages/rides/index.vue` + `app/utils/rideFilters.ts`** — `CANCELLED` is now a real, toggleable status filter and a default exclusion (finished work), with an `error` badge in the table.

## Migration note
SQLite stores Prisma enums as `TEXT` (the #33 init baseline already defines `status TEXT NOT NULL DEFAULT 'CREATED'` with no CHECK constraint), so adding an enum value generates **no SQL migration**. `prisma migrate dev --name add_cancelled_ride_status` reported the schema already in sync and created **no new migration file** — expected. No production migration is required for this change.

## Stacked on #76 (issue #33)
This PR is **stacked on `fix/33-adopt-migrations` (#76)** and targets it as the base branch so the diff shows only the cancellation delta. **It must merge after #76.**

## Verification
- **Regression test** `tests/e2e/ride-cancel.test.ts`:
  - As ADMIN, `PUT /api/put/rides/:id {status:'CANCELLED'}` → asserts **200** and GET-back persists `status === 'CANCELLED'`.
  - Cancels an `ASSIGNED` ride and asserts the volunteer is retained (exercising the `RIDE_CANCELLED` notification path — the email send is swallowed in test env, and the server log shows the attempted send).
  - **Pre-fix FAIL** (observed): `AssertionError: expected 400 to be 200` and `FetchError: [PUT] ... 400 Invalid request body`.
- Updated `tests/e2e/ride-filters.test.ts` (#22): the case that previously asserted `status:CANCELLED` was stripped as *stale* now asserts it is a valid, retained filter (CANCELLED is a real status as of this PR); added a separate case using a genuinely unknown value to keep sanitize coverage. The #22 invariant test (every default exclusion is toggleable) still passes.
- **Full suite:** `pnpm test` → **30 files / 114 tests passed**. `pnpm build` succeeds.

## Scope / risk
Touched files: `prisma/schema/enum.prisma` (schema — **flagged for human review**), the PUT rides route, the ride details + index pages, the shared ride-filters helper, and tests. No changes to auth, CI, dockerfile, or deps. Net non-test change: +68/-11 lines.

Fixes #5

<sub>Not closing #22: the stuck-filter bug it describes was already fixed on the base branch (`rideFilters.ts` sanitize). This PR keeps that fix coherent now that CANCELLED is real, but does not itself resolve #22.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)