### PR TITLE
Fix #25: surface SMTP send failures instead of swallowing them

### DIFF
--- a/server/api/_test/arm-fault.post.ts
+++ b/server/api/_test/arm-fault.post.ts
@@ -1,0 +1,31 @@
+import { armFault, disarmFault } from '../../utils/testHooks'
+
+// Test-only endpoint (issues #25, #45). Arms or disarms a context-free fault
+// label so an e2e test can force a failure inside code that has no request
+// event of its own — e.g. sendEmail() in better-auth's sendVerificationOTP hook
+// (issue #25), which the OTP-send route surfaces as an error.
+//
+// Hard-gated: returns 404 unless TEST_HOOKS=1 (only the harness sets it), so it
+// does not exist in production. Still behind the global auth middleware (admin).
+//
+// Body: { label: string, disarm?: boolean }. The fault stays armed on the
+// server until disarmed, so a test must disarm it after use. Because the e2e
+// suite runs test files serially (vitest fileParallelism: false), no other
+// request overlaps the armed window.
+export default defineEventHandler(async (event) => {
+  if (process.env.TEST_HOOKS !== '1') {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  const body = await readBody(event).catch(() => ({}))
+  const label = typeof body?.label === 'string' ? body.label : undefined
+  if (!label) {
+    throw createError({ statusCode: 400, statusMessage: 'label required' })
+  }
+
+  const disarm = body?.disarm === true
+  if (disarm) disarmFault(label)
+  else armFault(label)
+
+  return { ok: true, label, armed: !disarm }
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -59,7 +59,16 @@ export const auth = betterAuth({
   plugins: [
     emailOTP({
       async sendVerificationOTP({ email, otp, type }) {
-        sendEmail(email, 'OTP', `${otp}`)
+        // Surface send failures instead of swallowing them (issue #25): if the
+        // OTP email never sent, the user can't complete sign-in, so report the
+        // failure rather than a false success. `sendEmail` returns false on a
+        // failed send (and logs the error).
+        const sent = await sendEmail(email, 'OTP', `${otp}`)
+        if (!sent) {
+          throw new APIError('INTERNAL_SERVER_ERROR', {
+            message: 'Failed to send verification code. Please try again later.',
+          })
+        }
       },
     }),
   ],

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer'
+import { isFaultArmed } from './testHooks'
 
 const transporter = nodemailer.createTransport({
   service: 'gmail',
@@ -8,7 +9,28 @@ const transporter = nodemailer.createTransport({
   },
 })
 
-export const sendEmail = async (to: string, subject: string, html: string) => {
+/**
+ * Send an email. Returns `true` when the message was sent, `false` when the
+ * send threw (the error is still logged). Callers on user-facing paths (OTP
+ * send) should surface a `false`; background notifications may ignore it and
+ * stay fire-and-forget (issue #25).
+ *
+ * Test-only seam (issues #25, #45): the e2e harness has no SMTP, so under
+ * `TEST_HOOKS=1` this is a strict no-op that reports success WITHOUT sending —
+ * `loginAs()` and every normal flow keep working. A test can force a reported
+ * failure by arming the `'email-send'` fault (see testHooks.ts), which makes
+ * this return `false` so the failure-surfacing paths can be exercised.
+ * In production (`TEST_HOOKS` unset) none of this runs: real sends always occur.
+ */
+export const sendEmail = async (
+  to: string,
+  subject: string,
+  html: string,
+): Promise<boolean> => {
+  if (process.env.TEST_HOOKS === '1') {
+    return !isFaultArmed('email-send')
+  }
+
   try {
     await transporter.sendMail({
       from: process.env.EMAIL_USER,
@@ -16,7 +38,9 @@ export const sendEmail = async (to: string, subject: string, html: string) => {
       subject,
       html,
     })
+    return true
   } catch (error) {
     console.error('Error sending email:', error)
+    return false
   }
 }

--- a/server/utils/testHooks.ts
+++ b/server/utils/testHooks.ts
@@ -45,3 +45,12 @@ export function maybeFault(label: string, event?: H3Event): void {
     throw createError({ statusCode: 500, statusMessage: `injected test fault: ${label}` })
   }
 }
+
+// Non-throwing variant of the context-free (armed) fault check. Lets code that
+// reports failure via a return value — rather than by throwing — observe an
+// armed fault (e.g. sendEmail returning `false` on the 'email-send' fault, #25).
+// Strict no-op in production: always `false` unless TEST_HOOKS=1.
+export function isFaultArmed(label: string): boolean {
+  if (process.env.TEST_HOOKS !== '1') return false
+  return armedFaults.has(label)
+}

--- a/tests/e2e/otp-send-failure.test.ts
+++ b/tests/e2e/otp-send-failure.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { fetch as appFetch } from '@nuxt/test-utils/e2e'
 import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
@@ -28,16 +28,30 @@ await bootShared()
 // before-hook rejects unknown users before any OTP is issued).
 const SEEDED_EMAIL = 'bob@example.com'
 
-async function armEmailFault(disarm = false): Promise<void> {
-  // Requires an admin session (the _test route is behind the auth middleware).
-  const cookie = await loginAs('reachtusharwani@gmail.com')
+// Admin cookie captured ONCE, before any fault is armed. Arm AND disarm must be
+// independent of loginAs()/OTP-send: routing them through a fresh login would
+// itself hit send-verification-otp, so if the session cache were cold while the
+// 'email-send' fault is armed (e.g. a resetDb()/clearSessionCache() from #62/#72
+// landing mid-test), that login would 500 on the armed fault, the disarm would
+// throw, the global fault would stay armed, and every later loginAs in the
+// serial suite would cascade-fail. Capturing the cookie up front and POSTing
+// arm-fault directly with it keeps both arm and disarm unblockable.
+let adminCookie: string
+
+beforeAll(async () => {
+  adminCookie = await loginAs('reachtusharwani@gmail.com')
+})
+
+async function setEmailFault(armed: boolean): Promise<void> {
+  // The _test route is behind the auth middleware, so it needs the admin cookie
+  // — but never a fresh login (see the note above).
   const res = await appFetch('/api/_test/arm-fault', {
     method: 'POST',
-    headers: { cookie, 'content-type': 'application/json' },
-    body: JSON.stringify({ label: 'email-send', disarm }),
+    headers: { cookie: adminCookie, 'content-type': 'application/json' },
+    body: JSON.stringify({ label: 'email-send', disarm: !armed }),
   })
   if (res.status !== 200) {
-    throw new Error(`arm-fault(${disarm ? 'disarm' : 'arm'}) failed: ${res.status}`)
+    throw new Error(`arm-fault(${armed ? 'arm' : 'disarm'}) failed: ${res.status}`)
   }
 }
 
@@ -56,12 +70,13 @@ async function sendOtp(email: string): Promise<number> {
 
 describe('OTP send surfaces email failures (#25)', () => {
   afterEach(async () => {
-    // Never leak the armed fault into other tests / files.
-    await armEmailFault(true)
+    // Always runs, using the pre-captured admin cookie, so the global fault can
+    // never leak into other tests / files even if an assertion above threw.
+    await setEmailFault(false)
   })
 
   it('reports a failure when the OTP email cannot be sent', async () => {
-    await armEmailFault()
+    await setEmailFault(true)
     const status = await sendOtp(SEEDED_EMAIL)
     // Pre-fix: the swallowed send still returns 200 (false success) -> FAILS.
     // Post-fix: the hook throws on a failed send -> non-2xx.

--- a/tests/e2e/otp-send-failure.test.ts
+++ b/tests/e2e/otp-send-failure.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Regression test for issue #25: sendEmail used to swallow every SMTP failure
+// (just console.error), so POST /api/auth/email-otp/send-verification-otp always
+// reported success even when the OTP email never sent — a false positive that
+// left the user unable to sign in.
+//
+// The fix makes sendEmail return a success/failure boolean, and the OTP hook
+// (sendVerificationOTP) throws an APIError when the send fails, so the endpoint
+// reports the failure instead of a false success.
+//
+// How this is pinned without SMTP (revert-check shape): the 'email-send' fault
+// (testHooks.ts, gated on TEST_HOOKS) forces sendEmail to return false. We arm
+// it via the gated _test/arm-fault endpoint, hit the OTP-send route, and assert
+// a non-2xx response.
+//   - PRE-FIX: sendVerificationOTP fire-and-forgets sendEmail and never inspects
+//     the result, so the endpoint still returns 200 -> this assertion FAILS.
+//   - POST-FIX: sendEmail returns false -> the hook throws -> non-2xx.
+// The un-faulted case (and the whole loginAs-dependent suite) proves a normal
+// OTP send still succeeds.
+
+// A seeded account exists so the OTP send reaches the email step (the auth
+// before-hook rejects unknown users before any OTP is issued).
+const SEEDED_EMAIL = 'bob@example.com'
+
+async function armEmailFault(disarm = false): Promise<void> {
+  // Requires an admin session (the _test route is behind the auth middleware).
+  const cookie = await loginAs('reachtusharwani@gmail.com')
+  const res = await appFetch('/api/_test/arm-fault', {
+    method: 'POST',
+    headers: { cookie, 'content-type': 'application/json' },
+    body: JSON.stringify({ label: 'email-send', disarm }),
+  })
+  if (res.status !== 200) {
+    throw new Error(`arm-fault(${disarm ? 'disarm' : 'arm'}) failed: ${res.status}`)
+  }
+}
+
+async function sendOtp(email: string): Promise<number> {
+  const res = await appFetch('/api/auth/email-otp/send-verification-otp', {
+    method: 'POST',
+    // Unique IP so the per-IP rate limiter doesn't interfere.
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': `10.77.0.${Math.floor(Math.random() * 250) + 1}`,
+    },
+    body: JSON.stringify({ email, type: 'sign-in' }),
+  })
+  return res.status
+}
+
+describe('OTP send surfaces email failures (#25)', () => {
+  afterEach(async () => {
+    // Never leak the armed fault into other tests / files.
+    await armEmailFault(true)
+  })
+
+  it('reports a failure when the OTP email cannot be sent', async () => {
+    await armEmailFault()
+    const status = await sendOtp(SEEDED_EMAIL)
+    // Pre-fix: the swallowed send still returns 200 (false success) -> FAILS.
+    // Post-fix: the hook throws on a failed send -> non-2xx.
+    expect(status).toBeGreaterThanOrEqual(400)
+  })
+
+  it('a normal OTP send (no fault) still succeeds', async () => {
+    // Fault not armed: sendEmail reports success, so the endpoint returns 2xx —
+    // this is exactly what loginAs() relies on across the whole suite.
+    const status = await sendOtp(SEEDED_EMAIL)
+    expect(status).toBeLessThan(400)
+  })
+})


### PR DESCRIPTION
## What was broken

`sendEmail` swallowed every SMTP failure (only `console.error`) and returned nothing, so user-facing actions reported success even when the email never sent. In particular, `POST /api/auth/email-otp/send-verification-otp` returned 200 even when the OTP email failed — a false positive that left the user unable to sign in.

## What changed

- **`server/utils/email.ts`** — `sendEmail` now returns `Promise<boolean>`: `true` when sent, `false` when the send threw (the error is still logged).
- **`server/utils/auth.ts` (risk: auth OTP path)** — `sendVerificationOTP` now `await`s `sendEmail` and throws an `APIError('INTERNAL_SERVER_ERROR', ...)` when the send fails, so the OTP-send endpoint reports the real failure.
- **Background ride notifications stay fire-and-forget** (`server/utils/notification.ts`, `signup`/`unsignup`/`put rides`/`volunteers` welcome email) — they ignore the boolean and never throw into the request path, per #32. No functional change to those call sites.
- **Test-only bypass (strict prod no-op):** under `TEST_HOOKS=1` (only the e2e harness sets it) `sendEmail` is a strict no-op that reports success *without* sending, so `loginAs()` and every normal flow keep working with no SMTP. A test forces a failure by arming the `'email-send'` fault (reused `armFault`/`disarmFault` + new non-throwing `isFaultArmed` in `testHooks.ts`) via the new gated `POST /api/_test/arm-fault` endpoint (404 in prod, behind admin auth). When `TEST_HOOKS` is unset, none of this runs — production always really sends and surfaces real failures.

### Note on the admin "send test email" path
The owner decision mentions wiring an admin "send test email" endpoint. Grepping `sendEmail` across the codebase shows **no such endpoint exists** (the admin `notifications.vue` page only edits/toggles templates; there is no test-email button or route). Nothing to wire; not created here to avoid scope creep.

## Verification

- **Regression test:** `tests/e2e/otp-send-failure.test.ts`
  - `reports a failure when the OTP email cannot be sent` — arms the `email-send` fault, POSTs `send-verification-otp` for a seeded user, asserts a non-2xx response.
  - `a normal OTP send (no fault) still succeeds` — asserts 2xx (this is exactly what `loginAs` relies on).
- **Pre-fix FAIL (revert-check):** with `email.ts`/`auth.ts` reverted, the failure test fails with:
  `AssertionError: expected 200 to be greater than or equal to 400` (the swallowed send reports a false success). Post-fix it passes.
- **Full suite:** `pnpm test` → **35 files, 131 tests passed** (includes the new test; `loginAs` and the whole auth-gated suite still pass).
- **Build:** `pnpm build` succeeds.

Fixes #25