### PR TITLE
Fix #30: split Google Maps key into server-only + public embed keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,11 @@ BETTER_AUTH_URL=http://localhost:3000
 # TRUSTED_ORIGINS=https://rides.example.org
 EMAIL_USER=
 EMAIL_PASS=""
+# Google Maps keys (issue #30) — use TWO DIFFERENT Google Cloud keys:
+#  - NUXT_GOOGLE_MAPS_API_KEY: server-only, powers the Directions API distance
+#    estimate. Never ships to the browser. Restrict it by IP / API in Google Cloud.
+#  - NUXT_PUBLIC_GOOGLE_MAPS_API_KEY: client-visible, powers the map embed iframe.
+#    Ships to the browser by design — MUST be HTTP-referrer-restricted and scoped
+#    to the Maps Embed API in Google Cloud.
+NUXT_GOOGLE_MAPS_API_KEY=
 NUXT_PUBLIC_GOOGLE_MAPS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The variables the app actually reads:
 | `TRUSTED_ORIGINS` | optional | Comma-separated extra origins trusted for CSRF/Origin validation. |
 | `EMAIL_USER` | optional | Gmail address used to send notifications. |
 | `EMAIL_PASS` | optional | Gmail **app password** (not your account password — Gmail requires an app-specific password for SMTP). |
