### PR TITLE
Fix #93: scope get/rides/estimate/[id] to the caller (mirror byId)

### DIFF
--- a/server/api/get/rides/estimate/[id].ts
+++ b/server/api/get/rides/estimate/[id].ts
@@ -23,6 +23,7 @@ export default defineEventHandler(async (event): Promise<EstimateResponse> => {
   const ride = await prisma.ride.findFirst({
     where: { id, deletedAt: null },
     select: {
+      status: true,
       pickupDisplay: true,
       dropoffDisplay: true,
       cachedDistanceText: true,
@@ -30,6 +31,7 @@ export default defineEventHandler(async (event): Promise<EstimateResponse> => {
       cachedDurationText: true,
       cachedDurationValue: true,
       estimatedAt: true,
+      volunteer: { select: { userId: true } },
     },
   })
 
@@ -38,6 +40,23 @@ export default defineEventHandler(async (event): Promise<EstimateResponse> => {
       statusCode: 404,
       statusMessage: 'Ride not found',
     })
+  }
+
+  // Record-level scoping (issue #93, same class as #41): a non-admin may only
+  // read the estimate of a ride that is available to sign up for (CREATED) or
+  // that is assigned to them — never another volunteer's ride, and never
+  // triggering a billable Directions call on a ride that isn't theirs. Return
+  // 404 (not 403) so we don't reveal that the ride exists, matching
+  // get/rides/byId/[id].ts.
+  const session = getAuth(event)
+  const role = session?.user?.role
+  if (role !== 'ADMIN') {
+    const userId = session?.user?.id
+    const isAvailable = ride.status === 'CREATED'
+    const isMine = !!userId && ride.volunteer?.userId === userId
+    if (!isAvailable && !isMine) {
+      throw createError({ statusCode: 404, statusMessage: 'Ride not found' })
+    }
   }
 
   // Issue #14: serve the cached estimate when present. This avoids a live

--- a/tests/e2e/rides-estimate-scoping.test.ts
+++ b/tests/e2e/rides-estimate-scoping.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Issue #93 (sibling of #41): GET /api/get/rides/estimate/[id] did a bare
+// findFirst({ id, deletedAt: null }) with no session/role check, so any
+// authenticated volunteer could read ANY ride's cached estimate — and trigger a
+// billable Google Directions call on a cache miss — for rides that aren't theirs.
+// get/rides/byId/[id] already 404s in that case (#41); the estimate endpoint
+// must apply the same record-level scoping: a non-admin may only reach a ride
+// that is available (CREATED) or assigned to them, else 404.
+
+type Ride = {
+  id: string
+  status: string
+  volunteer: { userId: string } | null
+}
+
+interface EstimateResponse {
+  duration: string | null
+  distance: string | null
+  durationValue: number | null
+  distanceValue: number | null
+  error: string | null
+}
+
+// The test env configures no server Maps key, and no seeded ride has a cached
+// estimate, so an *authorized* call falls through to the cache-miss branch and
+// returns HTTP 200 with this sentinel (see estimate-cache.test.ts). Asserting on
+// it proves the caller cleared the scoping gate and reached the Google branch.
+const MISS_ERROR = 'Maps API Key not configured'
+
+async function allRides(cookie: string): Promise<Ride[]> {
+  const { items } = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie },
+  })
+  return items
+}
+
+describe('issue #93 — get/rides/estimate/[id] record scoping', () => {
+  it("VOLUNTEER cannot read the estimate of another volunteer's non-available ride (404)", async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bobCookie = await loginAs('bob@example.com')
+    const me = await $fetch<{ user: { id: string } }>('/api/get/volunteers/bySession', {
+      headers: { cookie: bobCookie },
+    })
+    const myUserId = me.user.id
+
+    // A ride that is NOT available (not CREATED) and belongs to someone else —
+    // in the seed this is Alice's completed ride. byId already 404s here (#41).
+    const foreign = (await allRides(adminCookie)).find(
+      (r) => r.status !== 'CREATED' && r.volunteer && r.volunteer.userId !== myUserId
+    )
+    expect(foreign, 'seed should contain a ride owned by another volunteer').toBeTruthy()
+
+    // Pre-fix this resolves with HTTP 200 (the cache-miss body) instead of
+    // rejecting, so this assertion fails: the estimate leaks across volunteers.
+    await expect(
+      $fetch(`/api/get/rides/estimate/${foreign!.id}`, { headers: { cookie: bobCookie } })
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('VOLUNTEER CAN read the estimate of their own assigned ride (200)', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bobCookie = await loginAs('bob@example.com')
+    const me = await $fetch<{ user: { id: string } }>('/api/get/volunteers/bySession', {
+      headers: { cookie: bobCookie },
+    })
+    const myUserId = me.user.id
+
+    // Non-available AND mine, so the 200 is due to ownership, not availability.
+    const mine = (await allRides(adminCookie)).find(
+      (r) => r.status !== 'CREATED' && r.volunteer && r.volunteer.userId === myUserId
+    )
+    expect(mine, 'seed should contain a non-available ride assigned to Bob').toBeTruthy()
+
+    const res = await $fetch<EstimateResponse>(`/api/get/rides/estimate/${mine!.id}`, {
+      headers: { cookie: bobCookie },
+    })
+    expect(res.error).toBe(MISS_ERROR)
+  })
+
+  it('VOLUNTEER CAN read the estimate of an available (CREATED) ride (200)', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bobCookie = await loginAs('bob@example.com')
+
+    const available = (await allRides(adminCookie)).find((r) => r.status === 'CREATED')
+    expect(available, 'seed should contain an available ride').toBeTruthy()
+
+    const res = await $fetch<EstimateResponse>(`/api/get/rides/estimate/${available!.id}`, {
+      headers: { cookie: bobCookie },
+    })
+    expect(res.error).toBe(MISS_ERROR)
+  })
+
+  it('ADMIN can read the estimate of any ride (200)', async () => {
+    const adminCookie = await loginAs('reachtusharwani@gmail.com')
+    const bobCookie = await loginAs('bob@example.com')
+    const me = await $fetch<{ user: { id: string } }>('/api/get/volunteers/bySession', {
+      headers: { cookie: bobCookie },
+    })
+    const myUserId = me.user.id
+
+    // The same foreign ride Bob is denied above — admins are unscoped.
+    const foreign = (await allRides(adminCookie)).find(
+      (r) => r.status !== 'CREATED' && r.volunteer && r.volunteer.userId !== myUserId
+    )
+    expect(foreign).toBeTruthy()
+
+    const res = await $fetch<EstimateResponse>(`/api/get/rides/estimate/${foreign!.id}`, {
+      headers: { cookie: adminCookie },
+    })
+    expect(res.error).toBe(MISS_ERROR)
+  })
+})


