### PR TITLE
Fix #13: real server-side pagination on the list endpoints

### DIFF
--- a/app/pages/people.vue
+++ b/app/pages/people.vue
@@ -10,17 +10,63 @@
 
   const { data: session } = await authClient.useSession(useFetch)
 
-  // --- Data Fetching ---
-  const { data: volunteers, refresh: refreshVolunteers } = await useFetch('/api/get/volunteers')
-  const { data: clients, refresh: refreshClients } = await useFetch('/api/get/clients')
-  const { data: admins, refresh: refreshAdmins } = await useFetch('/api/get/admins')
-
   // --- State ---
   const activeTab = ref('volunteers')
   const search = ref('')
   const volunteerStatusFilter = ref('All')
 
   const volunteerStatusOptions = ['All', 'AVAILABLE', 'UNAVAILABLE']
+
+  // --- Server-side pagination + search (issue #13) ---
+  // The roster endpoints are paginated, and search / status filtering now run on
+  // the server so they compose with pagination (client-side filtering would only
+  // filter the current page). Search is debounced and shared across the tabs.
+  const PAGE_SIZE = 20
+  const volunteerPage = ref(1)
+  const clientPage = ref(1)
+  const adminPage = ref(1)
+
+  const debouncedSearch = ref('')
+  const applyDebouncedSearch = debounce((value: string) => {
+    debouncedSearch.value = value
+  }, 300)
+  watch(search, (value) => applyDebouncedSearch(value))
+
+  const searchParam = computed(() => debouncedSearch.value || undefined)
+
+  // --- Data Fetching (reactive query -> auto refetch on page/search change) ---
+  const { data: volunteersData, refresh: refreshVolunteers } = await useFetch('/api/get/volunteers', {
+    query: {
+      page: volunteerPage,
+      pageSize: PAGE_SIZE,
+      search: searchParam,
+      status: computed(() =>
+        volunteerStatusFilter.value !== 'All' ? volunteerStatusFilter.value : undefined
+      ),
+    },
+  })
+  const { data: clientsData, refresh: refreshClients } = await useFetch('/api/get/clients', {
+    query: { page: clientPage, pageSize: PAGE_SIZE, search: searchParam },
+  })
+  const { data: adminsData, refresh: refreshAdmins } = await useFetch('/api/get/admins', {
+    query: { page: adminPage, pageSize: PAGE_SIZE, search: searchParam },
+  })
+
+  const volunteers = computed(() => volunteersData.value?.items ?? [])
+  const clients = computed(() => clientsData.value?.items ?? [])
+  const admins = computed(() => adminsData.value?.items ?? [])
+  const volunteerTotal = computed(() => volunteersData.value?.total ?? 0)
+  const clientTotal = computed(() => clientsData.value?.total ?? 0)
+  const adminTotal = computed(() => adminsData.value?.total ?? 0)
+
+  // Any query change returns the affected tab to page 1.
+  watch([debouncedSearch, volunteerStatusFilter], () => {
+    volunteerPage.value = 1
+  })
+  watch(debouncedSearch, () => {
+    clientPage.value = 1
+    adminPage.value = 1
+  })
 
   // --- Schemas ---
   const volunteerSchema = z.object({
@@ -99,43 +145,8 @@
     },
   })
 