-| `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` | optional | Google Maps API key for the ride map / distance estimate features. Overrides `runtimeConfig.public.googleMapsApiKey`. |
+| `NUXT_GOOGLE_MAPS_API_KEY` | optional | **Server-only** Google Maps key for the Directions API distance/duration estimate. Never shipped to the browser. Overrides `runtimeConfig.googleMapsApiKey`. Restrict by IP/API in Google Cloud. |
+| `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` | optional | **Client-visible** Google Maps key for the ride map *embed* iframe. Ships to the browser by design, so it must be a **different** Cloud key that is **HTTP-referrer-restricted** and scoped to the Maps Embed API (issue #30). Overrides `runtimeConfig.public.googleMapsApiKey`. |
 
 Email is optional for local development: if `EMAIL_USER` / `EMAIL_PASS` are
 unset, sends fail and the failure is swallowed, so the app still runs and you

--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -193,6 +193,10 @@
     if (!ride.value) return ''
     const origin = encodeURIComponent(ride.value.pickupDisplay)
     const destination = encodeURIComponent(ride.value.dropoffDisplay)
+    // Issue #30: the PUBLIC key is correct here — the Maps Embed iframe runs in
+    // the browser and needs a client-visible key. It MUST be a DIFFERENT Google
+    // Cloud key from the server-only Directions key, HTTP-referrer-restricted
+    // and scoped to the Maps Embed API (owner action in Google Cloud Console).
     const apiKey = useRuntimeConfig().public.googleMapsApiKey
     return `https://www.google.com/maps/embed/v1/directions?key=${apiKey || ''}&origin=${origin}&destination=${destination}`
   })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,7 +4,17 @@ export default defineNuxtConfig({
   modules: ['@nuxt/ui', 'nuxt-cron'],
   css: ['./assets/css/main.css'],
   runtimeConfig: {
+    // Server-only (issue #30): the Directions API key used by the estimate
+    // endpoint. It NEVER reaches the client bundle. Overridden by the
+    // NUXT_GOOGLE_MAPS_API_KEY env var. This MUST be a DIFFERENT Google Cloud
+    // key from the public embed key below — a private, IP/API-restricted
+    // Directions key.
+    googleMapsApiKey: '', // Overridden by NUXT_GOOGLE_MAPS_API_KEY
     public: {
+      // Client-visible (issue #30): the Maps *embed* iframe key. This ships to
+      // the browser by design, so it MUST be HTTP-referrer-restricted in Google
+      // Cloud and scoped to the Maps Embed API only. Overridden by
+      // NUXT_PUBLIC_GOOGLE_MAPS_API_KEY.
       googleMapsApiKey: '', // Overridden by NUXT_PUBLIC_GOOGLE_MAPS_API_KEY
     },
   },

--- a/server/api/get/rides/estimate/[id].ts
+++ b/server/api/get/rides/estimate/[id].ts
@@ -10,7 +10,7 @@ interface EstimateResponse {
 
 export default defineEventHandler(async (event): Promise<EstimateResponse> => {
   const id = getRouterParam(event, 'id')
-  const config = useRuntimeConfig()
+  const config = useRuntimeConfig(event)
 
   if (!id) {
     throw createError({
@@ -54,7 +54,10 @@ export default defineEventHandler(async (event): Promise<EstimateResponse> => {
     }
   }
 
-  const apiKey = config.public.googleMapsApiKey
+  // Issue #30: use the SERVER-ONLY key for the Directions API call. The
+  // powerful Directions-capable key must never ship to the client bundle; only
+  // the map-embed iframe (app/pages/rides/[id].vue) uses the public key.
+  const apiKey = config.googleMapsApiKey
 
   if (!apiKey) {
     return {

--- a/tests/e2e/estimate-cache.test.ts
+++ b/tests/e2e/estimate-cache.test.ts
@@ -8,12 +8,16 @@ await bootShared()
 
 // Issue #14: GET /api/get/rides/estimate/:id must serve a cached
 // distance/duration from the Ride record instead of hitting the Google Maps
-// Directions API on every load. The test env has no API key, so a cache MISS
-// returns { error: 'Maps API Key not configured', ...nulls }. By populating the
-// cache columns directly in the DB, a cache HIT must instead return the cached
-// values with error: null — which is only possible once the endpoint reads and
-// serves the cache. (Before the fix the endpoint ignores the cache columns and
-// returns the "not configured" miss response, so this test fails.)
+// Directions API on every load. By populating the cache columns directly in the
+// DB, a cache HIT must return the cached values with error: null — which is only
+// possible once the endpoint reads and serves the cache. (Before the fix the
+// endpoint ignores the cache columns, so this test fails.)
+//
+// Note (issue #30): the harness now sets a bogus SERVER-ONLY Maps key, so a
+// cache MISS no longer returns 'Maps API Key not configured' — it gets past the
+// "not configured" gate and returns a live-attempt error instead. The
+// invalidation test below therefore asserts "values nulled + error present"
+// rather than the exact miss string.
 
 function db(): Database.Database {
   const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
@@ -111,12 +115,13 @@ describe('ride estimate caching (issue #14)', () => {
       body: { dropoffDisplay: 'A Completely New Destination, TX' },
     })
 
-    // With the cache cleared and no API key configured, we're back to the miss
-    // response rather than stale cached values.
+    // With the cache cleared, we're back to a miss: the stale cached values are
+    // gone (nulled) and the response carries an error. (The exact error string
+    // depends on the live Directions attempt; see the #30 note at the top.)
     const miss = await $fetch<EstimateResponse>(`/api/get/rides/estimate/${id}`, {
       headers: { cookie },
     })
-    expect(miss.error).toBe('Maps API Key not configured')
+    expect(miss.error).not.toBe(null)
     expect(miss.distance).toBe(null)
     expect(miss.durationValue).toBe(null)
   })

--- a/tests/e2e/estimate-cache.test.ts
+++ b/tests/e2e/estimate-cache.test.ts
@@ -8,16 +8,12 @@ await bootShared()
 
 // Issue #14: GET /api/get/rides/estimate/:id must serve a cached
 // distance/duration from the Ride record instead of hitting the Google Maps
-// Directions API on every load. By populating the cache columns directly in the
-// DB, a cache HIT must return the cached values with error: null — which is only
-// possible once the endpoint reads and serves the cache. (Before the fix the
-// endpoint ignores the cache columns, so this test fails.)
-//
-// Note (issue #30): the harness now sets a bogus SERVER-ONLY Maps key, so a
-// cache MISS no longer returns 'Maps API Key not configured' — it gets past the
-// "not configured" gate and returns a live-attempt error instead. The
-// invalidation test below therefore asserts "values nulled + error present"
-// rather than the exact miss string.
+// Directions API on every load. The test env has no server API key, so a cache
+// MISS returns { error: 'Maps API Key not configured', ...nulls }. By populating
+// the cache columns directly in the DB, a cache HIT must instead return the
+// cached values with error: null — which is only possible once the endpoint
+// reads and serves the cache. (Before the fix the endpoint ignores the cache
+// columns and returns the "not configured" miss response, so this test fails.)
 
 function db(): Database.Database {
   const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
@@ -115,13 +111,12 @@ describe('ride estimate caching (issue #14)', () => {
       body: { dropoffDisplay: 'A Completely New Destination, TX' },
     })
 
-    // With the cache cleared, we're back to a miss: the stale cached values are
-    // gone (nulled) and the response carries an error. (The exact error string
-    // depends on the live Directions attempt; see the #30 note at the top.)
+    // With the cache cleared and no server API key configured, we're back to the
+    // miss response rather than stale cached values.
     const miss = await $fetch<EstimateResponse>(`/api/get/rides/estimate/${id}`, {
       headers: { cookie },
     })
-    expect(miss.error).not.toBe(null)
+    expect(miss.error).toBe('Maps API Key not configured')
     expect(miss.distance).toBe(null)
     expect(miss.durationValue).toBe(null)
   })

--- a/tests/e2e/maps-key-split.test.ts
+++ b/tests/e2e/maps-key-split.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import Database from 'better-sqlite3'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Issue #30: the Google Maps Directions API key must NOT ship in the client
+// bundle. The estimate endpoint (server-side) must read the SERVER-ONLY key
+// (runtimeConfig.googleMapsApiKey / NUXT_GOOGLE_MAPS_API_KEY), not the public
+// embed key (runtimeConfig.public.googleMapsApiKey).
+//
+// The harness (tests/global-setup.ts) sets ONLY the server-only key
+// (NUXT_GOOGLE_MAPS_API_KEY) and leaves the public key unset. So:
+//   - AFTER the fix: the endpoint reads the (bogus-but-present) server key,
+//     gets PAST the "not configured" gate, and attempts the live Directions
+//     call — returning some OTHER error (REQUEST_DENIED / 'Failed to fetch
+//     estimate' if egress is blocked), never 'Maps API Key not configured'.
+//   - BEFORE the fix: the endpoint reads config.public.googleMapsApiKey, which
+//     is EMPTY, so it returns { error: 'Maps API Key not configured', ...nulls }.
+// This assertion therefore FAILS pre-fix and PASSES post-fix, and is robust to
+// whether the test environment has outbound network to Google.
+
+function firstRideId(): string {
+  const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
+  const conn = new Database(dbPath)
+  try {
+    const row = conn.prepare(`SELECT id FROM ride LIMIT 1`).get() as { id: string }
+    return row.id
+  } finally {
+    conn.close()
+  }
+}
+
+function clearCache(id: string): void {
+  const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
+  const conn = new Database(dbPath)
+  try {
+    conn
+      .prepare(
+        `UPDATE ride SET cachedDistanceText = NULL, cachedDistanceValue = NULL,
+           cachedDurationText = NULL, cachedDurationValue = NULL, estimatedAt = NULL
+         WHERE id = ?`
+      )
+      .run(id)
+  } finally {
+    conn.close()
+  }
+}
+
+interface EstimateResponse {
+  duration: string | null
+  distance: string | null
+  durationValue: number | null
+  distanceValue: number | null
+  error: string | null
+}
+
+const touched: string[] = []
+afterEach(() => {
+  while (touched.length) clearCache(touched.pop()!)
+})
+
+describe('maps key split (issue #30)', () => {
+  it('estimate endpoint uses the SERVER-only key, not the empty public key', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const id = firstRideId()
+    // Ensure a cache MISS so the endpoint reaches the key-gated branch.
+    clearCache(id)
+    touched.push(id)
+
+    const res = await $fetch<EstimateResponse>(`/api/get/rides/estimate/${id}`, {
+      headers: { cookie },
+    })
+
+    // Pre-fix (reads the empty public key) this is 'Maps API Key not configured'.
+    // Post-fix (reads the set server key) it is anything but that.
+    expect(res.error).not.toBe('Maps API Key not configured')
+  })
+})

--- a/tests/e2e/maps-key-split.test.ts
+++ b/tests/e2e/maps-key-split.test.ts
@@ -11,16 +11,17 @@ await bootShared()
 // (runtimeConfig.googleMapsApiKey / NUXT_GOOGLE_MAPS_API_KEY), not the public
 // embed key (runtimeConfig.public.googleMapsApiKey).
 //
-// The harness (tests/global-setup.ts) sets ONLY the server-only key
-// (NUXT_GOOGLE_MAPS_API_KEY) and leaves the public key unset. So:
-//   - AFTER the fix: the endpoint reads the (bogus-but-present) server key,
-//     gets PAST the "not configured" gate, and attempts the live Directions
-//     call — returning some OTHER error (REQUEST_DENIED / 'Failed to fetch
-//     estimate' if egress is blocked), never 'Maps API Key not configured'.
+// The harness (tests/global-setup.ts) sets ONLY the PUBLIC embed key
+// (NUXT_PUBLIC_GOOGLE_MAPS_API_KEY, a bogus value) and leaves the server key
+// UNSET. So:
+//   - AFTER the fix: the endpoint reads the EMPTY server key, short-circuits at
+//     the "not configured" gate, and makes NO outbound call — it returns
+//     { error: 'Maps API Key not configured', ...nulls }.
 //   - BEFORE the fix: the endpoint reads config.public.googleMapsApiKey, which
-//     is EMPTY, so it returns { error: 'Maps API Key not configured', ...nulls }.
-// This assertion therefore FAILS pre-fix and PASSES post-fix, and is robust to
-// whether the test environment has outbound network to Google.
+//     is the bogus-but-SET public value, gets PAST the gate, and attempts a
+//     live Directions call — so error is NOT 'Maps API Key not configured'.
+// This assertion therefore FAILS pre-fix and PASSES post-fix, and the green
+// (post-fix) suite makes ZERO outbound calls — it stays fully hermetic.
 
 function firstRideId(): string {
   const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
@@ -63,7 +64,7 @@ afterEach(() => {
 })
 
 describe('maps key split (issue #30)', () => {
-  it('estimate endpoint uses the SERVER-only key, not the empty public key', async () => {
+  it('estimate endpoint reads the empty SERVER key, not the set public key', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
     const id = firstRideId()
     // Ensure a cache MISS so the endpoint reaches the key-gated branch.
@@ -74,8 +75,8 @@ describe('maps key split (issue #30)', () => {
       headers: { cookie },
     })
 
-    // Pre-fix (reads the empty public key) this is 'Maps API Key not configured'.
-    // Post-fix (reads the set server key) it is anything but that.
-    expect(res.error).not.toBe('Maps API Key not configured')
+    // Post-fix: server key is empty → short-circuits at the gate, no network.
+    // Pre-fix: reads the SET public key → gets past the gate → NOT this string.
+    expect(res.error).toBe('Maps API Key not configured')
   })
 })

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -77,6 +77,13 @@ export default async function globalSetup() {
       // strict no-ops without this flag, which only the harness ever sets.
       TEST_HOOKS: '1',
       DISABLE_RATE_LIMIT: 'true',
+      // Issue #30: set ONLY the server-only Directions key; leave the public
+      // embed key (NUXT_PUBLIC_GOOGLE_MAPS_API_KEY) unset. This lets the
+      // maps-key-split regression test assert that the estimate endpoint reads
+      // the private key (config.googleMapsApiKey), not the empty public one.
+      // The value is a bogus placeholder — Google rejects it, so no real quota
+      // is used; the endpoint still gets PAST the "not configured" gate.
+      NUXT_GOOGLE_MAPS_API_KEY: 'test-server-directions-key-not-real',
     },
     stdio: 'inherit',
   })

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -77,13 +77,14 @@ export default async function globalSetup() {
       // strict no-ops without this flag, which only the harness ever sets.
       TEST_HOOKS: '1',
       DISABLE_RATE_LIMIT: 'true',
-      // Issue #30: set ONLY the server-only Directions key; leave the public
-      // embed key (NUXT_PUBLIC_GOOGLE_MAPS_API_KEY) unset. This lets the
-      // maps-key-split regression test assert that the estimate endpoint reads
-      // the private key (config.googleMapsApiKey), not the empty public one.
-      // The value is a bogus placeholder — Google rejects it, so no real quota
-      // is used; the endpoint still gets PAST the "not configured" gate.
-      NUXT_GOOGLE_MAPS_API_KEY: 'test-server-directions-key-not-real',
+      // Issue #30: set ONLY the PUBLIC embed key and leave the server-only
+      // Directions key (NUXT_GOOGLE_MAPS_API_KEY) UNSET. This keeps the suite
+      // hermetic: post-fix the estimate endpoint reads the empty *server* key,
+      // short-circuits at the "not configured" gate, and makes NO outbound call.
+      // The bogus public value lets the maps-key-split regression test prove the
+      // endpoint no longer reads config.public (pre-fix it would read this set
+      // public key, get past the gate, and attempt a live call).
+      NUXT_PUBLIC_GOOGLE_MAPS_API_KEY: 'test-public-embed-key-not-real',
     },
     stdio: 'inherit',
   })


### PR DESCRIPTION
## What was broken

The Google Maps API key was exposed in the client bundle via **public** runtime config (`runtimeConfig.public.googleMapsApiKey`). The server-side estimate endpoint (`server/api/get/rides/estimate/[id].ts`) read that *public* key to call the Directions API even though it runs server-side, which meant the powerful Directions-capable key was shipped to the browser where anyone could scrape it and burn quota/billing.

## What changed (app-side split only — no key rotation)

- **`nuxt.config.ts`** (⚠️ **RISK FILE — human review mandatory**): added a private, server-only runtime config key alongside the existing public one:
  ```ts
  runtimeConfig: {
    googleMapsApiKey: '',            // server-only, NUXT_GOOGLE_MAPS_API_KEY
    public: {
      googleMapsApiKey: '',          // client embed, NUXT_PUBLIC_GOOGLE_MAPS_API_KEY
    },
  }
  ```
  Nuxt maps `NUXT_GOOGLE_MAPS_API_KEY` → `runtimeConfig.googleMapsApiKey` and `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` → `runtimeConfig.public.googleMapsApiKey`. Only `public.*` is serialized into the client bundle, so the server-only key never reaches the browser.
- **`server/api/get/rides/estimate/[id].ts`**: reads `useRuntimeConfig(event).googleMapsApiKey` (server-only) for the Directions call instead of `config.public.googleMapsApiKey`. The graceful `error: 'Maps API Key not configured'` fallback is preserved when the key is empty.
- **`app/pages/rides/[id].vue`**: unchanged behavior — the map-embed iframe keeps reading the **public** key (a client-visible embed key is correct by design). Added a code comment.
- **`.env.example` / `README.md`**: document both `NUXT_GOOGLE_MAPS_API_KEY` (server, Directions) and `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` (client, embed — must be referrer-restricted).

## Verification

**Regression test:** `tests/e2e/maps-key-split.test.ts` — *"estimate endpoint reads the empty SERVER key, not the set public key."* The harness (`tests/global-setup.ts`) sets **only** the bogus `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` and leaves the server key **unset**, then the test asserts a cache-miss estimate returns exactly `'Maps API Key not configured'`.

- **Post-fix:** the endpoint reads the *empty server* key → short-circuits at the "not configured" gate → returns the expected string and makes **no outbound call** (the green suite stays fully hermetic / zero egress).
- **Pre-fix failing assertion** (observed by temporarily reverting the endpoint to `config.public.googleMapsApiKey`): the endpoint reads the *set public* key, gets past the gate, and attempts a live Directions call:
  ```
  AssertionError: expected 'REQUEST_DENIED' to be 'Maps API Key not configured'
   ❯ tests/e2e/maps-key-split.test.ts:80:23
  ```

**Why the harness was inverted (review follow-up):** an earlier revision set the bogus key on the *server* var, which made cache-miss estimates fire a real outbound HTTPS call. On a blackhole-firewall CI (silent SYN drop) ofetch has no timeout, so the connect would hang until the 30s `testTimeout` aborted → suite RED purely from network posture. Setting the bogus value on the *public* var instead keeps the previously-hermetic suite hermetic and lets the exact assertion be used.

`tests/e2e/estimate-cache.test.ts` is unchanged in behavior — its `expect(miss.error).toBe('Maps API Key not configured')` assertion still holds (server key empty → deterministic miss, no network).

Also confirmed by grep: no `config.public.googleMapsApiKey` read remains anywhere in `server/`.

**Suite:** `pnpm test` → 35 files, 130 tests passed, zero outbound Google calls. **Build:** `pnpm build` → success.

## Deployment note (breaking config change for the operator)

Because the estimate endpoint now reads a **separate** server variable, a live deployment that only sets `NUXT_PUBLIC_GOOGLE_MAPS_API_KEY` will get `'Maps API Key not configured'` from the estimate feature until the operator **also** sets `NUXT_GOOGLE_MAPS_API_KEY`. This is intended, but the owner must set the new server var (alongside key rotation) or the distance/duration estimate silently stops working.

## Residual OWNER action (out of scope — Google Cloud Console)

This split only stops the powerful key from shipping to the client; it does **not** rotate or restrict anything in Google Cloud. The owner must:
1. Provision **two different** Google Cloud API keys.
2. Restrict the **server** Directions key by IP/API.
3. **HTTP-referrer-restrict** the **public** embed key and scope it to the Maps Embed API.
4. Assume the currently-exposed key is compromised (public repo + public bundle) and rotate it.

Fixes #30