### PR TITLE
Fix #28: audit logging system

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -40,6 +40,11 @@
           to: '/admin/notifications',
           icon: 'i-lucide-bell',
         },
+        {
+          label: 'Audit Log',
+          to: '/admin/audit',
+          icon: 'i-lucide-scroll-text',
+        },
       ]
     }
 

--- a/app/pages/admin/audit.vue
+++ b/app/pages/admin/audit.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { authClient } from '../../utils/auth-client'
+
+// Admin-only page (issue #28), matching the guard used by admin/notifications.vue.
+const { data: session } = await authClient.useSession(useFetch)
+if (session.value?.user?.role !== 'ADMIN') {
+  navigateTo('/')
+}
+
+type AuditLog = {
+  id: string
+  userId: string
+  action: string
+  targetType: string
+  targetId: string | null
+  details: unknown
+  createdAt: string
+}
+
+// Filters (by action and/or acting user id). Sent as query params to the
+// admin-only, bounded GET /api/get/audit endpoint.
+const actionFilter = ref('')
+const userFilter = ref('')
+
+const query = computed(() => {
+  const q: Record<string, string> = {}
+  if (actionFilter.value.trim()) q.action = actionFilter.value.trim()
+  if (userFilter.value.trim()) q.userId = userFilter.value.trim()
+  return q
+})
+
+const { data: logs } = await useFetch<AuditLog[]>('/api/get/audit', { query })
+
+function formatDetails(details: unknown): string {
+  if (details == null) return ''
+  try {
+    return typeof details === 'string' ? details : JSON.stringify(details)
+  } catch {
+    return ''
+  }
+}
+</script>
+
+<template>
+  <UContainer class="py-10">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold">Audit Log</h1>
+      <p class="text-sm text-gray-500">
+        Who did what — the most recent {{ logs?.length ?? 0 }} accountability events (newest first).
+      </p>
+    </div>
+
+    <div class="flex flex-wrap gap-3 mb-4">
+      <UFormField label="Filter by action">
+        <UInput v-model="actionFilter" placeholder="e.g. RIDE_CANCELLED" />
+      </UFormField>
+      <UFormField label="Filter by user id">
+        <UInput v-model="userFilter" placeholder="acting user id" />
+      </UFormField>
+    </div>
+
+    <div class="overflow-x-auto border border-gray-200 dark:border-gray-800 rounded-lg">
+      <table class="min-w-full text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-900">
+          <tr>
+            <th class="text-left font-semibold px-3 py-2">When</th>
+            <th class="text-left font-semibold px-3 py-2">Action</th>
+            <th class="text-left font-semibold px-3 py-2">Target</th>
+            <th class="text-left font-semibold px-3 py-2">User</th>
+            <th class="text-left font-semibold px-3 py-2">Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="log in logs"
+            :key="log.id"
+            class="border-t border-gray-100 dark:border-gray-800"
+          >
+            <td class="px-3 py-2 whitespace-nowrap">{{ new Date(log.createdAt).toLocaleString() }}</td>
+            <td class="px-3 py-2">
+              <UBadge variant="subtle">{{ log.action }}</UBadge>
+            </td>
+            <td class="px-3 py-2 whitespace-nowrap">{{ log.targetType }}<span v-if="log.targetId" class="text-gray-400"> · {{ log.targetId }}</span></td>
+            <td class="px-3 py-2 whitespace-nowrap font-mono text-xs">{{ log.userId }}</td>
+            <td class="px-3 py-2 font-mono text-xs text-gray-500">{{ formatDetails(log.details) }}</td>
+          </tr>
+          <tr v-if="!logs || logs.length === 0">
+            <td colspan="5" class="px-3 py-6 text-center text-gray-500">No audit events found.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </UContainer>
+</template>

--- a/prisma/migrations/20260713224440_add_audit_log/migration.sql
+++ b/prisma/migrations/20260713224440_add_audit_log/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "audit_log" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT,
+    "details" JSONB,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE INDEX "audit_log_createdAt_idx" ON "audit_log"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "audit_log_userId_idx" ON "audit_log"("userId");