### PR DESCRIPTION
## What was broken

`GET /api/get/rides/estimate/[id]` did a bare `findFirst({ id, deletedAt: null })` with no session/role check, so **any authenticated volunteer could read ANY ride's cached estimate** — and trigger a billable Google Directions call on a cache miss — for rides that aren't theirs (other volunteers' assigned/completed rides). Meanwhile `get/rides/byId/[id]` already 404s in that case (record-level scoping from #41), so the two endpoints disagreed and the estimate endpoint leaked existence + cached distance/duration across volunteers. Same class as #41; P3 because no addresses/PII are returned directly.

## What changed

`server/api/get/rides/estimate/[id].ts` (+19 lines, no schema change):

- Added `status` and `volunteer: { select: { userId: true } }` to the `findFirst` `select`.
- After the existing not-found check, added the same record-level scoping block used by `get/rides/byId/[id].ts`: for a non-admin, 404 unless the ride is available (`status === 'CREATED'`) or assigned to the caller (`ride.volunteer?.userId === session.user.id`). Returns **404, not 403**, so we don't reveal the ride exists — matching `byId`. Admins are unscoped. Authorized callers get the unchanged `EstimateResponse`.

The block is fail-closed: a missing/unknown role falls into the scoped branch, and `!!userId` guards against an `undefined === undefined` match on ownership.

## Verification

New regression test `tests/e2e/rides-estimate-scoping.test.ts` (4 tests), mirroring `record-scoping.test.ts` (dynamic ride discovery via the admin list endpoint) and `estimate-cache.test.ts` (the `EstimateResponse` shape + the no-API-key cache-miss sentinel):

- **`VOLUNTEER cannot read the estimate of another volunteer's non-available ride (404)`** — the pre-fix failer. As Bob, `GET /api/get/rides/estimate/<a non-CREATED ride owned by another volunteer>` must 404. Pre-fix it resolved with HTTP 200:
  > `AssertionError: promise resolved "{ duration: null, distance: null, …(3) }" instead of rejecting` — at `tests/e2e/rides-estimate-scoping.test.ts:63` (`.rejects.toMatchObject({ statusCode: 404 })`), body `{ error: 'Maps API Key not configured', ...nulls }`.

  Post-fix it passes (404).
- **Non-regressions (all 200):** as Bob, the estimate for his OWN non-available (assigned) ride; as Bob, the estimate for a CREATED ride; as ADMIN, the estimate for any ride. Each asserts the authorized cache-miss response (`error === 'Maps API Key not configured'`), proving the caller cleared the scoping gate and reached the Directions branch. These pass both pre- and post-fix (they guard against an over-aggressive fix).

Confirmed the target assertion **fails before the fix and passes after**. Full suite green with the fix applied: **38 files / 147 tests passed** (baseline 37/143 + this file's 4). `estimate-cache.test.ts` authenticates as admin, so it is unaffected.

Note on seed data: there is no ride *ASSIGNED* to Alice, but there is one *COMPLETED* by her; for scoping these are equivalent (non-CREATED + not Bob's must 404), and the test discovers "a non-available ride owned by another volunteer" dynamically rather than hardcoding ids.

## Follow-ups (out of scope, not addressed here)

- The scoping block is now duplicated between `byId` and `estimate`. Extracting a shared `assertRideVisible(session, ride)` helper would reduce duplication but touches `byId` (an auth-critical file) and widens this P3 diff, so I left it consistent-by-copy per the "mirror byId / one issue per PR" guidance. Candidate for a small tech-debt cleanup later.

Fixes #93