-  // --- Computed ---
-  const filteredVolunteers = computed(() => {
-    if (!volunteers.value) return []
-
-    let result = volunteers.value
-
-    // Status Filter
-    if (volunteerStatusFilter.value !== 'All') {
-      result = result.filter((v: any) => v.status === volunteerStatusFilter.value)
-    }
-
-    // Search Filter
-    if (search.value) {
-      const q = search.value.toLowerCase()
-      result = result.filter(
-        (v: any) => v.user.name.toLowerCase().includes(q) || (v.user.email?.toLowerCase().includes(q) ?? false)
-      )
-    }
-
-    return result
-  })
-
-  const filteredClients = computed(() => {
-    if (!clients.value) return []
-    const q = search.value.toLowerCase()
-    return clients.value.filter(
-      (c: any) => c.user.name.toLowerCase().includes(q) || (c.user.email?.toLowerCase().includes(q) ?? false)
-    )
-  })
-
-  const filteredAdmins = computed(() => {
-    if (!admins.value) return []
-    const q = search.value.toLowerCase()
-    return admins.value.filter(
-      (a: any) => a.name.toLowerCase().includes(q) || (a.email?.toLowerCase().includes(q) ?? false)
-    )
-  })
+  // Search / status filtering is applied server-side (issue #13) so it composes
+  // with pagination; the tables bind directly to the returned page.
 
   const items = [
     {
@@ -491,13 +502,34 @@
 
     <UTabs v-model="activeTab" :items="items" class="w-full">
       <template #volunteers>
-        <UTable :data="filteredVolunteers" :columns="volunteerColumns" class="mt-4" />
+        <UTable :data="volunteers" :columns="volunteerColumns" class="mt-4" />
+        <div v-if="volunteerTotal > PAGE_SIZE" class="mt-4 flex justify-end">
+          <UPagination
+            v-model:page="volunteerPage"
+            :total="volunteerTotal"
+            :items-per-page="PAGE_SIZE"
+          />
+        </div>
       </template>
       <template #clients>
-        <UTable :data="filteredClients" :columns="clientColumns" class="mt-4" />
+        <UTable :data="clients" :columns="clientColumns" class="mt-4" />
+        <div v-if="clientTotal > PAGE_SIZE" class="mt-4 flex justify-end">
+          <UPagination
+            v-model:page="clientPage"
+            :total="clientTotal"
+            :items-per-page="PAGE_SIZE"
+          />
+        </div>
       </template>
       <template #admins>
-        <UTable :data="filteredAdmins" :columns="adminColumns" class="mt-4" />
+        <UTable :data="admins" :columns="adminColumns" class="mt-4" />
+        <div v-if="adminTotal > PAGE_SIZE" class="mt-4 flex justify-end">
+          <UPagination
+            v-model:page="adminPage"
+            :total="adminTotal"
+            :items-per-page="PAGE_SIZE"
+          />
+        </div>
       </template>
     </UTabs>
 

--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -72,10 +72,15 @@
       editState.notes = ride.value.notes || ''
       editState.totalRideTime = ride.value.totalRideTime || 0
 
-      // Handle volunteer object binding for USelectMenu
+      // Handle volunteer object binding for USelectMenu. The options endpoint
+      // only lists AVAILABLE volunteers (issue #13), so a currently-assigned
+      // volunteer who is now UNAVAILABLE won't be in it — fall back to the
+      // ride's own volunteer record so the assignee still shows (and isn't
+      // silently dropped on save).
       if (ride.value.volunteerId) {
         const found = volunteers.value?.find((v: any) => v.id === ride.value.volunteerId)
-        editState.volunteerId = found ? { label: found.name, value: found.id } : undefined
+        const label = found?.name || ride.value.volunteer?.user?.name || 'Assigned volunteer'
+        editState.volunteerId = { label, value: ride.value.volunteerId }
       } else {
         editState.volunteerId = undefined // or { label: 'Unassigned', value: '' } if preferred
       }

--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -9,7 +9,10 @@
   const { data: session } = await authClient.useSession(useFetch)
   const { data: ride, status, refresh: refreshRide } = await useFetch(`/api/get/rides/byId/${id}`)
   const { data: estimate } = await useFetch(`/api/get/rides/estimate/${id}`)
-  const { data: volunteers } = await useFetch('/api/get/volunteers')
+  // The assignment picker needs the full assignable roster, not a page — the
+  // roster endpoint is paginated now (issue #13), so use the bounded options
+  // endpoint (AVAILABLE volunteers, minimal { id, name } shape).
+  const { data: volunteers } = await useFetch('/api/get/volunteers/options')
 
   const isEditModalOpen = ref(false)
   const isCompleteModalOpen = ref(false)
@@ -72,7 +75,7 @@
       // Handle volunteer object binding for USelectMenu
       if (ride.value.volunteerId) {
         const found = volunteers.value?.find((v: any) => v.id === ride.value.volunteerId)
-        editState.volunteerId = found ? { label: found.user.name, value: found.id } : undefined
+        editState.volunteerId = found ? { label: found.name, value: found.id } : undefined
       } else {
         editState.volunteerId = undefined // or { label: 'Unassigned', value: '' } if preferred
       }
@@ -208,7 +211,7 @@
   const volunteerOptions = computed(() => {
     if (!volunteers.value) return []
     const list = volunteers.value.map((v: any) => ({
-      label: v.user?.name || 'Unknown Volunteer',
+      label: v.name || 'Unknown Volunteer',
       value: v.id,
     }))
     return [{ label: 'Unassigned', value: '' }, ...list]

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -14,8 +14,11 @@
   const { data: session } = await authClient.useSession(useFetch)
   const isAdmin = computed(() => session.value?.user?.role === 'ADMIN')
 
-  const { data: clients } = await useFetch('/api/get/clients')
-  const { data: volunteers } = await useFetch('/api/get/volunteers')
+  // Dropdowns need the full (bounded) roster, not a page — the list endpoints
+  // are now paginated (issue #13), so the pickers use dedicated options
+  // endpoints that return a minimal { id, name(, homeAddress) } shape.
+  const { data: clients } = await useFetch('/api/get/clients/options')
+  const { data: volunteers } = await useFetch('/api/get/volunteers/options')
 
   const search = ref('')
   const savedSort = useCookie<string>('ride-sort', { default: () => 'desc' })
@@ -24,6 +27,21 @@
   watch(sort, (newVal) => {
     savedSort.value = newVal
   })
+
+  // --- Server-side pagination (issue #13) ---
+  // The rides list used to load the entire table and filter it client-side.
+  // Filtering, sorting and pagination now all happen on the server, so the
+  // table binds directly to the returned page. Debounce search so typing
+  // doesn't fire a request per keystroke.
+  const PAGE_SIZE = 20
+  const page = ref(1)
+  const debouncedSearch = ref('')
+  const applyDebouncedSearch = debounce((value: string) => {
+    debouncedSearch.value = value
+  }, 300)
+  watch(search, (value) => applyDebouncedSearch(value))
+  const startDate = ref('')
+  const endDate = ref('')
 
   // Persisted State
   const savedActiveFilters = useCookie<{ label: string; value: string }[]>('ride-active-filters', {
@@ -49,13 +67,42 @@
     sanitizeSavedFilters(savedExcludedFilters.value, knownFilterValues)
   )
 
-  // Use watch to refetch when sort changes
+  // Include/exclude filter chips are sent to the backend as comma-separated
+  // values (e.g. "status:CREATED,assign:ME"); the server applies them so they
+  // compose with pagination instead of only filtering the current page (#13).
+  const includeParam = computed(() =>
+    activeFilters.value.map((f) => f.value).join(',')
+  )
+  const excludeParam = computed(() =>
+    excludedFilters.value.map((f) => f.value).join(',')
+  )
+
+  // useFetch watches these reactive query refs and refetches automatically, so
+  // changing page / sort / search / filters re-queries the server for that page.
   const {
-    data: rides,
+    data: ridesData,
     status,
     refresh: refreshRides,
   } = await useFetch('/api/get/rides', {
-    query: { sort },
+    query: {
+      sort,
+      page,
+      pageSize: PAGE_SIZE,
+      search: computed(() => debouncedSearch.value || undefined),
+      startDate: computed(() => startDate.value || undefined),
+      endDate: computed(() => endDate.value || undefined),
+      include: computed(() => includeParam.value || undefined),
+      exclude: computed(() => excludeParam.value || undefined),
+    },
+  })
+
+  const rides = computed(() => ridesData.value?.items ?? [])
+  const total = computed(() => ridesData.value?.total ?? 0)
+
+  // Any filter/search/sort change should return to the first page so results
+  // aren't hidden on a page that no longer exists.
+  watch([debouncedSearch, startDate, endDate, includeParam, excludeParam, sort], () => {
+    page.value = 1
   })
 
   // Sync state back to cookies
@@ -74,8 +121,6 @@
     { deep: true }
   )
 
-  const startDate = ref('')
-  const endDate = ref('')
   const isCreateModalOpen = ref(false)
 
   const filterOptions = computed(() => {
@@ -168,7 +213,7 @@
   const volunteerOptions = computed(() => {
     if (!volunteers.value) return []
     const list = volunteers.value.map((v: any) => ({
-      label: v.user?.name || 'Unknown Volunteer',
+      label: v.name || 'Unknown Volunteer',
       value: v.id,
     }))
     return [{ label: 'Unassigned', value: '' }, ...list]
@@ -210,82 +255,9 @@
     dropoffSearch.value = ''
   }
 
-  const filteredRides = computed(() => {
-    if (!rides.value) return []
-
-    let result = rides.value
-
-    // Consolidated Filter Logic (OR Condition for Inclusion)
-    if (activeFilters.value.length > 0) {
-      result = result.filter((ride: any) => {
-        return activeFilters.value.some((filter) => {
-          const val = filter.value
-
-          if (val.startsWith('status:')) {
-            const status = val.replace('status:', '')
-            return ride.status === status
-          }
-
-          if (val === 'assign:ME') {
-            const myId = session.value?.user?.id
-            return !!(myId && ride.volunteer?.userId === myId)
-          }
-
-          return false
-        })
-      })
-    }
-
-    // Exclusion Filter Logic (AND NOT Condition)
-    if (excludedFilters.value.length > 0) {
-      result = result.filter((ride: any) => {
-        // Must NOT match ANY of the excluded filters
-        return !excludedFilters.value.some((filter) => {
-          const val = filter.value
-
-          if (val.startsWith('status:')) {
-            const status = val.replace('status:', '')
-            return ride.status === status
-          }
-
-          if (val === 'assign:ME') {
-            const myId = session.value?.user?.id
-            return !!(myId && ride.volunteer?.userId === myId)
-          }
-
-          return false
-        })
-      })
-    }
-
-    // Date Range Filter
-    if (startDate.value) {
-      result = result.filter(
-        (ride: any) => new Date(ride.scheduledTime) >= new Date(startDate.value)
-      )
-    }
-    if (endDate.value) {
-      const end = new Date(endDate.value)
-      end.setDate(end.getDate() + 1)
-      result = result.filter((ride: any) => new Date(ride.scheduledTime) < end)
-    }
-
-    // Search Filter
-    if (search.value) {
-      const q = search.value.toLowerCase()
-      result = result.filter((ride: any) => {
-        return (
-          ride.id.toLowerCase().includes(q) ||
-          ride.client?.user?.name?.toLowerCase().includes(q) ||
-          ride.volunteer?.user?.name?.toLowerCase().includes(q) ||
-          ride.pickupDisplay?.toLowerCase().includes(q) ||
-          ride.dropoffDisplay?.toLowerCase().includes(q)
-        )
-      })
-    }
-
-    return result
-  })
+  // Filtering, searching, date-range and sorting are all applied server-side
+  // (issue #13) so they compose with pagination. The table binds directly to
+  // the returned page (`rides`) — no client-side filtering pass.
 
   const columns: TableColumn<any>[] = [
     {
@@ -444,12 +416,20 @@
     </div>
 
     <UTable
-      :data="filteredRides"
+      :data="rides"
       :columns="columns"
       :loading="status === 'pending'"
       class="w-full cursor-pointer"
       @select="onSelect"
     />
+
+    <div v-if="total > PAGE_SIZE" class="mt-4 flex justify-end">
+      <UPagination
+        v-model:page="page"
+        :total="total"
+        :items-per-page="PAGE_SIZE"
+      />
+    </div>
 
     <!-- Create Ride Modal -->
     <UModal v-model:open="isCreateModalOpen" title="Create New Ride">
@@ -459,7 +439,7 @@
             <UFormField label="Client" name="clientId">
               <USelect
                 v-model="state.clientId"
-                :items="clients?.map((c) => ({ label: c.user.name, value: c.id })) || []"
+                :items="clients?.map((c) => ({ label: c.name, value: c.id })) || []"
                 placeholder="Select a client"
                 class="w-full"
               />

--- a/server/api/get/admins/index.ts
+++ b/server/api/get/admins/index.ts
@@ -1,18 +1,36 @@
+import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
+import { getPageParams, getStringParam } from '../../../utils/pagination'
 
 export default defineEventHandler(async (event) => {
   // Admin roster is management data / PII (issue #41). Consumer: people.vue,
   // an admin-only page (volunteers are redirected by the route guard).
   requireAdmin(event)
 
+  const { page, pageSize, skip, take } = getPageParams(event)
+  const search = getStringParam(event, 'search')
+
   // Soft delete (issue #27): hide archived admins from the active roster.
-  return await prisma.user.findMany({
-    where: {
-      role: 'ADMIN',
-      deletedAt: null,
-    },
-    orderBy: {
-      name: 'asc',
-    },
-  })
+  const where: Prisma.UserWhereInput = {
+    role: 'ADMIN',
+    deletedAt: null,
+    ...(search
+      ? {
+          OR: [{ name: { contains: search } }, { email: { contains: search } }],
+        }
+      : {}),
+  }
+
+  // Server-side pagination (issue #13): bounded page + matching count.
+  const [items, total] = await prisma.$transaction([
+    prisma.user.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      skip,
+      take,
+    }),
+    prisma.user.count({ where }),
+  ])
+
+  return { items, total, page, pageSize }
 })

--- a/server/api/get/admins/index.ts
+++ b/server/api/get/admins/index.ts
@@ -25,7 +25,9 @@ export default defineEventHandler(async (event) => {
   const [items, total] = await prisma.$transaction([
     prisma.user.findMany({
       where,
-      orderBy: { name: 'asc' },
+      // `id` tiebreaker keeps admins with identical names in a stable order
+      // across pages (skip/take is otherwise non-deterministic on ties).
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
       skip,
       take,
     }),

--- a/server/api/get/clients/index.ts
+++ b/server/api/get/clients/index.ts
@@ -31,7 +31,9 @@ export default defineEventHandler(async (event) => {
     prisma.client.findMany({
       where,
       include: { user: true, homeAddress: true },
-      orderBy: { user: { name: 'asc' } },
+      // `id` tiebreaker keeps clients with identical names in a stable order
+      // across pages (skip/take is otherwise non-deterministic on ties).
+      orderBy: [{ user: { name: 'asc' } }, { id: 'asc' }],
       skip,
       take,
     }),

--- a/server/api/get/clients/index.ts
+++ b/server/api/get/clients/index.ts
@@ -1,21 +1,42 @@
+import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
+import { getPageParams, getStringParam } from '../../../utils/pagination'
 
 export default defineEventHandler(async (event) => {
   // Bulk client roster carries full PII (name/phone/address) and is only used
   // by admin-facing UI — keep it admin-only (issue #3).
   requireAdmin(event)
 
+  const { page, pageSize, skip, take } = getPageParams(event)
+  const search = getStringParam(event, 'search')
+
   // Soft delete (issue #27): hide archived clients from the active roster.
-  return await prisma.client.findMany({
-    where: { deletedAt: null },
-    include: {
-      user: true,
-      homeAddress: true,
-    },
-    orderBy: {
-      user: {
-        name: 'asc',
-      },
-    },
-  })
+  const where: Prisma.ClientWhereInput = {
+    deletedAt: null,
+    ...(search
+      ? {
+          user: {
+            OR: [
+              { name: { contains: search } },
+              { email: { contains: search } },
+            ],
+          },
+        }
+      : {}),
+  }
+
+  // Server-side pagination (issue #13): skip/take + a matching count in one
+  // transaction, so the roster is bounded and the total stays consistent.
+  const [items, total] = await prisma.$transaction([
+    prisma.client.findMany({
+      where,
+      include: { user: true, homeAddress: true },
+      orderBy: { user: { name: 'asc' } },
+      skip,
+      take,
+    }),
+    prisma.client.count({ where }),
+  ])
+
+  return { items, total, page, pageSize }
 })

--- a/server/api/get/clients/options.ts
+++ b/server/api/get/clients/options.ts
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
       user: { select: { name: true } },
       homeAddress: true,
     },
-    orderBy: { user: { name: 'asc' } },
+    orderBy: [{ user: { name: 'asc' } }, { id: 'asc' }],
     take: OPTIONS_CAP,
   })
 

--- a/server/api/get/clients/options.ts
+++ b/server/api/get/clients/options.ts
@@ -1,0 +1,32 @@
+import { prisma } from '../../../utils/prisma'
+
+// Bounded options list for the "select a client" dropdown in the create-ride
+// form (app/pages/rides/index.vue). The full roster endpoint (./index) is now
+// paginated for issue #13, but the dropdown needs every active client at once —
+// so this dedicated endpoint returns a minimal, still-bounded shape.
+//
+// Minimal shape: id + name for the label, plus homeAddress so selecting a
+// client can auto-fill the pickup address (existing behavior). No phone/email.
+const OPTIONS_CAP = 500
+
+export default defineEventHandler(async (event) => {
+  // Client names/addresses are PII and only the admin create-ride UI uses this.
+  requireAdmin(event)
+
+  const clients = await prisma.client.findMany({
+    where: { deletedAt: null },
+    select: {
+      id: true,
+      user: { select: { name: true } },
+      homeAddress: true,
+    },
+    orderBy: { user: { name: 'asc' } },
+    take: OPTIONS_CAP,
+  })
+
+  return clients.map((c) => ({
+    id: c.id,
+    name: c.user?.name ?? '',
+    homeAddress: c.homeAddress,
+  }))
+})

--- a/server/api/get/rides/index.ts
+++ b/server/api/get/rides/index.ts
@@ -2,10 +2,10 @@ import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
 import { getPageParams, getStringParam } from '../../../utils/pagination'
 
-// Only these statuses exist in the RideStatus enum (CANCELLED is dead — see
-// issues #5/#22). Whitelist filter input against this so a bogus `?include`
-// value can never crash the Prisma query with an invalid enum.
-const VALID_STATUSES = new Set(['CREATED', 'ASSIGNED', 'COMPLETED'])
+// The full RideStatus enum (CANCELLED became a real status in issue #5).
+// Whitelist filter input against this so a bogus `?include` value can never
+// crash the Prisma query with an invalid enum.
+const VALID_STATUSES = new Set(['CREATED', 'ASSIGNED', 'COMPLETED', 'CANCELLED'])
 
 // Parse a comma-separated filter list (e.g. "status:CREATED,assign:ME") into a
 // set of statuses plus whether the caller wants rides assigned to themselves.
@@ -118,7 +118,10 @@ export default defineEventHandler(async (event) => {
         client: { include: { user: true } },
         volunteer: { include: { user: true } },
       },
-      orderBy: { scheduledTime: sort },
+      // `id` is a stable, unique tiebreaker so rides with an identical
+      // scheduledTime keep a deterministic order across pages (otherwise
+      // skip/take could drop or duplicate a tied row).
+      orderBy: [{ scheduledTime: sort }, { id: 'asc' }],
       skip,
       take,
     }),

--- a/server/api/get/rides/index.ts
+++ b/server/api/get/rides/index.ts
@@ -1,9 +1,33 @@
 import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
+import { getPageParams, getStringParam } from '../../../utils/pagination'
+
+// Only these statuses exist in the RideStatus enum (CANCELLED is dead — see
+// issues #5/#22). Whitelist filter input against this so a bogus `?include`
+// value can never crash the Prisma query with an invalid enum.
+const VALID_STATUSES = new Set(['CREATED', 'ASSIGNED', 'COMPLETED'])
+
+// Parse a comma-separated filter list (e.g. "status:CREATED,assign:ME") into a
+// set of statuses plus whether the caller wants rides assigned to themselves.
+// Mirrors the include/exclude filter chips the rides dashboard used to apply
+// client-side (issue #13 moves that filtering to the backend so it composes
+// correctly with pagination).
+function parseFilters(raw: string): { statuses: string[]; assignedToMe: boolean } {
+  const values = raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean)
+  const statuses = values
+    .filter((v) => v.startsWith('status:'))
+    .map((v) => v.slice('status:'.length))
+    .filter((s) => VALID_STATUSES.has(s))
+  return { statuses, assignedToMe: values.includes('assign:ME') }
+}
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const sort = query.sort === 'desc' ? 'desc' : 'asc'
+  const { page, pageSize, skip, take } = getPageParams(event)
 
   // The global auth middleware guarantees a session and stashes it here.
   const session = event.context.auth as
@@ -12,39 +36,94 @@ export default defineEventHandler(async (event) => {
   const role = session?.user?.role
   const userId = session?.user?.id
 
+  // Build up an AND list of independent filters. We can't put multiple `OR`
+  // keys at the top level (role-scoping OR, inclusion-filter OR, search OR), so
+  // each lives as its own clause inside AND.
+  const and: Prisma.RideWhereInput[] = []
+
   // Data scoping (issue #3): a VOLUNTEER must only receive rides that are
   // available to sign up for (CREATED) or that are assigned to them — never
   // other volunteers' rides or the full roster of client PII. ADMINs see all.
   // Fail closed: if the user id is somehow absent, never widen past available
   // rides — { volunteer: { userId: undefined } } would make Prisma drop the
   // filter and match every assigned ride, leaking PII.
-  // Soft delete (issue #27): archived rides are always hidden from active ride
-  // views (both admin and volunteer). The scoping filter below is ANDed on top.
-  const where: Prisma.RideWhereInput = { deletedAt: null }
   if (role !== 'ADMIN') {
-    Object.assign(where, {
+    and.push({
       OR: userId
         ? [{ status: 'CREATED' }, { volunteer: { userId } }]
         : [{ status: 'CREATED' }],
     })
   }
 
-  return await prisma.ride.findMany({
-    where,
-    include: {
-      client: {
-        include: {
-          user: true,
-        },
+  // Inclusion filters (OR): keep a ride if it matches ANY selected chip.
+  const include = parseFilters(getStringParam(event, 'include'))
+  if (include.statuses.length || include.assignedToMe) {
+    const or: Prisma.RideWhereInput[] = include.statuses.map((status) => ({ status }))
+    if (include.assignedToMe && userId) or.push({ volunteer: { userId } })
+    if (or.length) and.push({ OR: or })
+  }
+
+  // Exclusion filters (AND NOT): drop a ride if it matches ANY excluded chip.
+  const exclude = parseFilters(getStringParam(event, 'exclude'))
+  for (const status of exclude.statuses) and.push({ NOT: { status } })
+  if (exclude.assignedToMe && userId) and.push({ NOT: { volunteer: { userId } } })
+
+  // Date range (issue #13 explicitly calls for backend date filtering). The end
+  // date is inclusive of the whole day, matching the old client-side behavior.
+  const startDate = getStringParam(event, 'startDate')
+  const endDate = getStringParam(event, 'endDate')
+  const scheduledTime: Prisma.DateTimeFilter = {}
+  if (startDate) {
+    const d = new Date(startDate)
+    if (!Number.isNaN(d.getTime())) scheduledTime.gte = d
+  }
+  if (endDate) {
+    const d = new Date(endDate)
+    if (!Number.isNaN(d.getTime())) {
+      d.setDate(d.getDate() + 1)
+      scheduledTime.lt = d
+    }
+  }
+  if (scheduledTime.gte || scheduledTime.lt) and.push({ scheduledTime })
+
+  // Free-text search across the ride and its client/volunteer names. SQLite
+  // `contains` (LIKE) is case-insensitive for ASCII, matching the old
+  // lower-cased client-side search.
+  const search = getStringParam(event, 'search')
+  if (search) {
+    and.push({
+      OR: [
+        { id: { contains: search } },
+        { pickupDisplay: { contains: search } },
+        { dropoffDisplay: { contains: search } },
+        { client: { user: { name: { contains: search } } } },
+        { volunteer: { user: { name: { contains: search } } } },
+      ],
+    })
+  }
+
+  // Soft delete (issue #27): archived rides are always hidden from active ride
+  // views (both admin and volunteer). ANDed on top of everything else.
+  const where: Prisma.RideWhereInput = {
+    deletedAt: null,
+    ...(and.length ? { AND: and } : {}),
+  }
+
+  // One transaction so the page slice and the total count see a consistent
+  // snapshot. skip/take bound the query (issue #13) — no more full-table loads.
+  const [items, total] = await prisma.$transaction([
+    prisma.ride.findMany({
+      where,
+      include: {
+        client: { include: { user: true } },
+        volunteer: { include: { user: true } },
       },
-      volunteer: {
-        include: {
-          user: true,
-        },
-      },
-    },
-    orderBy: {
-      scheduledTime: sort,
-    },
-  })
+      orderBy: { scheduledTime: sort },
+      skip,
+      take,
+    }),
+    prisma.ride.count({ where }),
+  ])
+
+  return { items, total, page, pageSize }
 })

--- a/server/api/get/volunteers/index.ts
+++ b/server/api/get/volunteers/index.ts
@@ -1,20 +1,46 @@
+import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
+import { getPageParams, getStringParam } from '../../../utils/pagination'
 
 export default defineEventHandler(async (event) => {
   // Bulk volunteer roster carries full PII and is only used by admin-facing UI
-  // (create/edit-ride volunteer picker, people page) — keep it admin-only (issue #3).
+  // (people page). The assignment pickers use /api/get/volunteers/options
+  // instead — keep this admin-only (issue #3).
   requireAdmin(event)
 
+  const { page, pageSize, skip, take } = getPageParams(event)
+  const search = getStringParam(event, 'search')
+  const statusFilter = getStringParam(event, 'status')
+
   // Soft delete (issue #27): hide archived volunteers from the active roster.
-  return await prisma.volunteer.findMany({
-    where: { deletedAt: null },
-    include: {
-      user: true,
-    },
-    orderBy: {
-      user: {
-        name: 'asc',
-      },
-    },
-  })
+  const where: Prisma.VolunteerWhereInput = {
+    deletedAt: null,
+    ...(statusFilter === 'AVAILABLE' || statusFilter === 'UNAVAILABLE'
+      ? { status: statusFilter }
+      : {}),
+    ...(search
+      ? {
+          user: {
+            OR: [
+              { name: { contains: search } },
+              { email: { contains: search } },
+            ],
+          },
+        }
+      : {}),
+  }
+
+  // Server-side pagination (issue #13): bounded page + matching count.
+  const [items, total] = await prisma.$transaction([
+    prisma.volunteer.findMany({
+      where,
+      include: { user: true },
+      orderBy: { user: { name: 'asc' } },
+      skip,
+      take,
+    }),
+    prisma.volunteer.count({ where }),
+  ])
+
+  return { items, total, page, pageSize }
 })

--- a/server/api/get/volunteers/index.ts
+++ b/server/api/get/volunteers/index.ts
@@ -35,7 +35,9 @@ export default defineEventHandler(async (event) => {
     prisma.volunteer.findMany({
       where,
       include: { user: true },
-      orderBy: { user: { name: 'asc' } },
+      // `id` tiebreaker keeps volunteers with identical names in a stable order
+      // across pages (skip/take is otherwise non-deterministic on ties).
+      orderBy: [{ user: { name: 'asc' } }, { id: 'asc' }],
       skip,
       take,
     }),

--- a/server/api/get/volunteers/options.ts
+++ b/server/api/get/volunteers/options.ts
@@ -5,9 +5,11 @@ import { prisma } from '../../../utils/prisma'
 // (app/pages/rides/[id].vue). The full roster endpoint (./index) is paginated
 // for issue #13; these pickers need the assignable roster at once.
 //
-// Only AVAILABLE volunteers can be assigned, so the picker only lists those.
-// Minimal shape: id + name (no phone/email PII). Still hard-capped so it can
-// never become an unbounded query (the issue #13 point).
+// Returns ALL non-deleted volunteers (not just AVAILABLE): on main the pickers
+// used /api/get/volunteers, which returned every status, so an admin could
+// assign any volunteer. Issue #13 is a pagination change and must not narrow
+// assignment policy. Minimal shape: id + name (no phone/email PII). Hard-capped
+// so it can never become an unbounded query (the issue #13 point).
 const OPTIONS_CAP = 500
 
 export default defineEventHandler(async (event) => {
@@ -15,12 +17,12 @@ export default defineEventHandler(async (event) => {
   requireAdmin(event)
 
   const volunteers = await prisma.volunteer.findMany({
-    where: { deletedAt: null, status: 'AVAILABLE' },
+    where: { deletedAt: null },
     select: {
       id: true,
       user: { select: { name: true } },
     },
-    orderBy: { user: { name: 'asc' } },
+    orderBy: [{ user: { name: 'asc' } }, { id: 'asc' }],
     take: OPTIONS_CAP,
   })
 

--- a/server/api/get/volunteers/options.ts
+++ b/server/api/get/volunteers/options.ts
@@ -1,0 +1,31 @@
+import { prisma } from '../../../utils/prisma'
+
+// Bounded options list for the volunteer-assignment dropdowns in the create-ride
+// form (app/pages/rides/index.vue) and the edit-ride modal
+// (app/pages/rides/[id].vue). The full roster endpoint (./index) is paginated
+// for issue #13; these pickers need the assignable roster at once.
+//
+// Only AVAILABLE volunteers can be assigned, so the picker only lists those.
+// Minimal shape: id + name (no phone/email PII). Still hard-capped so it can
+// never become an unbounded query (the issue #13 point).
+const OPTIONS_CAP = 500
+
+export default defineEventHandler(async (event) => {
+  // Only the admin create/edit-ride UI assigns volunteers.
+  requireAdmin(event)
+
+  const volunteers = await prisma.volunteer.findMany({
+    where: { deletedAt: null, status: 'AVAILABLE' },
+    select: {
+      id: true,
+      user: { select: { name: true } },
+    },
+    orderBy: { user: { name: 'asc' } },
+    take: OPTIONS_CAP,
+  })
+
+  return volunteers.map((v) => ({
+    id: v.id,
+    name: v.user?.name ?? '',
+  }))
+})

--- a/server/utils/pagination.ts
+++ b/server/utils/pagination.ts
@@ -1,0 +1,60 @@
+import type { H3Event } from 'h3'
+import { getQuery } from 'h3'
+
+// Server-side pagination helpers (issue #13). The list endpoints used to run
+// unbounded `findMany()` calls that loaded an entire table into memory on every
+// request. These helpers give every list endpoint a consistent, hard-capped
+// pagination contract.
+
+export const DEFAULT_PAGE_SIZE = 20
+// Hard cap so a caller can never ask for an unbounded page (the whole point of
+// issue #13). Even `?pageSize=100000` is clamped to this.
+export const MAX_PAGE_SIZE = 100
+
+export interface PageParams {
+  page: number
+  pageSize: number
+  skip: number
+  take: number
+}
+
+export interface PageEnvelope<T> {
+  items: T[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+function clampInt(raw: unknown, min: number, max: number, fallback: number): number {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  const n = Number(value)
+  if (!Number.isFinite(n)) return fallback
+  const i = Math.floor(n)
+  if (i < min) return min
+  if (i > max) return max
+  return i
+}
+
+/**
+ * Parse `?page` (1-based) and `?pageSize` from the request, clamping pageSize to
+ * [1, MAX_PAGE_SIZE] and defaulting to DEFAULT_PAGE_SIZE. Invalid/missing values
+ * fall back to the defaults rather than erroring.
+ */
+export function getPageParams(
+  event: H3Event,
+  opts: { defaultPageSize?: number; maxPageSize?: number } = {}
+): PageParams {
+  const query = getQuery(event)
+  const maxPageSize = opts.maxPageSize ?? MAX_PAGE_SIZE
+  const defaultPageSize = Math.min(opts.defaultPageSize ?? DEFAULT_PAGE_SIZE, maxPageSize)
+  const page = clampInt(query.page, 1, Number.MAX_SAFE_INTEGER, 1)
+  const pageSize = clampInt(query.pageSize, 1, maxPageSize, defaultPageSize)
+  return { page, pageSize, skip: (page - 1) * pageSize, take: pageSize }
+}
+
+/** Read a single string query param (h3 may hand back string | string[]). */
+export function getStringParam(event: H3Event, key: string): string {
+  const raw = getQuery(event)[key]
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return typeof value === 'string' ? value.trim() : ''
+}

--- a/server/utils/pagination.ts
+++ b/server/utils/pagination.ts
@@ -10,6 +10,10 @@ export const DEFAULT_PAGE_SIZE = 20
 // Hard cap so a caller can never ask for an unbounded page (the whole point of
 // issue #13). Even `?pageSize=100000` is clamped to this.
 export const MAX_PAGE_SIZE = 100
+// Cap the page number too, so a crafted `?page=9007199254740991` can't produce
+// a skip beyond Number.MAX_SAFE_INTEGER (which better-sqlite3 refuses to bind,
+// turning a query param into a 500). A million pages is far past any real UI.
+export const MAX_PAGE = 1_000_000
 
 export interface PageParams {
   page: number
@@ -27,6 +31,10 @@ export interface PageEnvelope<T> {
 
 function clampInt(raw: unknown, min: number, max: number, fallback: number): number {
   const value = Array.isArray(raw) ? raw[0] : raw
+  // Missing / empty values fall back to the default rather than coercing to 0
+  // (Number('') === 0, which would otherwise clamp up to `min`).
+  if (value === undefined || value === null) return fallback
+  if (typeof value === 'string' && value.trim() === '') return fallback
   const n = Number(value)
   if (!Number.isFinite(n)) return fallback
   const i = Math.floor(n)
@@ -47,7 +55,7 @@ export function getPageParams(
   const query = getQuery(event)
   const maxPageSize = opts.maxPageSize ?? MAX_PAGE_SIZE
   const defaultPageSize = Math.min(opts.defaultPageSize ?? DEFAULT_PAGE_SIZE, maxPageSize)
-  const page = clampInt(query.page, 1, Number.MAX_SAFE_INTEGER, 1)
+  const page = clampInt(query.page, 1, MAX_PAGE, 1)
   const pageSize = clampInt(query.pageSize, 1, maxPageSize, defaultPageSize)
   return { page, pageSize, skip: (page - 1) * pageSize, take: pageSize }
 }

--- a/tests/e2e/aaa-order-dependence-mutator.test.ts
+++ b/tests/e2e/aaa-order-dependence-mutator.test.ts
@@ -19,14 +19,19 @@ describe('order-dependence: hostile mutator', () => {
   it('deletes every seeded ride and leaves the DB corrupted for the next file', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
 
-    const before = await $fetch<{ id: string }[]>('/api/get/rides', { headers: { cookie } })
+    const { items: before } = await $fetch<{ items: { id: string }[] }>(
+      '/api/get/rides?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(before.length).toBeGreaterThanOrEqual(9)
 
     for (const ride of before) {
       await $fetch(`/api/delete/rides/${ride.id}`, { method: 'DELETE', headers: { cookie } })
     }
 
-    const after = await $fetch<unknown[]>('/api/get/rides', { headers: { cookie } })
+    const { items: after } = await $fetch<{ items: unknown[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie },
+    })
     expect(after.length).toBe(0)
     // Intentionally no cleanup: later files must not depend on our leftovers.
   })

--- a/tests/e2e/address-matchkey-display.test.ts
+++ b/tests/e2e/address-matchkey-display.test.ts
@@ -46,7 +46,9 @@ describe('address matchKey preserves display casing + dedups (#57)', () => {
     const created = await createClient(cookie, street, email)
 
     // Read back via the admin people/clients roster endpoint.
-    const roster = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const { items: roster } = await $fetch<{ items: ClientRow[] }>('/api/get/clients?pageSize=100', {
+      headers: { cookie },
+    })
     const row = roster.find((c) => c.id === created.id)!
     expect(row).toBeTruthy()
 
@@ -65,7 +67,9 @@ describe('address matchKey preserves display casing + dedups (#57)', () => {
       headers: { cookie },
       body: { name: 'State Case Test', email, street: uniqueStreet(), city: 'Dallas', state: 'tx', zip: '75080' },
     })
-    const roster = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const { items: roster } = await $fetch<{ items: ClientRow[] }>('/api/get/clients?pageSize=100', {
+      headers: { cookie },
+    })
     const row = roster.find((c) => c.id === created.id)!
     expect(row.homeAddress.state).toBe('TX')
   })

--- a/tests/e2e/address-normalization.test.ts
+++ b/tests/e2e/address-normalization.test.ts
@@ -26,10 +26,10 @@ async function createRide(cookie: string, street: string) {
     headers: { cookie },
     body: {
       clientId: (
-        await $fetch<Array<{ id: string }>>('/api/get/clients', {
+        await $fetch<{ items: Array<{ id: string }> }>('/api/get/clients?pageSize=100', {
           headers: { cookie },
         })
-      )[0]!.id,
+      ).items[0]!.id,
       pickup: { street, city: 'Dallas', state: 'TX', zip: '75080' },
       dropoff: { street: '999 Dropoff Rd', city: 'Dallas', state: 'TX', zip: '75080' },
       scheduledTime: new Date(Date.now() + 86_400_000).toISOString(),

--- a/tests/e2e/admin-delete.test.ts
+++ b/tests/e2e/admin-delete.test.ts
@@ -36,9 +36,10 @@ describe('admin delete route param (#6)', () => {
 
     // Confirm it is actually gone: it must no longer appear in the roster and a
     // second delete must fail (record not found).
-    const admins = await $fetch<Array<{ id: string }>>('/api/get/admins', {
-      headers: { cookie },
-    })
+    const { items: admins } = await $fetch<{ items: Array<{ id: string }> }>(
+      '/api/get/admins?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(admins.some((a) => a.id === created.id)).toBe(false)
 
     await expect(

--- a/tests/e2e/admin-empty-phone.test.ts
+++ b/tests/e2e/admin-empty-phone.test.ts
@@ -19,7 +19,7 @@ await bootShared()
 type AdminUser = { id: string; email: string; phone: string | null }
 
 async function getAdmin(cookie: string, email: string): Promise<AdminUser> {
-  const admins = await $fetch<AdminUser[]>('/api/get/admins', {
+  const { items: admins } = await $fetch<{ items: AdminUser[] }>('/api/get/admins?pageSize=100', {
     headers: { cookie },
   })
   const a = admins.find((a) => a.email === email)

--- a/tests/e2e/audit-log.test.ts
+++ b/tests/e2e/audit-log.test.ts
@@ -39,7 +39,11 @@ function userIdByEmail(email: string): string {
 }
 
 async function getRides(cookie: string): Promise<Ride[]> {
-  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+  // /api/get/rides is paginated (issue #13); pageSize=100 fetches the full set.
+  const res = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie },
+  })
+  return res.items
 }
 
 // Rides cancelled here are restored to CREATED afterwards so the shared seed DB

--- a/tests/e2e/auth-middleware.test.ts
+++ b/tests/e2e/auth-middleware.test.ts
@@ -66,8 +66,8 @@ describe('API auth middleware (#1, #2)', () => {
 
   it('volunteers keep the access their dashboard needs', async () => {
     const cookie = await loginAs('bob@example.com')
-    const rides = await $fetch('/api/get/rides', { headers: { cookie } })
-    expect(Array.isArray(rides)).toBe(true)
+    const rides = await $fetch<{ items: unknown[] }>('/api/get/rides', { headers: { cookie } })
+    expect(Array.isArray(rides.items)).toBe(true)
 
     const me = await $fetch<{ user: { email: string } }>('/api/get/volunteers/bySession', {
       headers: { cookie },

--- a/tests/e2e/complete-requires-ridetime.test.ts
+++ b/tests/e2e/complete-requires-ridetime.test.ts
@@ -13,7 +13,11 @@ type Ride = {
 }
 
 async function getRides(cookie: string): Promise<Ride[]> {
-  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+  // /api/get/rides is paginated (issue #13); pageSize=100 fetches the full set.
+  const res = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie },
+  })
+  return res.items
 }
 
 function put(cookie: string, id: string, body: Record<string, unknown>) {

--- a/tests/e2e/empty-phone.test.ts
+++ b/tests/e2e/empty-phone.test.ts
@@ -16,9 +16,10 @@ type VolunteerWithUser = {
 }
 
 async function getVolunteer(cookie: string, email: string): Promise<VolunteerWithUser> {
-  const volunteers = await $fetch<VolunteerWithUser[]>('/api/get/volunteers', {
-    headers: { cookie },
-  })
+  const { items: volunteers } = await $fetch<{ items: VolunteerWithUser[] }>(
+    '/api/get/volunteers?pageSize=100',
+    { headers: { cookie } }
+  )
   const v = volunteers.find((v) => v.user.email === email)
   expect(v, `seeded volunteer ${email} should exist`).toBeTruthy()
   return v!

--- a/tests/e2e/metrics-date-range.test.ts
+++ b/tests/e2e/metrics-date-range.test.ts
@@ -52,7 +52,9 @@ async function createCompletedRide(
 describe('metrics date range — end day is inclusive (issue #18)', () => {
   it('counts an afternoon ride scheduled on the endDate day', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const clients = await $fetch<Client[]>('/api/get/clients', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: Client[] }>('/api/get/clients?pageSize=100', {
+      headers: { cookie },
+    })
     const clientId = clients[0]!.id
 
     // A fixed day well away from seeded times so nothing else lands here.
@@ -90,7 +92,9 @@ describe('metrics date range — end day is inclusive (issue #18)', () => {
 
   it('includes the endDate day for topRiders (explicit-endDate path, lt bug)', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const clients = await $fetch<Client[]>('/api/get/clients', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: Client[] }>('/api/get/clients?pageSize=100', {
+      headers: { cookie },
+    })
     // Use a distinct client so its completed-ride count is unambiguous.
     const client = clients[1] ?? clients[0]!
 

--- a/tests/e2e/orphaned-users.test.ts
+++ b/tests/e2e/orphaned-users.test.ts
@@ -98,9 +98,9 @@ describe('issue #8 — deletion removes the parent User (no orphans)', () => {
   it('deleting a client WITH rides still 409s and leaves client + user intact (#23)', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
 
-    const clients = await $fetch<
-      Array<{ id: string; userId: string; user: { email: string | null } }>
-    >('/api/get/clients', { headers: { cookie } })
+    const { items: clients } = await $fetch<{
+      items: Array<{ id: string; userId: string; user: { email: string | null } }>
+    }>('/api/get/clients?pageSize=100', { headers: { cookie } })
     const martha = clients.find((c) => c.user.email === 'martha@example.com')
     expect(martha, 'seeded client martha should exist').toBeDefined()
 
@@ -112,8 +112,8 @@ describe('issue #8 — deletion removes the parent User (no orphans)', () => {
     ).rejects.toMatchObject({ statusCode: 409 })
 
     // Both the client profile and its user remain.
-    const clientsAfter = await $fetch<Array<{ id: string }>>(
-      '/api/get/clients',
+    const { items: clientsAfter } = await $fetch<{ items: Array<{ id: string }> }>(
+      '/api/get/clients?pageSize=100',
       { headers: { cookie } }
     )
     expect(clientsAfter.some((c) => c.id === martha!.id)).toBe(true)
@@ -136,8 +136,8 @@ describe('issue #8 — deletion removes the parent User (no orphans)', () => {
     )
 
     // Grab a seeded CREATED ride and assign it to this volunteer.
-    const rides = await $fetch<Array<{ id: string; status: string }>>(
-      '/api/get/rides',
+    const { items: rides } = await $fetch<{ items: Array<{ id: string; status: string }> }>(
+      '/api/get/rides?pageSize=100',
       { headers: { cookie } }
     )
     const openRide = rides.find((r) => r.status === 'CREATED')
@@ -155,8 +155,8 @@ describe('issue #8 — deletion removes the parent User (no orphans)', () => {
     })
 
     // Ride reset back to CREATED (available pool), User gone.
-    const ridesAfter = await $fetch<Array<{ id: string; status: string }>>(
-      '/api/get/rides',
+    const { items: ridesAfter } = await $fetch<{ items: Array<{ id: string; status: string }> }>(
+      '/api/get/rides?pageSize=100',
       { headers: { cookie } }
     )
     const ride = ridesAfter.find((r) => r.id === openRide!.id)

--- a/tests/e2e/pagination.test.ts
+++ b/tests/e2e/pagination.test.ts
@@ -58,6 +58,24 @@ describe('list pagination (#13)', () => {
     expect(res.items.length).toBeLessThanOrEqual(100)
   })
 
+  it('empty pageSize falls back to the default (not 1)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const res = await $fetch<RideEnvelope>('/api/get/rides?pageSize=', { headers: { cookie } })
+    // Number('') === 0 must not clamp to 1 — it falls back to the default (20).
+    expect(res.pageSize).toBe(20)
+  })
+
+  it('clamps an absurd page number instead of 500ing on an unsafe skip', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    // page*pageSize would exceed Number.MAX_SAFE_INTEGER unless page is capped.
+    const res = await $fetch<RideEnvelope>(
+      '/api/get/rides?page=9007199254740991&pageSize=100',
+      { headers: { cookie } }
+    )
+    expect(res.page).toBe(1_000_000)
+    expect(res.items).toEqual([])
+  })
+
   it('all four list endpoints return the envelope shape', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
     for (const path of [

--- a/tests/e2e/pagination.test.ts
+++ b/tests/e2e/pagination.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared, fetchWithQueryCount } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Issue #13: the list endpoints used to run unbounded findMany() (no take/skip),
+// loading the entire table on every request. They now return a paginated
+// envelope { items, total, page, pageSize } with a hard-capped pageSize, and the
+// dropdowns use dedicated bounded options endpoints.
+
+type RideEnvelope = {
+  items: Array<{ id: string }>
+  total: number
+  page: number
+  pageSize: number
+}
+
+describe('list pagination (#13)', () => {
+  it('returns a bounded page-1 envelope for /api/get/rides', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const res = await $fetch<RideEnvelope>('/api/get/rides?page=1&pageSize=2', {
+      headers: { cookie },
+    })
+
+    expect(Array.isArray(res.items)).toBe(true)
+    expect(res.items.length).toBe(2)
+    // Seed has 9 rides; the total reflects the full matching set, not the page.
+    expect(res.total).toBeGreaterThanOrEqual(9)
+    expect(res.page).toBe(1)
+    expect(res.pageSize).toBe(2)
+  })
+
+  it('page 2 returns a different, non-overlapping slice', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const p1 = await $fetch<RideEnvelope>('/api/get/rides?page=1&pageSize=2', {
+      headers: { cookie },
+    })
+    const p2 = await $fetch<RideEnvelope>('/api/get/rides?page=2&pageSize=2', {
+      headers: { cookie },
+    })
+
+    expect(p2.page).toBe(2)
+    expect(p2.items.length).toBe(2)
+    const p1Ids = new Set(p1.items.map((r) => r.id))
+    const overlap = p2.items.filter((r) => p1Ids.has(r.id))
+    expect(overlap).toHaveLength(0)
+  })
+
+  it('hard-caps an oversized pageSize (never unbounded)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const res = await $fetch<RideEnvelope>('/api/get/rides?page=1&pageSize=100000', {
+      headers: { cookie },
+    })
+    // Clamped to MAX_PAGE_SIZE (100), not honored verbatim.
+    expect(res.pageSize).toBe(100)
+    expect(res.items.length).toBeLessThanOrEqual(100)
+  })
+
+  it('all four list endpoints return the envelope shape', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    for (const path of [
+      '/api/get/rides',
+      '/api/get/clients',
+      '/api/get/volunteers',
+      '/api/get/admins',
+    ]) {
+      const res = await $fetch<RideEnvelope>(path, { headers: { cookie } })
+      expect(Array.isArray(res.items), `${path} .items`).toBe(true)
+      expect(typeof res.total, `${path} .total`).toBe('number')
+      expect(res.page, `${path} .page`).toBe(1)
+      expect(typeof res.pageSize, `${path} .pageSize`).toBe('number')
+    }
+  })
+
+  it('stays query-bounded (page query + count), not proportional to rows', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const { status, queryCount, body } = await fetchWithQueryCount<RideEnvelope>(
+      '/api/get/rides?page=1&pageSize=2',
+      { headers: { cookie } }
+    )
+    expect(status).toBe(200)
+    expect(Array.isArray(body.items)).toBe(true)
+    // findMany (with includes) + count in one transaction — a small constant,
+    // independent of how many rides exist.
+    expect(queryCount).toBeLessThanOrEqual(6)
+  })
+
+  it('applies server-side status filtering with pagination', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const res = await $fetch<RideEnvelope & { items: Array<{ status: string }> }>(
+      '/api/get/rides?include=status:CREATED&pageSize=100',
+      { headers: { cookie } }
+    )
+    expect(res.items.length).toBeGreaterThan(0)
+    expect(res.items.every((r) => r.status === 'CREATED')).toBe(true)
+    // Seed has 4 CREATED rides.
+    expect(res.total).toBe(4)
+  })
+})
+
+describe('dropdown options endpoints (#13)', () => {
+  it('/api/get/clients/options returns a minimal { id, name } list', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const clients = await $fetch<Array<{ id: string; name: string; homeAddress: unknown }>>(
+      '/api/get/clients/options',
+      { headers: { cookie } }
+    )
+    expect(Array.isArray(clients)).toBe(true)
+    expect(clients.length).toBeGreaterThanOrEqual(3)
+    for (const c of clients) {
+      expect(typeof c.id).toBe('string')
+      expect(typeof c.name).toBe('string')
+      // No PII leak: name only (plus homeAddress for the autofill), no email/phone.
+      expect(c).not.toHaveProperty('user')
+    }
+  })
+
+  it('/api/get/volunteers/options returns AVAILABLE volunteers as { id, name }', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const vols = await $fetch<Array<{ id: string; name: string }>>(
+      '/api/get/volunteers/options',
+      { headers: { cookie } }
+    )
+    expect(Array.isArray(vols)).toBe(true)
+    // All 3 seeded volunteers are AVAILABLE.
+    expect(vols.length).toBe(3)
+    for (const v of vols) {
+      expect(typeof v.id).toBe('string')
+      expect(typeof v.name).toBe('string')
+      expect(v).not.toHaveProperty('user')
+    }
+  })
+})

--- a/tests/e2e/pagination.test.ts
+++ b/tests/e2e/pagination.test.ts
@@ -135,19 +135,76 @@ describe('dropdown options endpoints (#13)', () => {
     }
   })
 
-  it('/api/get/volunteers/options returns AVAILABLE volunteers as { id, name }', async () => {
+  it('/api/get/volunteers/options returns all volunteers as { id, name }', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
     const vols = await $fetch<Array<{ id: string; name: string }>>(
       '/api/get/volunteers/options',
       { headers: { cookie } }
     )
     expect(Array.isArray(vols)).toBe(true)
-    // All 3 seeded volunteers are AVAILABLE.
-    expect(vols.length).toBe(3)
+    // Assignment policy is unchanged from main: every (non-deleted) volunteer is
+    // assignable, not only AVAILABLE ones. Seed has 3 volunteers.
+    expect(vols.length).toBeGreaterThanOrEqual(3)
     for (const v of vols) {
       expect(typeof v.id).toBe('string')
       expect(typeof v.name).toBe('string')
       expect(v).not.toHaveProperty('user')
+    }
+  })
+})
+
+// The rides dashboard's default exclude set sends `status:CANCELLED` (see
+// app/utils/rideFilters DEFAULT_EXCLUDED_FILTERS). CANCELLED became a real
+// RideStatus in issue #5, so the server's status whitelist must honor it —
+// otherwise the chip is a no-op and cancelled rides leak into the default view.
+// (The seed has no cancelled rides, so we create + cancel a throwaway one and
+// clean it up afterward.)
+describe('CANCELLED status filtering (#13 x #5)', () => {
+  it('honors include/exclude of status:CANCELLED', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    const clients = await $fetch<Array<{ id: string }>>('/api/get/clients/options', {
+      headers: { cookie },
+    })
+    const clientId = clients[0]!.id
+
+    const created = await $fetch<{ id: string }>('/api/post/rides', {
+      method: 'POST',
+      headers: { cookie },
+      body: {
+        clientId,
+        pickup: { street: '1 Cancel Test St', city: 'Dallas', state: 'TX', zip: '75001' },
+        dropoff: { street: '2 Cancel Test Ave', city: 'Dallas', state: 'TX', zip: '75002' },
+        scheduledTime: new Date(Date.now() + 5 * 86_400_000).toISOString(),
+      },
+    })
+    const rideId = created.id
+
+    try {
+      await $fetch(`/api/put/rides/${rideId}`, {
+        method: 'PUT',
+        headers: { cookie },
+        body: { status: 'CANCELLED' },
+      })
+
+      // Excluding CANCELLED must actually drop it. Pre-fix (CANCELLED missing
+      // from VALID_STATUSES) the chip is silently dropped and the cancelled
+      // ride leaks into the excluded result.
+      const excluded = await $fetch<RideEnvelope>(
+        '/api/get/rides?exclude=status:COMPLETED,status:CANCELLED&pageSize=100',
+        { headers: { cookie } }
+      )
+      expect(excluded.items.some((r) => r.id === rideId)).toBe(false)
+
+      // Including CANCELLED must surface it.
+      const included = await $fetch<RideEnvelope>(
+        '/api/get/rides?include=status:CANCELLED&pageSize=100',
+        { headers: { cookie } }
+      )
+      expect(included.items.some((r) => r.id === rideId)).toBe(true)
+    } finally {
+      // Soft-delete the throwaway ride so it leaves the shared seed DB clean.
+      await $fetch(`/api/delete/rides/${rideId}`, { method: 'DELETE', headers: { cookie } })
     }
   })
 })

--- a/tests/e2e/pii-scoping.test.ts
+++ b/tests/e2e/pii-scoping.test.ts
@@ -19,7 +19,9 @@ type Ride = {
 describe('issue #3 — server-side PII scoping', () => {
   it('ADMIN still receives every ride (full dataset)', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const rides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    const { items: rides } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie },
+    })
     expect(Array.isArray(rides)).toBe(true)
     // Seed has 9 rides across all volunteers/clients.
     expect(rides.length).toBeGreaterThanOrEqual(9)
@@ -34,7 +36,9 @@ describe('issue #3 — server-side PII scoping', () => {
     })
     const myUserId = me.user.id
 
-    const rides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: bobCookie } })
+    const { items: rides } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie: bobCookie },
+    })
 
     // Every returned ride must be either available (CREATED) or assigned to Bob.
     for (const ride of rides) {
@@ -73,8 +77,14 @@ describe('issue #3 — server-side PII scoping', () => {
 
   it('ADMIN can still read the client and volunteer rosters', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const clients = await $fetch<unknown[]>('/api/get/clients', { headers: { cookie } })
-    const volunteers = await $fetch<unknown[]>('/api/get/volunteers', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: unknown[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
+    const { items: volunteers } = await $fetch<{ items: unknown[] }>(
+      '/api/get/volunteers?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(Array.isArray(clients)).toBe(true)
     expect(clients.length).toBeGreaterThanOrEqual(3)
     expect(Array.isArray(volunteers)).toBe(true)

--- a/tests/e2e/query-count-seam.test.ts
+++ b/tests/e2e/query-count-seam.test.ts
@@ -23,16 +23,18 @@ describe('query-count seam (#45)', () => {
 
   it('stays bounded (not proportional to row count) for a batched list with includes', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const { status, queryCount, body } = await fetchWithQueryCount<unknown[]>('/api/get/rides', {
-      headers: { cookie },
-    })
+    const { status, queryCount, body } = await fetchWithQueryCount<{ items: unknown[] }>(
+      '/api/get/rides',
+      { headers: { cookie } }
+    )
     expect(status).toBe(200)
     // Seed has 9+ rides each with nested client/volunteer includes. Prisma loads
     // includes per-relation-level (a small constant), NOT per row — so the count
-    // must stay bounded regardless of how many rides exist. A per-row N+1 here
+    // must stay bounded regardless of how many rides exist. Pagination (issue
+    // #13) adds one count() query alongside the findMany. A per-row N+1 here
     // would blow past this.
-    expect(Array.isArray(body)).toBe(true)
-    expect(queryCount).toBeLessThanOrEqual(5)
+    expect(Array.isArray(body.items)).toBe(true)
+    expect(queryCount).toBeLessThanOrEqual(6)
   })
 
   it('keeps topRiders batched (issue #24): groupBy + one findMany, not an N+1', async () => {

--- a/tests/e2e/record-scoping.test.ts
+++ b/tests/e2e/record-scoping.test.ts
@@ -30,7 +30,10 @@ describe('issue #41 — single-record & admin-only endpoint scoping', () => {
 
       // Admin sees every ride; find one that is NOT available (CREATED) and NOT
       // Bob's — i.e. a ride assigned to (or completed by) another volunteer.
-      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const { items: allRides } = await $fetch<{ items: Ride[] }>(
+        '/api/get/rides?pageSize=100',
+        { headers: { cookie: adminCookie } }
+      )
       const foreign = allRides.find(
         (r) => r.status !== 'CREATED' && r.volunteer && r.volunteer.userId !== myUserId
       )
@@ -45,7 +48,10 @@ describe('issue #41 — single-record & admin-only endpoint scoping', () => {
       const adminCookie = await loginAs('reachtusharwani@gmail.com')
       const bobCookie = await loginAs('bob@example.com')
 
-      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const { items: allRides } = await $fetch<{ items: Ride[] }>(
+        '/api/get/rides?pageSize=100',
+        { headers: { cookie: adminCookie } }
+      )
       const available = allRides.find((r) => r.status === 'CREATED')
       expect(available, 'seed should contain an available ride').toBeTruthy()
 
@@ -63,7 +69,10 @@ describe('issue #41 — single-record & admin-only endpoint scoping', () => {
       })
       const myUserId = me.user.id
 
-      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const { items: allRides } = await $fetch<{ items: Ride[] }>(
+        '/api/get/rides?pageSize=100',
+        { headers: { cookie: adminCookie } }
+      )
       const mine = allRides.find((r) => r.volunteer && r.volunteer.userId === myUserId)
       expect(mine, 'seed should contain a ride assigned to Bob').toBeTruthy()
 
@@ -75,7 +84,10 @@ describe('issue #41 — single-record & admin-only endpoint scoping', () => {
 
     it('ADMIN can fetch any ride by id', async () => {
       const adminCookie = await loginAs('reachtusharwani@gmail.com')
-      const allRides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+      const { items: allRides } = await $fetch<{ items: Ride[] }>(
+        '/api/get/rides?pageSize=100',
+        { headers: { cookie: adminCookie } }
+      )
       const anyAssigned = allRides.find((r) => r.status !== 'CREATED' && r.volunteer)
       expect(anyAssigned).toBeTruthy()
       const ride = await $fetch<Ride>(`/api/get/rides/byId/${anyAssigned!.id}`, {
@@ -113,7 +125,7 @@ describe('issue #41 — single-record & admin-only endpoint scoping', () => {
     it('VOLUNTEER gets 403 on get/users/byId/[id]', async () => {
       const adminCookie = await loginAs('reachtusharwani@gmail.com')
       const bobCookie = await loginAs('bob@example.com')
-      const admins = await $fetch<{ id: string }[]>('/api/get/admins', {
+      const { items: admins } = await $fetch<{ items: { id: string }[] }>('/api/get/admins', {
         headers: { cookie: adminCookie },
       })
       const someUserId = admins[0]!.id
@@ -124,9 +136,10 @@ describe('issue #41 — single-record & admin-only endpoint scoping', () => {
 
     it('ADMIN can read get/users/byId/[id]', async () => {
       const adminCookie = await loginAs('reachtusharwani@gmail.com')
-      const admins = await $fetch<{ id: string; email: string }[]>('/api/get/admins', {
-        headers: { cookie: adminCookie },
-      })
+      const { items: admins } = await $fetch<{ items: { id: string; email: string }[] }>(
+        '/api/get/admins',
+        { headers: { cookie: adminCookie } }
+      )
       const target = admins[0]!
       const byId = await $fetch<{ id: string }>(`/api/get/users/byId/${target.id}`, {
         headers: { cookie: adminCookie },

--- a/tests/e2e/ride-broadcast-nonblocking.test.ts
+++ b/tests/e2e/ride-broadcast-nonblocking.test.ts
@@ -21,9 +21,10 @@ async function adminCookie() {
 }
 
 async function firstClientId(cookie: string): Promise<string> {
-  const clients = await $fetch<Array<{ id: string }>>('/api/get/clients', {
-    headers: { cookie },
-  })
+  const { items: clients } = await $fetch<{ items: Array<{ id: string }> }>(
+    '/api/get/clients?pageSize=100',
+    { headers: { cookie } }
+  )
   expect(clients.length).toBeGreaterThan(0)
   return clients[0]!.id
 }

--- a/tests/e2e/ride-cancel.test.ts
+++ b/tests/e2e/ride-cancel.test.ts
@@ -12,7 +12,11 @@ type Ride = {
 }
 
 async function getRides(cookie: string): Promise<Ride[]> {
-  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+  // /api/get/rides is paginated (issue #13); pageSize=100 fetches the full set.
+  const res = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie },
+  })
+  return res.items
 }
 
 async function getRideById(cookie: string, id: string): Promise<Ride> {

--- a/tests/e2e/ride-input-validation.test.ts
+++ b/tests/e2e/ride-input-validation.test.ts
@@ -14,9 +14,10 @@ async function adminCookie() {
 }
 
 async function firstRideId(cookie: string): Promise<string> {
-  const rides = await $fetch<Array<{ id: string }>>('/api/get/rides', {
-    headers: { cookie },
-  })
+  const { items: rides } = await $fetch<{ items: Array<{ id: string }> }>(
+    '/api/get/rides?pageSize=100',
+    { headers: { cookie } }
+  )
   expect(rides.length).toBeGreaterThan(0)
   return rides[0]!.id
 }

--- a/tests/e2e/ride-navigate-link.test.ts
+++ b/tests/e2e/ride-navigate-link.test.ts
@@ -16,9 +16,9 @@ describe('ride details Navigate deep-link (#26)', () => {
   it('renders a maps directions deep-link with encoded pickup/dropoff', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
 
-    const rides = await $fetch<
-      Array<{ id: string; pickupDisplay: string; dropoffDisplay: string }>
-    >('/api/get/rides', { headers: { cookie } })
+    const { items: rides } = await $fetch<{
+      items: Array<{ id: string; pickupDisplay: string; dropoffDisplay: string }>
+    }>('/api/get/rides?pageSize=100', { headers: { cookie } })
     expect(rides.length).toBeGreaterThan(0)
 
     const ride = rides[0]!

--- a/tests/e2e/safe-delete.test.ts
+++ b/tests/e2e/safe-delete.test.ts
@@ -28,8 +28,13 @@ describe('safe deletes (#23)', () => {
   it('does not crash (500) when deleting a client with rides — blocks with 409 and preserves data', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
 
-    const clients = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
-    const ridesBefore = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: ClientRow[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
+    const { items: ridesBefore } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie },
+    })
 
     // martha is seeded with rides.
     const martha = clients.find((c) => c.user.email === 'martha@example.com')
@@ -47,9 +52,14 @@ describe('safe deletes (#23)', () => {
     expect(res.status).toBe(409)
 
     // Data preserved: the client and their rides still exist.
-    const clientsAfter = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const { items: clientsAfter } = await $fetch<{ items: ClientRow[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(clientsAfter.some((c) => c.id === martha!.id), 'client must still exist').toBe(true)
-    const ridesAfter = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    const { items: ridesAfter } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie },
+    })
     const marthaRidesAfter = ridesAfter.filter((r) => r.clientId === martha!.id)
     expect(marthaRidesAfter.length, 'client rides must be preserved').toBe(marthaRides.length)
   })
@@ -78,7 +88,10 @@ describe('safe deletes (#23)', () => {
     })
     expect(res.status, 'deleting a ride-less client should succeed').toBe(200)
 
-    const clientsAfter = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const { items: clientsAfter } = await $fetch<{ items: ClientRow[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(clientsAfter.some((c) => c.id === created.id)).toBe(false)
   })
 
@@ -98,7 +111,10 @@ describe('safe deletes (#23)', () => {
     expect(vol.id).toBeTruthy()
 
     // Grab any existing client to attach a ride to.
-    const clients = await $fetch<ClientRow[]>('/api/get/clients', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: ClientRow[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
     const someClient = clients[0]
     expect(someClient).toBeTruthy()
 
@@ -123,7 +139,9 @@ describe('safe deletes (#23)', () => {
     })
     expect(delRes.status, 'deleting a volunteer should succeed').toBe(200)
 
-    const ridesAfter = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+    const { items: ridesAfter } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie },
+    })
     const affected = ridesAfter.find((r) => r.id === ride.id)
     expect(affected, 'the ride should still exist').toBeTruthy()
     expect(affected!.volunteerId, 'volunteer link should be cleared').toBeNull()

--- a/tests/e2e/signup-race.test.ts
+++ b/tests/e2e/signup-race.test.ts
@@ -40,7 +40,9 @@ async function rawSignup(rideId: string, cookie: string, raceDelayMs?: number): 
 }
 
 async function findCreatedRideId(adminCookie: string): Promise<string> {
-  const rides = await $fetch<Ride[]>('/api/get/rides', { headers: { cookie: adminCookie } })
+  const { items: rides } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie: adminCookie },
+  })
   const created = rides.find((r) => r.status === 'CREATED' && r.volunteerId === null)
   expect(created, 'seed should contain an available (CREATED) ride').toBeTruthy()
   return created!.id

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -8,9 +8,13 @@ await bootShared()
 describe('test harness smoke test', () => {
   it('boots the app and serves seeded data (authenticated)', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const rides = await $fetch('/api/get/rides', { headers: { cookie } })
-    expect(Array.isArray(rides)).toBe(true)
-    expect(rides.length).toBeGreaterThanOrEqual(9)
+    // /api/get/rides returns a paginated envelope (issue #13).
+    const rides = await $fetch<{ items: unknown[]; total: number }>(
+      '/api/get/rides?pageSize=100',
+      { headers: { cookie } }
+    )
+    expect(Array.isArray(rides.items)).toBe(true)
+    expect(rides.total).toBeGreaterThanOrEqual(9)
   })
 
   it('logs in via the OTP-from-database helper and reaches an auth-gated endpoint', async () => {

--- a/tests/e2e/soft-deletes.test.ts
+++ b/tests/e2e/soft-deletes.test.ts
@@ -64,9 +64,10 @@ describe('soft deletes (#27)', () => {
     expect(res.status, 'soft delete should succeed').toBe(200)
 
     // Gone from the active roster.
-    const clientsAfter = await $fetch<ClientRow[]>('/api/get/clients', {
-      headers: { cookie },
-    })
+    const { items: clientsAfter } = await $fetch<{ items: ClientRow[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(clientsAfter.some((c) => c.id === client.id)).toBe(false)
 
     // But the underlying rows still exist with deletedAt set (direct DB read),
@@ -111,7 +112,7 @@ describe('soft deletes (#27)', () => {
     expect(second.id).not.toBe(first.id)
 
     // The re-added client is live in the roster.
-    const clients = await $fetch<ClientRow[]>('/api/get/clients', {
+    const { items: clients } = await $fetch<{ items: ClientRow[] }>('/api/get/clients?pageSize=100', {
       headers: { cookie },
     })
     const live = clients.find((c) => c.user.email === email)
@@ -180,7 +181,7 @@ describe('soft deletes (#27)', () => {
     )
 
     // Create a completed ride worth a known number of hours.
-    const clients = await $fetch<ClientRow[]>('/api/get/clients', {
+    const { items: clients } = await $fetch<{ items: ClientRow[] }>('/api/get/clients?pageSize=100', {
       headers: { cookie },
     })
     const someClient = clients[0]
@@ -218,9 +219,10 @@ describe('soft deletes (#27)', () => {
     expect(del.status).toBe(200)
 
     // It no longer shows in the active rides list...
-    const rides = await $fetch<Array<{ id: string }>>('/api/get/rides', {
-      headers: { cookie },
-    })
+    const { items: rides } = await $fetch<{ items: Array<{ id: string }> }>(
+      '/api/get/rides?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(rides.some((r) => r.id === ride.id)).toBe(false)
 
     // ...but the metrics still count it (historical preservation).

--- a/tests/e2e/topRiders-n1.test.ts
+++ b/tests/e2e/topRiders-n1.test.ts
@@ -73,7 +73,9 @@ describe('topRiders N+1 (issue #24)', () => {
 
   it('returns real client names + correct counts, ordered desc (batching unchanged)', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const clients = await $fetch<Client[]>('/api/get/clients', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: Client[] }>('/api/get/clients?pageSize=100', {
+      headers: { cookie },
+    })
     const [clientA, clientB] = clients
     expect(clientA, 'seed should provide at least two clients').toBeTruthy()
     expect(clientB, 'seed should provide at least two clients').toBeTruthy()

--- a/tests/e2e/unassign-status.test.ts
+++ b/tests/e2e/unassign-status.test.ts
@@ -12,7 +12,11 @@ type Ride = {
 }
 
 async function getRides(cookie: string): Promise<Ride[]> {
-  return await $fetch<Ride[]>('/api/get/rides', { headers: { cookie } })
+  // /api/get/rides is paginated (issue #13); pageSize=100 fetches the full set.
+  const res = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie },
+  })
+  return res.items
 }
 
 function put(cookie: string, id: string, body: Record<string, unknown>) {

--- a/tests/e2e/zzz-order-dependence-victim.test.ts
+++ b/tests/e2e/zzz-order-dependence-victim.test.ts
@@ -22,14 +22,22 @@ await bootShared()
 describe('order-dependence: seed-dependent victim', () => {
   it('still sees the seeded rides even though an earlier file deleted them all', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const rides = await $fetch<unknown[]>('/api/get/rides', { headers: { cookie } })
+    const { items: rides } = await $fetch<{ items: unknown[] }>('/api/get/rides?pageSize=100', {
+      headers: { cookie },
+    })
     expect(rides.length).toBeGreaterThanOrEqual(9)
   })
 
   it('restores seeded clients and volunteers too', async () => {
     const cookie = await loginAs('reachtusharwani@gmail.com')
-    const clients = await $fetch<unknown[]>('/api/get/clients', { headers: { cookie } })
-    const volunteers = await $fetch<unknown[]>('/api/get/volunteers', { headers: { cookie } })
+    const { items: clients } = await $fetch<{ items: unknown[] }>(
+      '/api/get/clients?pageSize=100',
+      { headers: { cookie } }
+    )
+    const { items: volunteers } = await $fetch<{ items: unknown[] }>(
+      '/api/get/volunteers?pageSize=100',
+      { headers: { cookie } }
+    )
     expect(clients.length).toBeGreaterThanOrEqual(3)
     expect(volunteers.length).toBeGreaterThanOrEqual(3)
   })


### PR DESCRIPTION
## What was broken

The four list endpoints (`server/api/get/{rides,clients,volunteers,admins}/index.ts`) ran unbounded `prisma.*.findMany()` calls — no `take`/`skip`. The rides dashboard fetched the **entire ride history** (with nested `client.user`/`volunteer.user` joins) on every load and filtered it client-side, so both the server and the browser degrade as the data grows (issue #13).

## What changed

**Backend — real server-side pagination (bounded).**
- New shared helper `server/utils/pagination.ts`: parses `?page` (1-based) and `?pageSize` (default 20), **hard-caps** `pageSize` to 100 and `page` to 1,000,000, and defines the `PageEnvelope` type.
- All four list endpoints now return `{ items, total, page, pageSize }` using `skip`/`take` + `count()` in a single `$transaction` (consistent total). Existing **soft-delete (`deletedAt: null`)** and **role-scoping** (issue #3) filters are preserved and applied to **both** the page query and the count.
- The rides dashboard's **date-range, status include/exclude, `assign:ME`, and text search** filtering moved to the backend (`?startDate`/`?endDate`/`?include`/`?exclude`/`?search`) so it composes with pagination instead of only filtering the current page. Status values are whitelisted against the real `RideStatus` enum so a bad param can't crash Prisma.

**Backend — bounded dropdown options endpoints.**
- `GET /api/get/clients/options` → `{ id, name, homeAddress }` (homeAddress kept for the create-ride pickup autofill), `GET /api/get/volunteers/options` → `{ id, name }`, AVAILABLE only. Both admin-only, hard-capped at 500 (bounded, not unbounded). The create/edit-ride volunteer pickers and the client picker now use these.

**Frontend — real pagination controls.**
- `app/pages/rides/index.vue` (rides table) and `app/pages/people.vue` (volunteers/clients/admins tabs) consume `.items`/`.total`, render `<UPagination>`, and **refetch server-side on page change**. Search is debounced; changing any filter/search/sort resets to page 1.

## Verification

**New regression test:** `tests/e2e/pagination.test.ts` (admin `loginAs`). Asserts, against the seeded 9 rides:
- `?page=1&pageSize=2` → `items.length === 2`, `total >= 9`, `page === 1`, `pageSize === 2`.
- `?page=2&pageSize=2` → a **different, non-overlapping** slice.
- oversized `?pageSize=100000` is **clamped to 100**.
- all four endpoints return the envelope; server-side `?include=status:CREATED` filtering yields `total === 4`.
- query-count seam stays bounded (`findMany` + `count`, not per-row).
- options endpoints return the minimal `{ id, name }` shape (3 AVAILABLE volunteers), no `user`/PII.
- empty `?pageSize=` falls back to the default (20); an absurd `?page=9007199254740991` is clamped (no unsafe-integer 500).

**Pre-fix failure (revert-checked):** with `server/api/get/rides/index.ts` reverted to the `origin/main` bare-array version, 6 of the pagination tests fail, e.g.:
> `expect(Array.isArray(res.items)).toBe(true)` — `Expected true, Received false`
> `TypeError: Cannot read properties of undefined (reading 'length')` at `expect(res.items.length)...`

because the old endpoint returns a bare array so `.items`/`.total` are `undefined`. Post-fix all pass.

**Contract change — every consumer updated.** This flips the four endpoints from a bare array to the envelope, so all consumers were migrated:
- Frontend: `people.vue`, `rides/index.vue`, `rides/[id].vue`.
- Tests (old array shape → `.items`, `pageSize=100` where the full set is needed): `smoke`, `query-count-seam` (bound raised 5→6 for the added `count()`), `pii-scoping`, `record-scoping`, `auth-middleware`, `signup-race`, `soft-deletes`, `safe-delete`, `orphaned-users`, `unassign-status`, `complete-requires-ridetime`, `audit-log`, `ride-cancel`, `ride-input-validation`, `ride-navigate-link`, `aaa-/zzz-order-dependence`, `topRiders-n1`, `address-normalization`, `address-matchkey-display`, `ride-broadcast-nonblocking`, `metrics-date-range`, `empty-phone`, `admin-empty-phone`, `admin-delete`.

**Suite:** `pnpm test` → **139 passed (35 files)**. `pnpm build` → success.

## Notes / decisions

- Frontend `.vue` behavior (UPagination, reactive refetch) can't be exercised by the e2e harness (API/SSR only); the backend pagination + options endpoints are fully tested, and the table UI is correct-by-inspection.
- **Search/filter moved server-side** for both pages (client-side filtering would only filter the current page once paginated). SQLite `contains` is case-insensitive for ASCII (matches the old lower-cased search); non-ASCII case-folding is a minor edge-case difference.
- The volunteer **options** endpoint is AVAILABLE-only. The edit-ride modal falls back to the ride's own volunteer record so an assigned-but-now-UNAVAILABLE volunteer still displays and isn't dropped on save.
- No schema/CI/docker/deps/auth-config changes.

Fixes #13