--- a/prisma/schema/audit.prisma
+++ b/prisma/schema/audit.prisma
@@ -1,0 +1,22 @@
+// Audit log (issue #28): an append-only record of who did what, for
+// accountability and troubleshooting on an app that handles client PII,
+// location data, and scheduling.
+//
+// `userId` is stored as a plain string (the acting user's id) rather than a
+// relation on purpose: the actor may later be soft- or hard-deleted, and the
+// audit trail must survive that without a dangling FK. `details` is a small
+// JSON blob describing the change (e.g. { from, to } for a status change) —
+// deliberately minimal, never a full client/PII record.
+model AuditLog {
+  id         String   @id @default(uuid())
+  userId     String
+  action     String
+  targetType String
+  targetId   String?
+  details    Json?
+  createdAt  DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([userId])
+  @@map("audit_log")
+}

--- a/server/api/delete/admins/[id].ts
+++ b/server/api/delete/admins/[id].ts
@@ -25,8 +25,8 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    return await prisma.$transaction(async (tx) => {
-      const updated = await tx.user.update({
+    const updated = await prisma.$transaction(async (tx) => {
+      const u = await tx.user.update({
         where: { id, deletedAt: null },
         data: {
           deletedAt: new Date(),
@@ -40,8 +40,17 @@ export default defineEventHandler(async (event) => {
       // to the session table and log the user out. Soft delete must do the same
       // explicitly, or an archived user's live cookie would keep API access.
       await tx.session.deleteMany({ where: { userId: id } })
-      return updated
+      return u
     })
+
+    // Audit (issue #28): record the archival after the transaction commits.
+    await writeAuditLog(event, {
+      action: 'ADMIN_DELETED',
+      targetType: 'User',
+      targetId: id,
+    })
+
+    return updated
   } catch (err) {
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&

--- a/server/api/delete/clients/[id].ts
+++ b/server/api/delete/clients/[id].ts
@@ -43,12 +43,12 @@ export default defineEventHandler(async (event) => {
   }
 
   const now = new Date()
-  return await prisma.$transaction(async (tx) => {
+  const updated = await prisma.$transaction(async (tx) => {
     await tx.client.update({
       where: { id, deletedAt: null },
       data: { deletedAt: now },
     })
-    const updated = await tx.user.update({
+    const u = await tx.user.update({
       where: { id: client.userId, deletedAt: null },
       data: {
         deletedAt: now,
@@ -62,6 +62,16 @@ export default defineEventHandler(async (event) => {
     // the session table and log the user out. Soft delete must do the same
     // explicitly, or an archived client's live cookie would keep API access.
     await tx.session.deleteMany({ where: { userId: client.userId } })
-    return updated
+    return u
   })
+
+  // Audit (issue #28): record the archival after the transaction commits.
+  await writeAuditLog(event, {
+    action: 'CLIENT_DELETED',
+    targetType: 'Client',
+    targetId: id,
+    details: { userId: client.userId },
+  })
+
+  return updated
 })

--- a/server/api/delete/rides/[id].ts
+++ b/server/api/delete/rides/[id].ts
@@ -16,10 +16,17 @@ export default defineEventHandler(async (event) => {
   // metrics. Guard on deletedAt: null so a second delete of an already-archived
   // ride 404s (P2025) rather than silently re-archiving.
   try {
-    return await prisma.ride.update({
+    const archived = await prisma.ride.update({
       where: { id, deletedAt: null },
       data: { deletedAt: new Date() },
     })
+    // Audit (issue #28): record the archival (soft delete).
+    await writeAuditLog(event, {
+      action: 'RIDE_DELETED',
+      targetType: 'Ride',
+      targetId: id,
+    })
+    return archived
   } catch (err) {
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&

--- a/server/api/delete/volunteers/[id].ts
+++ b/server/api/delete/volunteers/[id].ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
   // reused by a new record without a unique violation (decision #2). We clear
   // volunteerId on their ASSIGNED rides so the available-rides scoping (which
   // still sees CREATED rides) doesn't leak the archived volunteer's link.
-  return await prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     const volunteer = await tx.volunteer.findFirst({
       where: { id, deletedAt: null },
       select: { userId: true, user: { select: { email: true, phone: true } } },
@@ -60,4 +60,13 @@ export default defineEventHandler(async (event) => {
     await tx.session.deleteMany({ where: { userId: volunteer.userId } })
     return updated
   })
+
+  // Audit (issue #28): record the archival after the transaction commits.
+  await writeAuditLog(event, {
+    action: 'VOLUNTEER_DELETED',
+    targetType: 'Volunteer',
+    targetId: id,
+  })
+
+  return result
 })

--- a/server/api/get/audit/index.ts
+++ b/server/api/get/audit/index.ts
@@ -1,0 +1,37 @@
+import { prisma } from '../../../utils/prisma'
+
+// How many rows we ever return in one call. Audit logs grow unbounded over
+// time, so this endpoint is capped (issue #13 — never return unbounded lists).
+const MAX_LIMIT = 100
+
+export default defineEventHandler(async (event) => {
+  // Admin-only (issue #28). Mirrors the metrics routes' requireAdmin guard —
+  // the global middleware already enforces authentication.
+  requireAdmin(event)
+
+  const query = getQuery(event)
+
+  // Optional filters: by action string and/or by acting user id.
+  const where: { action?: string; userId?: string } = {}
+  if (typeof query.action === 'string' && query.action.trim() !== '') {
+    where.action = query.action.trim()
+  }
+  if (typeof query.userId === 'string' && query.userId.trim() !== '') {
+    where.userId = query.userId.trim()
+  }
+
+  // Bounded page size (1..MAX_LIMIT), newest first.
+  const requested = Number.parseInt(String(query.limit ?? ''), 10)
+  const take =
+    Number.isFinite(requested) && requested > 0
+      ? Math.min(requested, MAX_LIMIT)
+      : MAX_LIMIT
+
+  const logs = await prisma.auditLog.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take,
+  })
+
+  return logs
+})

--- a/server/api/post/admins/index.ts
+++ b/server/api/post/admins/index.ts
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
 
   if (existingUser) {
     // If user exists, update role to ADMIN
-    return await prisma.user.update({
+    const updated = await prisma.user.update({
       where: { id: existingUser.id },
       data: {
         role: 'ADMIN',
@@ -25,9 +25,17 @@ export default defineEventHandler(async (event) => {
         phone: emptyToNull(body.phone),
       },
     })
+    // Audit (issue #28): a user was promoted to ADMIN — a privileged change.
+    await writeAuditLog(event, {
+      action: 'USER_ROLE_CHANGED',
+      targetType: 'User',
+      targetId: updated.id,
+      details: { from: existingUser.role, to: 'ADMIN' },
+    })
+    return updated
   } else {
     // Create new user
-    return await prisma.user.create({
+    const created = await prisma.user.create({
       data: {
         name: body.name,
         email: body.email,
@@ -35,5 +43,13 @@ export default defineEventHandler(async (event) => {
         role: 'ADMIN',
       },
     })
+    // Audit (issue #28): a new ADMIN user was created.
+    await writeAuditLog(event, {
+      action: 'USER_ROLE_CHANGED',
+      targetType: 'User',
+      targetId: created.id,
+      details: { from: null, to: 'ADMIN' },
+    })
+    return created
   }
 })

--- a/server/api/post/rides/[id]/signup.ts
+++ b/server/api/post/rides/[id]/signup.ts
@@ -110,6 +110,14 @@ export default defineEventHandler(async (event) => {
     throw err
   }
 
+  // Audit (issue #28): the volunteer claimed this ride.
+  await writeAuditLog(event, {
+    action: 'VOLUNTEER_SIGNED_UP',
+    targetType: 'Ride',
+    targetId: id,
+    details: { volunteerId: volunteer.id },
+  })
+
   // 4. Notifications
   const admins = await prisma.user.findMany({
     where: { role: 'ADMIN' }

--- a/server/api/post/rides/[id]/unsignup.ts
+++ b/server/api/post/rides/[id]/unsignup.ts
@@ -94,6 +94,14 @@ export default defineEventHandler(async (event) => {
     throw err
   }
 
+  // Audit (issue #28): the volunteer dropped this ride.
+  await writeAuditLog(event, {
+    action: 'VOLUNTEER_UNSIGNED_UP',
+    targetType: 'Ride',
+    targetId: id,
+    details: { volunteerId: volunteer.id },
+  })
+
   // 4. Notifications
   const admins = await prisma.user.findMany({
     where: { role: 'ADMIN' }

--- a/server/api/post/rides/index.ts
+++ b/server/api/post/rides/index.ts
@@ -51,6 +51,14 @@ export default defineEventHandler(async (event) => {
     },
   })
 
+  // Audit (issue #28): record the ride creation after it succeeds.
+  await writeAuditLog(event, {
+    action: 'RIDE_CREATED',
+    targetType: 'Ride',
+    targetId: ride.id,
+    details: { clientId: ride.clientId, status: ride.status },
+  })
+
   // Notify all volunteers
   const scheduledTime = new Date(body.scheduledTime)
 

--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -154,6 +154,19 @@ export default defineEventHandler(async (event) => {
     },
   })
 
+  // Audit (issue #28): record ride lifecycle transitions (cancel/complete/
+  // assign/unassign) after the update succeeds. Action reflects the new status
+  // (e.g. RIDE_CANCELLED, RIDE_COMPLETED) so the log reads meaningfully; details
+  // keep only the from/to, never the full ride record.
+  if (ride.status !== existingRide.status) {
+    await writeAuditLog(event, {
+      action: `RIDE_${ride.status}`,
+      targetType: 'Ride',
+      targetId: ride.id,
+      details: { from: existingRide.status, to: ride.status },
+    })
+  }
+
   // Notifications
   const scheduledTime = new Date(ride.scheduledTime)
   const commonContext = {

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -1,0 +1,46 @@
+import type { H3Event } from 'h3'
+import { prisma } from './prisma'
+import { getAuth } from './authz'
+
+type AuditEntry = {
+  action: string
+  targetType: string
+  targetId?: string | null
+  // Keep this MINIMAL — a small description of the change (e.g. { from, to }).
+  // Never dump full client records / PII / secrets in here.
+  details?: Record<string, unknown> | null
+}
+
+/**
+ * Records an audit-log row for a successful mutation (issue #28).
+ *
+ * The acting user is resolved from the session the global auth middleware
+ * already put on the event (`event.context.auth`, via getAuth) — the same
+ * source the authz guards use — so callers don't re-run the session lookup.
+ *
+ * Fire-and-forget by contract: an audit-write failure MUST NEVER break or fail
+ * the underlying action. Everything is wrapped in try/catch and errors are
+ * swallowed + logged, mirroring the codebase's non-blocking style (sendEmail,
+ * broadcastNotification). Call this AFTER the action has succeeded.
+ */
+export async function writeAuditLog(event: H3Event, entry: AuditEntry): Promise<void> {
+  try {
+    const auth = getAuth(event)
+    // If we can't resolve an actor (shouldn't happen behind the auth middleware)
+    // fall back to 'unknown' rather than throwing — the log is best-effort.
+    const userId = auth?.user?.id ?? 'unknown'
+
+    await prisma.auditLog.create({
+      data: {
+        userId,
+        action: entry.action,
+        targetType: entry.targetType,
+        targetId: entry.targetId ?? null,
+        details: entry.details ?? undefined,
+      },
+    })
+  } catch (err) {
+    // Never propagate — the mutation already succeeded.
+    console.error('[audit] failed to write audit log', err)
+  }
+}

--- a/tests/e2e/audit-log.test.ts
+++ b/tests/e2e/audit-log.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import Database from 'better-sqlite3'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+type Ride = {
+  id: string
+  status: 'CREATED' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED'
+  volunteerId: string | null
+}
+
+type AuditLog = {
+  id: string
+  userId: string
+  action: string
+  targetType: string
+  targetId: string | null
+  details: unknown
+  createdAt: string
+}
+
+// Read a single value straight from the throwaway test DB (same trick as
+// tests/utils/auth.ts) so we can assert the acting user's id.
+function userIdByEmail(email: string): string {
+  const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
+  const db = new Database(dbPath, { readonly: true })
+  try {
+    const row = db.prepare(`SELECT id FROM user WHERE email = ? LIMIT 1`).get(email) as
+      | { id: string }
+      | undefined
+    if (!row) throw new Error(`no user row for ${email}`)
+    return row.id
+  } finally {
+    db.close()
+  }
+}
+
+async function getRides(cookie: string): Promise<Ride[]> {
+  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+}
+
+// Rides cancelled here are restored to CREATED afterwards so the shared seed DB
+// stays intact for other e2e files (mirrors ride-cancel.test.ts).
+const touchedRideIds = new Set<string>()
+
+afterEach(async () => {
+  if (!touchedRideIds.size) return
+  const cookie = await loginAs('reachtusharwani@gmail.com')
+  for (const id of touchedRideIds) {
+    await appFetch(`/api/put/rides/${id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ volunteerId: '', status: 'CREATED' }),
+    })
+  }
+  touchedRideIds.clear()
+})
+
+describe('Audit logging system (issue #28)', () => {
+  it('writes an audit row when an admin cancels a ride, readable via GET /api/get/audit', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const ride = (await getRides(cookie)).find(
+      (r) => r.status === 'CREATED' && !touchedRideIds.has(r.id),
+    )
+    expect(ride, 'seed should have an untouched CREATED ride').toBeTruthy()
+    touchedRideIds.add(ride!.id)
+
+    // Perform the logged action.
+    const cancelled = await $fetch<Ride>(`/api/put/rides/${ride!.id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: { status: 'CANCELLED' },
+    })
+    expect(cancelled.status).toBe('CANCELLED')
+
+    // Read the audit trail back through the admin endpoint (bounded, newest-first).
+    const logs = await $fetch<AuditLog[]>('/api/get/audit', {
+      headers: { cookie },
+      query: { action: 'RIDE_CANCELLED' },
+    })
+
+    const entry = logs.find((l) => l.targetId === ride!.id)
+    expect(entry, 'expected a RIDE_CANCELLED audit row for the cancelled ride').toBeTruthy()
+    expect(entry!.action).toBe('RIDE_CANCELLED')
+    expect(entry!.targetType).toBe('Ride')
+    expect(entry!.targetId).toBe(ride!.id)
+    // The acting user recorded is the logged-in admin.
+    expect(entry!.userId).toBe(userIdByEmail('reachtusharwani@gmail.com'))
+  })
+
+  it('caps the result set (bounded, not unbounded)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const logs = await $fetch<AuditLog[]>('/api/get/audit', { headers: { cookie } })
+    expect(Array.isArray(logs)).toBe(true)
+    expect(logs.length).toBeLessThanOrEqual(100)
+  })
+
+  it('is admin-gated: a volunteer cannot read the audit log', async () => {
+    const cookie = await loginAs('bob@example.com')
+    await expect(
+      $fetch('/api/get/audit', { headers: { cookie } }),
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('is admin-gated: an unauthenticated request is rejected', async () => {
+    await expect($fetch('/api/get/audit')).rejects.toMatchObject({ statusCode: 401 })
+  })
+})


### PR DESCRIPTION
## What was missing

WCOA handles client PII, location data, and scheduling but had no record of **who did what** — no way to answer "who cancelled ride #123" or "who promoted this user to admin". Issue #28 asks for an admin audit trail over the accountability-critical mutations.

## What changed

- **Prisma model `AuditLog`** (`prisma/schema/audit.prisma`): `id`, `userId` (the actor, stored as a plain string so the trail survives actor deletion — no dangling FK), `action`, `targetType`, `targetId?`, `details Json?`, `createdAt`, indexed on `createdAt` and `userId`, mapped `@@map("audit_log")`.
- **Migration** `20260713224440_add_audit_log` — additive `CREATE TABLE audit_log` (+ indexes). Safe/additive; generated with `prisma migrate dev` and committed per the #33 workflow.
- **Helper `server/utils/audit.ts`** — `writeAuditLog(event, { action, targetType, targetId?, details? })`. Resolves the acting user from the session the auth middleware already put on the event (`getAuth`, same source the authz guards use) and inserts a row. **Non-blocking by contract:** the whole body is wrapped in try/catch that swallows + `console.error`s, so an audit-write failure can never break or fail the underlying action. Called only *after* the action succeeds. Mirrors the codebase's `sendEmail`/broadcast style.
- **Injected into the critical mutations only:**
  - `post/rides/index.ts` → `RIDE_CREATED`
  - `post/rides/[id]/signup.ts` → `VOLUNTEER_SIGNED_UP`
  - `post/rides/[id]/unsignup.ts` → `VOLUNTEER_UNSIGNED_UP`
  - `put/rides/[id].ts` → `RIDE_<STATUS>` on any lifecycle transition (incl. `RIDE_CANCELLED`, `RIDE_COMPLETED`), with `{ from, to }`
  - `delete/{rides,clients,volunteers,admins}/[id].ts` → `RIDE_DELETED` / `CLIENT_DELETED` / `VOLUNTEER_DELETED` / `ADMIN_DELETED` (logs the soft-delete/archival)
  - `post/admins/index.ts` → `USER_ROLE_CHANGED` (`{ from, to: 'ADMIN' }`)
  - `details` is kept minimal (from/to, ids) — never full client records/PII.
- **Admin-only read endpoint `GET /api/get/audit`** — `requireAdmin(event)` (like the metrics routes), newest-first, **capped at 100** rows (mindful of #13, never unbounded), optional `action` / `userId` filters.
- **Admin UI `app/pages/admin/audit.vue`** — admin-guarded table (matches `admin/notifications.vue`), filter by action or user id; nav link added in `app/app.vue`.

## Verification

Regression test: **`tests/e2e/audit-log.test.ts`**
- `writes an audit row when an admin cancels a ride, readable via GET /api/get/audit` — cancels a ride (PUT `{status:'CANCELLED'}`), then asserts a row with `action: RIDE_CANCELLED`, `targetType: Ride`, `targetId` = ride id, `userId` = the acting admin's id (read from the test DB).
- `caps the result set (bounded, not unbounded)` — asserts ≤ 100.
- `is admin-gated: a volunteer cannot read the audit log` — expects 403.
- `is admin-gated: an unauthenticated request is rejected` — expects 401.

**Pre-fix (stashed my changes, ran against origin/main state):** `Tests 3 failed | 1 passed (4)` — the audit-row, bounded, and volunteer-403 tests all failed because `GET /api/get/audit` did not exist (404) and no `audit_log` table/rows existed; only the unauthenticated case passed (the global middleware 401s any request). The volunteer test failed on `.rejects.toMatchObject({ statusCode: 403 })` — it received 404 (no such route) instead of 403.

**Post-fix full suite:** `Test Files 33 passed (33)` / `Tests 125 passed (125)`. (The SMTP `EAUTH` lines in output are the pre-existing swallowed email failures, issue #25.)

## Risk / review notes

- **Risk files touched:** `prisma/schema/` + a new migration — this PR should be human-reviewed regardless. The migration is purely additive (a new table), no data migration. No CI/docker/deps/auth-config changes.
- The audit-write is non-blocking (cannot throw into the request path) and the read endpoint is admin-gated and bounded.

Fixes #28