### PR TITLE
Fix #28 review: audit action naming (RIDE_UNASSIGNED, no RIDE_CREATED collision)

### DIFF
--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -154,16 +154,32 @@ export default defineEventHandler(async (event) => {
     },
   })
 
-  // Audit (issue #28): record ride lifecycle transitions (cancel/complete/
-  // assign/unassign) after the update succeeds. Action reflects the new status
-  // (e.g. RIDE_CANCELLED, RIDE_COMPLETED) so the log reads meaningfully; details
-  // keep only the from/to, never the full ride record.
-  if (ride.status !== existingRide.status) {
+  // Audit (issue #28): record ride lifecycle transitions after the update
+  // succeeds. A volunteer change is logged as RIDE_ASSIGNED/RIDE_UNASSIGNED so
+  // it stays distinct from a genuine status transition — otherwise an admin
+  // unassigning a volunteer (which auto-resets status to CREATED, see above)
+  // would log RIDE_CREATED and collide with actual ride creation in the trail.
+  // Pure status changes (cancel/complete) log RIDE_<status>. details keep only
+  // the from/to, never the full ride record.
+  const statusChanged = ride.status !== existingRide.status
+  const volunteerChanged = ride.volunteerId !== existingRide.volunteerId
+  if (statusChanged || volunteerChanged) {
+    const action = volunteerChanged
+      ? ride.volunteerId === null
+        ? 'RIDE_UNASSIGNED'
+        : 'RIDE_ASSIGNED'
+      : `RIDE_${ride.status}`
     await writeAuditLog(event, {
-      action: `RIDE_${ride.status}`,
+      action,
       targetType: 'Ride',
       targetId: ride.id,
-      details: { from: existingRide.status, to: ride.status },
+      details: {
+        from: existingRide.status,
+        to: ride.status,
+        ...(volunteerChanged
+          ? { fromVolunteerId: existingRide.volunteerId, toVolunteerId: ride.volunteerId }
+          : {}),
+      },
     })
   }
 

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -18,10 +18,12 @@ type AuditEntry = {
  * already put on the event (`event.context.auth`, via getAuth) — the same
  * source the authz guards use — so callers don't re-run the session lookup.
  *
- * Fire-and-forget by contract: an audit-write failure MUST NEVER break or fail
- * the underlying action. Everything is wrapped in try/catch and errors are
- * swallowed + logged, mirroring the codebase's non-blocking style (sendEmail,
- * broadcastNotification). Call this AFTER the action has succeeded.
+ * Non-failing by contract: an audit-write failure MUST NEVER break or fail the
+ * underlying action. Everything is wrapped in try/catch and errors are swallowed
+ * + logged. Callers DO await this (so the audit row is durably written before
+ * the response — durability matters more than shaving one indexed INSERT of
+ * latency), but because it can never throw, awaiting it can't fail the request.
+ * Call this AFTER the action has succeeded.
  */
 export async function writeAuditLog(event: H3Event, entry: AuditEntry): Promise<void> {
   try {

--- a/tests/e2e/audit-log.test.ts
+++ b/tests/e2e/audit-log.test.ts
@@ -92,6 +92,57 @@ describe('Audit logging system (issue #28)', () => {
     expect(entry!.userId).toBe(userIdByEmail('reachtusharwani@gmail.com'))
   })
 
+  it('logs an admin unassign as RIDE_UNASSIGNED, not RIDE_CREATED (no collision with ride creation)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    // Start from a CREATED ride and borrow a volunteer id from any seeded ride.
+    const rides = await getRides(cookie)
+    const ride = rides.find((r) => r.status === 'CREATED' && !touchedRideIds.has(r.id))
+    expect(ride, 'seed should have an untouched CREATED ride').toBeTruthy()
+    touchedRideIds.add(ride!.id)
+    const volunteerId = rides.find((r) => r.volunteerId)?.volunteerId
+    expect(volunteerId, 'seed should have a ride with a volunteer').toBeTruthy()
+
+    // Assign, then unassign. The unassign auto-resets status ASSIGNED->CREATED
+    // (issue #7); pre-fix that made the audit log RIDE_CREATED, colliding with
+    // actual ride creation.
+    await $fetch(`/api/put/rides/${ride!.id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: { volunteerId, status: 'ASSIGNED' },
+    })
+    const unassigned = await $fetch<Ride>(`/api/put/rides/${ride!.id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: { volunteerId: '' },
+    })
+    expect(unassigned.status).toBe('CREATED')
+    expect(unassigned.volunteerId).toBeNull()
+
+    // The unassign is logged as RIDE_UNASSIGNED...
+    const unassignLogs = await $fetch<AuditLog[]>('/api/get/audit', {
+      headers: { cookie },
+      query: { action: 'RIDE_UNASSIGNED' },
+    })
+    expect(
+      unassignLogs.find((l) => l.targetId === ride!.id),
+      'expected a RIDE_UNASSIGNED audit row for the unassigned ride',
+    ).toBeTruthy()
+
+    // ...and NOT as RIDE_CREATED. The pre-fix collision logged the ASSIGNED->CREATED
+    // auto-unassign as RIDE_CREATED (details.from === 'ASSIGNED'); assert no such
+    // row exists (a genuine RIDE_CREATED would have from CANCELLED/other, e.g. the
+    // afterEach cleanup restore — so match on details.from to target the collision).
+    const createdLogs = await $fetch<AuditLog[]>('/api/get/audit', {
+      headers: { cookie },
+      query: { action: 'RIDE_CREATED' },
+    })
+    const collision = createdLogs.find(
+      (l) => l.targetId === ride!.id && (l.details as { from?: string } | null)?.from === 'ASSIGNED',
+    )
+    expect(collision, 'unassigning (ASSIGNED->CREATED) must NOT log RIDE_CREATED').toBeFalsy()
+  })
+
   it('caps the result set (bounded, not unbounded)', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
     const logs = await $fetch<AuditLog[]>('/api/get/audit', { headers: { cookie } })


### PR DESCRIPTION
Follow-up to #28 / PR #81 (already merged). Addresses the one review finding on #81.

## What was wrong
In `PUT /api/put/rides/[id]`, an admin unassigning a volunteer auto-resets the ride to `CREATED` (issue-#7 logic), so the audit recorded `action: 'RIDE_CREATED'` — the same string an actual new-ride creation logs. Filtering the audit trail for "rides created" returned unassignments too, and "volunteer unassigned" was un-findable.

## What changed
Derive the audit action from *what actually changed* rather than blindly from the destination status:
- a volunteer change → `RIDE_ASSIGNED` / `RIDE_UNASSIGNED` (this also now captures an admin **reassignment** that keeps status `ASSIGNED`, which previously logged nothing);
- a pure status change → `RIDE_<status>` (cancel/complete unchanged).
`details` now also carries `fromVolunteerId`/`toVolunteerId` on volunteer changes. Also clarified the `writeAuditLog` docstring (it is `await`ed for durability and can never throw).

## Verification
- New test case in `tests/e2e/audit-log.test.ts`: *"logs an admin unassign as RIDE_UNASSIGNED, not RIDE_CREATED"* — assigns then unassigns a ride and asserts a `RIDE_UNASSIGNED` row exists and no `RIDE_CREATED` row with `details.from === 'ASSIGNED'`.
- **Revert-check:** with the pre-fix action logic restored, the test fails (`expected a RIDE_UNASSIGNED audit row … expected undefined to be truthy`); with the fix it passes.
- Full suite: **33 files / 126 tests passing**.
- No schema/migration/CI/docker/deps/auth changes — a pure application-logic + test change on top of merged #28.

Fixes the #81 review finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)