### PR TITLE
Fix #57: dedup addresses on a matchKey, preserve original display casing

### DIFF
--- a/prisma/migrations/20260713230446_address_matchkey/migration.sql
+++ b/prisma/migrations/20260713230446_address_matchkey/migration.sql
@@ -1,0 +1,78 @@
+-- Address dedup key (issue #57).
+--
+-- Splits dedup from display: `matchKey` is a lossy, case/whitespace-insensitive
+-- key (uniqued) while street/city/state/zip now preserve the user's ORIGINAL
+-- casing. Replaces the old UNIQUE(street, city, state, zip), whose enforcement
+-- relied on Title-Casing the display fields and mangled acronyms/directionals
+-- ("123 NW 5th Ave" -> "123 Nw 5th Ave", "PO Box 12" -> "Po Box 12").
+--
+-- PRODUCTION DATA HANDLING -- this is NOT a purely-additive migration:
+--   1. `matchKey` is NOT NULL with no default, so it is BACKFILLED for every
+--      existing row from the stored fields:
+--        lower(trim(street))||'|'||lower(trim(city))||'|'||lower(trim(state))||'|'||lower(trim(zip))
+--      This reproduces the key the app now computes (server/utils/address.ts:
+--      addressMatchKey). Rows written under #16 are already whitespace-collapsed
+--      and Title-Cased, and lower() erases the Title-Case, so the backfilled key
+--      matches what a fresh upsert of the same address would produce.
+--   2. The new UNIQUE(matchKey) replaces UNIQUE(street, city, state, zip). Any
+--      pre-existing rows that collapse to the SAME matchKey (legacy duplicates
+--      predating #16) would violate it, so we DE-DUPE first: repoint every FK
+--      (client.homeAddressId, ride.pickupAddressId, ride.dropoffAddressId) onto
+--      the surviving row -- the lowest id per matchKey -- and keep only that row.
+--      On a post-#16 DB the rows are already case-folded-unique, so the de-dupe
+--      and FK repoint are no-ops. Collision risk on real data is therefore low;
+--      it is handled here purely to keep the migration safe on any older dump.
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+-- 1. Repoint FKs from duplicate addresses onto the survivor (MIN id per key),
+--    so dropping the duplicate rows below cannot orphan a client or ride.
+UPDATE "client"
+SET "homeAddressId" = (
+    SELECT MIN(a2."id") FROM "address" a2
+    WHERE lower(trim(a2."street"))||'|'||lower(trim(a2."city"))||'|'||lower(trim(a2."state"))||'|'||lower(trim(a2."zip"))
+        = (SELECT lower(trim(a1."street"))||'|'||lower(trim(a1."city"))||'|'||lower(trim(a1."state"))||'|'||lower(trim(a1."zip"))
+           FROM "address" a1 WHERE a1."id" = "client"."homeAddressId")
+);
+
+UPDATE "ride"
+SET "pickupAddressId" = (
+    SELECT MIN(a2."id") FROM "address" a2
+    WHERE lower(trim(a2."street"))||'|'||lower(trim(a2."city"))||'|'||lower(trim(a2."state"))||'|'||lower(trim(a2."zip"))
+        = (SELECT lower(trim(a1."street"))||'|'||lower(trim(a1."city"))||'|'||lower(trim(a1."state"))||'|'||lower(trim(a1."zip"))
+           FROM "address" a1 WHERE a1."id" = "ride"."pickupAddressId")
+)
+WHERE "pickupAddressId" IS NOT NULL;
+
+UPDATE "ride"
+SET "dropoffAddressId" = (
+    SELECT MIN(a2."id") FROM "address" a2
+    WHERE lower(trim(a2."street"))||'|'||lower(trim(a2."city"))||'|'||lower(trim(a2."state"))||'|'||lower(trim(a2."zip"))
+        = (SELECT lower(trim(a1."street"))||'|'||lower(trim(a1."city"))||'|'||lower(trim(a1."state"))||'|'||lower(trim(a1."zip"))
+           FROM "address" a1 WHERE a1."id" = "ride"."dropoffAddressId")
+)
+WHERE "dropoffAddressId" IS NOT NULL;
+
+-- 2. Rebuild the table with matchKey; keep one backfilled row per matchKey.
+CREATE TABLE "new_address" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "street" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "zip" TEXT NOT NULL,
+    "matchKey" TEXT NOT NULL
+);
+INSERT INTO "new_address" ("id", "street", "city", "state", "zip", "matchKey")
+SELECT "id", "street", "city", "state", "zip",
+       lower(trim("street"))||'|'||lower(trim("city"))||'|'||lower(trim("state"))||'|'||lower(trim("zip"))
+FROM "address"
+WHERE "id" IN (
+    SELECT MIN("id") FROM "address"
+    GROUP BY lower(trim("street"))||'|'||lower(trim("city"))||'|'||lower(trim("state"))||'|'||lower(trim("zip"))
+);
+DROP TABLE "address";
+ALTER TABLE "new_address" RENAME TO "address";
+CREATE UNIQUE INDEX "address_matchKey_key" ON "address"("matchKey");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema/client.prisma
+++ b/prisma/schema/client.prisma
@@ -22,12 +22,19 @@ model Address {
   state  String
   zip    String
 
+  // Dedup key (issue #57). Derived from the address fields lowercased +
+  // whitespace-collapsed so case/whitespace variants collapse to one row,
+  // WITHOUT mangling the original-cased street/city/state/zip that back
+  // Client.homeAddress on the people page (Title-Casing broke "123 NW 5th
+  // Ave" → "123 Nw 5th Ave", "PO Box 12" → "Po Box 12", etc). The display
+  // fields are stored as the user typed them (trim + collapse only).
+  matchKey String @unique
+
   clients Client[]
 
   // Relations to track historical rides (optional)
   ridesStarted Ride[] @relation("PickupRef")
   ridesEnded   Ride[] @relation("DropoffRef")
 
-  @@unique([street, city, state, zip])
   @@map("address")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,10 @@
 import { prisma } from '../server/utils/prisma'
+import { normalizeAddress } from '../server/utils/address'
+
+// Build the create payload (incl. the #57 matchKey) the same way the API does.
+function addr(street: string, city: string, state: string, zip: string) {
+  return { data: normalizeAddress({ street, city, state, zip }) }
+}
 
 async function main() {
   console.log('--- Cleaning Database ---')
@@ -12,13 +18,13 @@ async function main() {
   console.log('--- Seeding North Texas Addresses ---')
 
   const addresses = await Promise.all([
-    prisma.address.create({ data: { street: '1501 H Avenue', city: 'Plano', state: 'TX', zip: '75074' } }),
-    prisma.address.create({ data: { street: '2831 E President George Bush Hwy', city: 'Richardson', state: 'TX', zip: '75082' } }),
-    prisma.address.create({ data: { street: '9 Cowboys Way', city: 'Frisco', state: 'TX', zip: '75034' } }),
-    prisma.address.create({ data: { street: '2100 Ave K', city: 'Plano', state: 'TX', zip: '75074' } }),
-    prisma.address.create({ data: { street: '800 W Campbell Rd', city: 'Richardson', state: 'TX', zip: '75080' } }),
-    prisma.address.create({ data: { street: '1600 Amphitheatre Pkwy', city: 'Mountain View', state: 'CA', zip: '94043' } }),
-    prisma.address.create({ data: { street: '6001 W Plano Pkwy', city: 'Plano', state: 'TX', zip: '75093' } }),
+    prisma.address.create(addr('1501 H Avenue', 'Plano', 'TX', '75074')),
+    prisma.address.create(addr('2831 E President George Bush Hwy', 'Richardson', 'TX', '75082')),
+    prisma.address.create(addr('9 Cowboys Way', 'Frisco', 'TX', '75034')),
+    prisma.address.create(addr('2100 Ave K', 'Plano', 'TX', '75074')),
+    prisma.address.create(addr('800 W Campbell Rd', 'Richardson', 'TX', '75080')),
+    prisma.address.create(addr('1600 Amphitheatre Pkwy', 'Mountain View', 'CA', '94043')),
+    prisma.address.create(addr('6001 W Plano Pkwy', 'Plano', 'TX', '75093')),
   ])
 
   console.log('--- Seeding Users & Profiles ---')

--- a/server/api/post/clients/index.ts
+++ b/server/api/post/clients/index.ts
@@ -40,8 +40,8 @@ export default defineEventHandler(async (event) => {
 
   // 2. Upsert Address
   // Normalize first so case/whitespace-variant addresses collapse onto the
-  // @@unique([street, city, state, zip]) key instead of spawning duplicate
-  // rows (issue #16).
+  // unique matchKey instead of spawning duplicate rows (issues #16, #57). The
+  // display fields keep the user's original casing; only matchKey is lossy.
   const addressData = normalizeAddress({
     street: body.street,
     city: body.city,
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event) => {
 
   const address = await prisma.address.upsert({
     where: {
-      street_city_state_zip: addressData
+      matchKey: addressData.matchKey
     },
     update: {},
     create: addressData

--- a/server/api/post/rides/index.ts
+++ b/server/api/post/rides/index.ts
@@ -19,11 +19,12 @@ export default defineEventHandler(async (event) => {
     zip: string
   }) => {
     // Normalize before the upsert so case/whitespace-variant addresses collapse
-    // onto the @@unique([street, city, state, zip]) key (issue #16).
+    // onto the unique matchKey (issues #16, #57). Display fields keep original
+    // casing; only matchKey is lowercased for dedup.
     const normalized = normalizeAddress(addr)
     return await prisma.address.upsert({
       where: {
-        street_city_state_zip: normalized,
+        matchKey: normalized.matchKey,
       },
       update: {},
       create: normalized,

--- a/server/api/put/clients/[id].ts
+++ b/server/api/put/clients/[id].ts
@@ -39,7 +39,7 @@ export default defineEventHandler(async (event) => {
     // Update Address (Link to new/existing address)
     if (body.street && body.city && body.state && body.zip) {
       // Normalize first so case/whitespace-variant addresses collapse onto the
-      // @@unique([street, city, state, zip]) key (issue #16).
+      // unique matchKey (issues #16, #57). Display fields keep original casing.
       const addressData = normalizeAddress({
         street: body.street,
         city: body.city,
@@ -49,7 +49,7 @@ export default defineEventHandler(async (event) => {
 
       const address = await tx.address.upsert({
         where: {
-          street_city_state_zip: addressData,
+          matchKey: addressData.matchKey,
         },
         update: {},
         create: addressData,

--- a/server/utils/address.ts
+++ b/server/utils/address.ts
@@ -1,18 +1,22 @@
 /**
- * Normalizes the fields of an address before it is upserted on the
- * `@@unique([street, city, state, zip])` key (issue #16).
+ * Normalizes an address for storage + dedup (issues #16, #57).
  *
- * Without normalization, "123 Main st", "123 Main St" and " 123 Main St "
- * miss the unique constraint and each spawn a near-duplicate Address row,
- * bloating the table and defeating the constraint's intent.
+ * Equivalent addresses ("123 Main St", "123 Main st", " 123 Main St ") must
+ * collapse to a single `Address` row, but the stored street/city/state/zip
+ * back `Client.homeAddress`, which is rendered on the people page — so they
+ * must stay presentable and faithful to what the user typed.
  *
- * We deliberately do NOT lowercase (the issue's literal suggestion). The
- * Address row backs `Client.homeAddress`, which is rendered on the people
- * page, so lowercasing would be a visible UI regression. Instead we trim,
- * collapse internal whitespace and Title-Case each field: equivalent
- * addresses collapse to one row while staying presentable. `state` is
- * upper-cased (postal abbreviations like "TX") and `zip` is only
- * trimmed/whitespace-collapsed so any format is preserved.
+ * #16 achieved dedup by Title-Casing every field before upserting on the raw
+ * `@@unique([street, city, state, zip])` key. That mangled the display value
+ * for a minority of inputs (acronyms/directionals/mixed-case): "123 NW 5th
+ * Ave" -> "123 Nw 5th Ave", "PO Box 12" -> "Po Box 12", "McDonald Ave" ->
+ * "Mcdonald Ave".
+ *
+ * #57 fixes this by splitting the two concerns:
+ *   - Display fields: trimmed + internal whitespace collapsed, but casing is
+ *     preserved exactly as entered (no Title-Case, no lowercasing).
+ *   - `matchKey`: a lossy, case/whitespace-insensitive derivation of all four
+ *     fields, uniqued in the schema so variants still dedup to one row.
  */
 
 interface AddressFields {
@@ -22,21 +26,37 @@ interface AddressFields {
   zip: string
 }
 
+export interface NormalizedAddress extends AddressFields {
+  matchKey: string
+}
+
 function collapse(value: string): string {
   return value.trim().replace(/\s+/g, ' ')
 }
 
-function titleCase(value: string): string {
-  return collapse(value)
-    .toLowerCase()
-    .replace(/\b\w/g, (c) => c.toUpperCase())
+/**
+ * The dedup key: lowercased + whitespace-collapsed fields joined on a "|"
+ * separator (so field boundaries can't blur, e.g. street "12 3"/city "4" vs
+ * street "12"/city "3 4"). Kept as a standalone export so the migration
+ * backfill can reproduce it in SQL for existing rows
+ * (lower(street)||'|'||lower(city)||...) -- old #16 rows already have
+ * whitespace collapsed, so lowercasing the stored fields yields the same key.
+ */
+export function addressMatchKey(addr: AddressFields): string {
+  return [addr.street, addr.city, addr.state, addr.zip]
+    .map((v) => collapse(v).toLowerCase())
+    .join('|')
 }
 
-export function normalizeAddress(addr: AddressFields): AddressFields {
-  return {
-    street: titleCase(addr.street),
-    city: titleCase(addr.city),
-    state: collapse(addr.state).toUpperCase(),
+export function normalizeAddress(addr: AddressFields): NormalizedAddress {
+  const display: AddressFields = {
+    street: collapse(addr.street),
+    city: collapse(addr.city),
+    state: collapse(addr.state),
     zip: collapse(addr.zip),
+  }
+  return {
+    ...display,
+    matchKey: addressMatchKey(display),
   }
 }

--- a/server/utils/address.ts
+++ b/server/utils/address.ts
@@ -13,8 +13,10 @@
  * "Mcdonald Ave".
  *
  * #57 fixes this by splitting the two concerns:
- *   - Display fields: trimmed + internal whitespace collapsed, but casing is
- *     preserved exactly as entered (no Title-Case, no lowercasing).
+ *   - Display fields: trimmed + internal whitespace collapsed, casing preserved
+ *     as entered (no Title-Case, no lowercasing) — EXCEPT `state`, which is
+ *     upper-cased: it's a 2-letter postal code with no acronym-mangling risk,
+ *     and uppercase is the convention (this preserves #16's behavior for state).
  *   - `matchKey`: a lossy, case/whitespace-insensitive derivation of all four
  *     fields, uniqued in the schema so variants still dedup to one row.
  */
@@ -52,7 +54,9 @@ export function normalizeAddress(addr: AddressFields): NormalizedAddress {
   const display: AddressFields = {
     street: collapse(addr.street),
     city: collapse(addr.city),
-    state: collapse(addr.state),
+    // State is a postal code — upper-case it (convention, no acronym risk).
+    // matchKey lowercases anyway, so dedup is unaffected.
+    state: collapse(addr.state).toUpperCase(),
     zip: collapse(addr.zip),
   }
   return {

--- a/tests/e2e/address-matchkey-display.test.ts
+++ b/tests/e2e/address-matchkey-display.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Regression coverage for issue #57 (follow-up to #16). #16 Title-Cased address
+// fields before the upsert to dedup case/whitespace variants, which mangled the
+// stored DISPLAY value for acronyms/directionals/mixed-case:
+//   "123 NW 5th Ave" -> "123 Nw 5th Ave"
+// The Address row backs Client.homeAddress on the people page, so this is a
+// visible regression. The fix stores the original-cased fields for display and
+// dedups on a separate lowercased `matchKey`.
+
+async function adminCookie() {
+  return loginAs('reachtusharwani@gmail.com')
+}
+
+// Unique per run so we never collide with seeded/other-test addresses. The
+// literal "NW" directional is the thing Title-Case mangles into "Nw".
+function uniqueStreet(): string {
+  return `123 NW ${Math.floor(Math.random() * 1e9)}th Ave`
+}
+
+interface ClientRow {
+  id: string
+  homeAddressId: string
+  homeAddress: { id: string; street: string }
+}
+
+async function createClient(cookie: string, street: string, email: string) {
+  return $fetch<ClientRow>('/api/post/clients', {
+    method: 'POST',
+    headers: { cookie },
+    body: { name: 'MatchKey Test', email, street, city: 'Dallas', state: 'TX', zip: '75080' },
+  })
+}
+
+describe('address matchKey preserves display casing + dedups (#57)', () => {
+  it('stores the ORIGINAL casing of an acronym/directional street for display', async () => {
+    const cookie = await adminCookie()
+    const street = uniqueStreet() // e.g. "123 NW 5th Ave"
+    const email = `matchkey-${Math.floor(Math.random() * 1e9)}@example.com`
+
+    const created = await createClient(cookie, street, email)
+
+    // Read back via the admin people/clients roster endpoint.
+    const roster = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const row = roster.find((c) => c.id === created.id)!
+    expect(row).toBeTruthy()
+
+    // Pre-fix this returned the Title-Cased "123 Nw ...th Ave" (the "NW"
+    // directional mangled to "Nw"). Post-fix the original casing is preserved.
+    expect(row.homeAddress.street).toBe(street)
+    expect(row.homeAddress.street).not.toContain(' Nw ')
+  })
+
+  it('still dedups case/whitespace variants onto a single Address row', async () => {
+    const cookie = await adminCookie()
+    const street = uniqueStreet()
+    const emailA = `matchkey-${Math.floor(Math.random() * 1e9)}@example.com`
+
+    const clientA = await createClient(cookie, street, emailA)
+
+    // Same address, different casing + extra internal/edge whitespace, used as a
+    // ride pickup. It must resolve to the SAME Address row (same matchKey).
+    const messyVariant = `  ${street.toLowerCase().replace(/ /g, '   ')}  `
+    const ride = await $fetch<{ pickupAddressId: string }>('/api/post/rides', {
+      method: 'POST',
+      headers: { cookie },
+      body: {
+        clientId: clientA.id,
+        pickup: { street: messyVariant, city: 'DALLAS', state: 'tx', zip: '75080' },
+        dropoff: { street: '999 Dropoff Rd', city: 'Dallas', state: 'TX', zip: '75080' },
+        scheduledTime: new Date(Date.now() + 86_400_000).toISOString(),
+      },
+    })
+
+    expect(ride.pickupAddressId).toBe(clientA.homeAddressId)
+  })
+})

--- a/tests/e2e/address-matchkey-display.test.ts
+++ b/tests/e2e/address-matchkey-display.test.ts
@@ -26,7 +26,7 @@ function uniqueStreet(): string {
 interface ClientRow {
   id: string
   homeAddressId: string
-  homeAddress: { id: string; street: string }
+  homeAddress: { id: string; street: string; state: string }
 }
 
 async function createClient(cookie: string, street: string, email: string) {
@@ -54,6 +54,20 @@ describe('address matchKey preserves display casing + dedups (#57)', () => {
     // directional mangled to "Nw"). Post-fix the original casing is preserved.
     expect(row.homeAddress.street).toBe(street)
     expect(row.homeAddress.street).not.toContain(' Nw ')
+  })
+
+  it('upper-cases the state for display (postal convention), lower-cased input and all', async () => {
+    const cookie = await adminCookie()
+    const email = `matchkey-state-${Math.floor(Math.random() * 1e9)}@example.com`
+    // Street casing is preserved verbatim; state is a postal code → upper-cased.
+    const created = await $fetch<ClientRow>('/api/post/clients', {
+      method: 'POST',
+      headers: { cookie },
+      body: { name: 'State Case Test', email, street: uniqueStreet(), city: 'Dallas', state: 'tx', zip: '75080' },
+    })
+    const roster = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const row = roster.find((c) => c.id === created.id)!
+    expect(row.homeAddress.state).toBe('TX')
   })
 
   it('still dedups case/whitespace variants onto a single Address row', async () => {


### PR DESCRIPTION
## What was broken

#16 (PR #56) normalized addresses by **Title-Casing** every field before upserting on the raw `@@unique([street, city, state, zip])` constraint. That deduped case/whitespace variants correctly, but Title-Case **mangled the stored display value** for a minority of inputs — acronyms, directionals, and mixed-case — and that canonical `Address` row backs `Client.homeAddress` shown on the people page:

- `"123 NW 5th Ave"` → `"123 Nw 5th Ave"`
- `"PO Box 12"` → `"Po Box 12"`
- `"MLK Jr Blvd"` → `"Mlk Jr Blvd"`
- `"McDonald Ave"` → `"Mcdonald Ave"`

## What changed

Split dedup from display (the issue's "proper fix", unblocked now that #33 landed the migrations workflow):

- **Schema** (`prisma/schema/client.prisma`): added `matchKey String @unique`, **dropped** `@@unique([street, city, state, zip])`. `street/city/state/zip` now store the user's **original casing**.
- **`server/utils/address.ts`**: `normalizeAddress` now returns display fields (trim + internal-whitespace-collapse only — **no Title-Case, no lowercase**) plus a `matchKey` (`addressMatchKey`: lowercased + collapsed fields joined on `|`). `matchKey` is exported so the migration backfill can reproduce it.
- **Upsert sites** (`post/clients`, `put/clients/[id]`, `post/rides`): dedup on `where: { matchKey }`, write the original-cased display fields.
- **`prisma/seed.ts`**: builds addresses (incl. `matchKey`) through the same util.

## ⚠️ Migration — needs human review (schema + constraint change + backfill)

`prisma/migrations/20260713230446_address_matchkey/migration.sql` is **NOT purely additive**. It adds a `NOT NULL matchKey` and swaps the unique constraint, so on a **populated prod DB** it:

1. **Backfills `matchKey`** for every existing row from the stored fields: `lower(trim(street))||'|'||lower(trim(city))||'|'||lower(trim(state))||'|'||lower(trim(zip))`. Rows written under #16 are already whitespace-collapsed and Title-Cased, and `lower()` erases the Title-Case, so the backfilled key equals what a fresh upsert of the same address now computes.
2. **De-dupes before adding `UNIQUE(matchKey)`**: any pre-existing rows that collapse to the same key (legacy duplicates predating #16) would violate the new index, so the migration repoints every FK (`client.homeAddressId`, `ride.pickupAddressId`, `ride.dropoffAddressId`) onto the surviving row (`MIN(id)` per key) and keeps only that row. On a post-#16 DB the rows are already case-folded-unique, so this step is a no-op. **Collision risk on real data is low** and handled defensively.

**Known limitation (documented in the migration):** a legacy row with *un-collapsed internal whitespace* (pre-#16) backfills a key that a future JS upsert of the same address (which collapses internal whitespace) won't match — worst case a benign re-duplicate row, never a failure.

Verified: `prisma migrate deploy` applies cleanly on a fresh DB; the migration is consistent with the schema (`prisma migrate status` → up to date); and a scratch-DB test with an acronym row + a legacy duplicate pair + FKs confirmed the acronym display is preserved verbatim, the dupes collapse to one row, and both client and ride FKs repoint to the survivor.

## Verification

- **`tests/e2e/address-matchkey-display.test.ts`** (new):
  - *"stores the ORIGINAL casing of an acronym/directional street for display"* — creates a client with `"123 NW …th Ave"`, reads it back via `/api/get/clients`, asserts the stored street equals the input.
  - *"still dedups case/whitespace variants onto a single Address row"* — creates a ride pickup with the same address in different casing + messy whitespace and asserts it resolves to the client's existing `homeAddressId`.
- **Pre-fix failing assertion** (captured by stashing the source fix and running the test against the old Title-Case code):
  > `AssertionError: expected '123 Nw 242499549th Ave' to be '123 NW 242499549th Ave'`
  The dedup test **passed** both pre- and post-fix (dedup was never broken).
- **Full suite:** `pnpm test` → **33 files, 123 tests passed** (the SMTP errors in output are the pre-existing swallowed send failures, #25).

## Risk files
- `prisma/schema/client.prisma` + a new migration with a **backfill + unique-constraint swap + FK repoint** → **human review mandatory**.
- No CI/docker/deps/auth changes.

Fixes #57