### PR TITLE
Fix #87: Volunteers cannot complete their own rides — UI offers 'Mark as Completed' but the API returns 403

### DIFF
--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -120,10 +120,12 @@
 
   async function handleComplete(event: any) {
     try {
-      await $fetch(`/api/put/rides/${id}`, {
-        method: 'PUT',
+      // Self-service completion endpoint (issue #87): PUT /api/put/rides/[id] is
+      // blocked for volunteers by the global auth middleware, so the assigned
+      // volunteer (and admins) complete a ride through this dedicated POST.
+      await $fetch(`/api/post/rides/${id}/complete`, {
+        method: 'POST',
         body: {
-          status: 'COMPLETED',
           totalRideTime: event.data.totalRideTime,
         },
       })

--- a/server/api/post/rides/[id]/complete.ts
+++ b/server/api/post/rides/[id]/complete.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod'
+import { Prisma } from '../../../../../prisma/generated/client'
+import { prisma } from '../../../../utils/prisma'
+import { sendEmail } from '../../../../utils/email'
+import { sendNotification } from '../../../../utils/notification'
+import { readValidatedBody } from '../../../../utils/validation'
+
+// Self-service ride completion (issue #87).
+//
+// The ride-detail UI's "Mark as Completed" button (app/pages/rides/[id].vue) is
+// shown to the assigned volunteer, but the only completion path was
+// PUT /api/put/rides/[id], which the global auth middleware blocks for
+// volunteers (403 "Admin access required"). This dedicated endpoint mirrors the
+// signup/unsignup self-service pattern: the middleware allows the POST (via
+// VOLUNTEER_WRITE_ALLOW), and authorization is enforced HERE — the caller must
+// be an ADMIN or the volunteer actually assigned to this ride.
+//
+// It reuses the same completion semantics as the admin PUT path so the two
+// stay behaviour-consistent:
+//   - a ride can only be COMPLETED from ASSIGNED (soft-deleted rides are 404);
+//   - a valid totalRideTime (>= 0.1h) is required (issue #10) — otherwise the
+//     ride completes with null/zero hours and skews the hours metrics (#18);
+//   - on success it writes a RIDE_COMPLETED audit row (issue #28) and sends the
+//     RIDE_COMPLETED notification + admin emails (same side-effects as PUT).
+const completeSchema = z
+  .object({
+    // Mirror the issue #10 guard in server/api/put/rides/[id].ts.
+    totalRideTime: z.number().min(0.1),
+  })
+  .strict()
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Ride ID is required' })
+  }
+
+  // Session resolved by the global auth middleware (server/middleware/auth.ts).
+  const session = getAuth(event)
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  // Validate the body before any writes (issue #31): a missing/zero/negative
+  // duration is a 400 here, mirroring the admin PUT completion guard (#10).
+  const { totalRideTime } = await readValidatedBody(event, completeSchema)
+
+  // Soft delete (issue #27): an archived ride can't be completed — treat as 404.
+  const ride = await prisma.ride.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      volunteer: { include: { user: true } },
+      client: { include: { user: true } },
+    },
+  })
+
+  if (!ride) {
+    throw createError({ statusCode: 404, statusMessage: 'Ride not found' })
+  }
+
+  // Authorization: an ADMIN, or the volunteer actually assigned to this ride.
+  // A logged-in non-owner gets 404 (not 403) so the endpoint doesn't reveal
+  // another volunteer's ride assignment (mirrors GET rides/byId scoping, #41).
+  const isAdmin = session.user.role === 'ADMIN'
+  const isOwner = !!ride.volunteer && ride.volunteer.userId === session.user.id
+  if (!isAdmin && !isOwner) {
+    throw createError({ statusCode: 404, statusMessage: 'Ride not found' })
+  }
+
+  // State guard: only an ASSIGNED ride can be completed. Rejecting
+  // CREATED/COMPLETED/CANCELLED here keeps the ride state machine honest.
+  if (ride.status !== 'ASSIGNED') {
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'Only an assigned ride can be completed',
+    })
+  }
+
+  // Atomic transition (mirrors signup/unsignup, issue #12): guard the write on
+  // the exact state we validated — still ASSIGNED AND still assigned to the same
+  // volunteer — so a concurrent unassign OR reassignment can't race it. Pinning
+  // volunteerId (as unsignup pins it) is what stops the read→write window where
+  // an admin reassigns the ride while an owner is completing it, which would
+  // otherwise credit the new volunteer with this caller's reported hours. If the
+  // ride is no longer this ASSIGNED, same-volunteer ride, Prisma throws P2025 → 409.
+  let updated
+  try {
+    updated = await prisma.ride.update({
+      where: { id, status: 'ASSIGNED', volunteerId: ride.volunteerId, deletedAt: null },
+      data: { status: 'COMPLETED', totalRideTime },
+      include: {
+        volunteer: { include: { user: true } },
+        client: { include: { user: true } },
+      },
+    })
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'Ride is no longer available to complete',
+      })
+    }
+    throw err
+  }
+
+  // Audit (issue #28): a status transition to COMPLETED. Mirrors the PUT path's
+  // status-derived RIDE_COMPLETED action + minimal { from, to } details.
+  await writeAuditLog(event, {
+    action: 'RIDE_COMPLETED',
+    targetType: 'Ride',
+    targetId: updated.id,
+    details: { from: ride.status, to: updated.status },
+  })
+
+  // Notifications (mirror the PUT COMPLETED transition): notify the volunteer
+  // and the admins. Email sends are swallowed in the test env (issue #25).
+  const scheduledTime = new Date(updated.scheduledTime)
+  const commonContext = {
+    client: updated.client.user.name,
+    pickup: updated.pickupDisplay,
+    dropoff: updated.dropoffDisplay,
+    date: formatNotificationDate(scheduledTime),
+    time: formatNotificationTime(scheduledTime),
+    link: `${process.env.APP_URL || 'http://localhost:3000'}/rides/${updated.id}`,
+    notes: updated.notes || 'None',
+  }
+
+  if (updated.volunteer) {
+    await sendNotification('RIDE_COMPLETED', updated.volunteer.id, {
+      name: updated.volunteer.user.name,
+      ...commonContext,
+    })
+  }
+
+  const admins = await prisma.user.findMany({ where: { role: 'ADMIN' } })
+  admins
+    .map((admin) => admin.email)
+    .filter(Boolean)
+    .forEach((email) => {
+      if (email) {
+        sendEmail(
+          email,
+          'Ride Completed by Volunteer',
+          `
+            <h1>Ride Completed</h1>
+            <p><strong>Volunteer:</strong> ${updated.volunteer?.user?.name || 'N/A'}</p>
+            <p><strong>Ride Details:</strong></p>
+            <p><strong>From:</strong> ${updated.pickupDisplay}</p>
+            <p><strong>To:</strong> ${updated.dropoffDisplay}</p>
+            <p><strong>Total Time:</strong> ${updated.totalRideTime || 'N/A'} hours</p>
+          `
+        ).catch(console.error)
+      }
+    })
+
+  return updated
+})

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -16,6 +16,7 @@ import { auth } from '../utils/auth'
 const VOLUNTEER_WRITE_ALLOW = [
   /^\/api\/post\/rides\/[^/]+\/signup$/,
   /^\/api\/post\/rides\/[^/]+\/unsignup$/,
+  /^\/api\/post\/rides\/[^/]+\/complete$/,
   /^\/api\/put\/volunteers\/bySession(\/|$)/,
 ]
 

--- a/tests/e2e/rides-volunteer-complete.test.ts
+++ b/tests/e2e/rides-volunteer-complete.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+type Ride = {
+  id: string
+  status: 'CREATED' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED'
+  volunteerId: string | null
+  totalRideTime: number | null
+  volunteer: { userId: string; user: { email: string } } | null
+}
+
+const ADMIN = 'reachtusharwani@gmail.com'
+const BOB = 'bob@example.com'
+const ALICE = 'alice@example.com'
+
+async function getRides(cookie: string): Promise<Ride[]> {
+  // /api/get/rides is paginated (issue #13); pageSize=100 fetches the full set.
+  const res = await $fetch<{ items: Ride[] }>('/api/get/rides?pageSize=100', {
+    headers: { cookie },
+  })
+  return res.items
+}
+
+function put(cookie: string, id: string, body: Record<string, unknown>) {
+  return $fetch<Ride>(`/api/put/rides/${id}`, {
+    method: 'PUT',
+    headers: { cookie },
+    body,
+  })
+}
+
+// Raw POST to the self-service complete endpoint so we can assert the exact
+// status code — including the pre-fix 403 the global auth middleware returns for
+// a volunteer POST outside VOLUNTEER_WRITE_ALLOW (appFetch does not throw on
+// non-2xx the way $fetch does).
+function postComplete(cookie: string, id: string, body: Record<string, unknown>) {
+  return appFetch(`/api/post/rides/${id}/complete`, {
+    method: 'POST',
+    headers: { cookie, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function volunteerIdByEmail(adminCookie: string, email: string): Promise<string> {
+  // The admin ride listing includes volunteer.user, so we can resolve a
+  // volunteer's id from any ride they are attached to without hard-coding ids.
+  const match = (await getRides(adminCookie)).find((r) => r.volunteer?.user?.email === email)
+  expect(match, `seed should have a ride whose volunteer is ${email}`).toBeTruthy()
+  return match!.volunteerId!
+}
+
+// Rides this file mutated; restored to CREATED/unassigned after each test so a
+// COMPLETED/ASSIGNED ride from one `it` can't leak into the next (the seed DB is
+// reset per-file, not per-test).
+const touchedRideIds = new Set<string>()
+
+// Assign a fresh, untouched CREATED ride to the given volunteer and return its
+// id, so each destructive test operates on its own ride.
+async function freshAssignedRideFor(adminCookie: string, volunteerId: string): Promise<string> {
+  const created = (await getRides(adminCookie)).find(
+    (r) => r.status === 'CREATED' && !touchedRideIds.has(r.id),
+  )
+  expect(created, 'seed should have an untouched CREATED ride').toBeTruthy()
+  touchedRideIds.add(created!.id)
+  const assigned = await put(adminCookie, created!.id, { volunteerId, status: 'ASSIGNED' })
+  expect(assigned.status).toBe('ASSIGNED')
+  return created!.id
+}
+
+afterEach(async () => {
+  if (!touchedRideIds.size) return
+  const cookie = await loginAs(ADMIN)
+  for (const id of touchedRideIds) {
+    await put(cookie, id, { volunteerId: '', status: 'CREATED' })
+  }
+  touchedRideIds.clear()
+})
+
+describe('POST /api/post/rides/[id]/complete — volunteers can complete their own rides (issue #87)', () => {
+  it('lets the assigned volunteer complete their ride (200) and persists COMPLETED + totalRideTime', async () => {
+    const adminCookie = await loginAs(ADMIN)
+    const bobVolId = await volunteerIdByEmail(adminCookie, BOB)
+    const rideId = await freshAssignedRideFor(adminCookie, bobVolId)
+
+    // Headline. Pre-fix this endpoint does not exist AND the global auth
+    // middleware 403s any volunteer POST outside VOLUNTEER_WRITE_ALLOW, so this
+    // returned 403 "Admin access required" and the ride stayed ASSIGNED.
+    const bobCookie = await loginAs(BOB)
+    const res = await postComplete(bobCookie, rideId, { totalRideTime: 1.5 })
+    expect(res.status).toBe(200)
+
+    const after = (await getRides(adminCookie)).find((r) => r.id === rideId)
+    expect(after!.status).toBe('COMPLETED')
+    expect(after!.totalRideTime).toBe(1.5)
+  })
+
+  it('rejects a volunteer completing a ride assigned to a different volunteer (alice) — 403/404, ride not completed', async () => {
+    const adminCookie = await loginAs(ADMIN)
+    const aliceVolId = await volunteerIdByEmail(adminCookie, ALICE)
+    const rideId = await freshAssignedRideFor(adminCookie, aliceVolId)
+
+    // Bob is not the assigned volunteer, so even a well-formed request must be
+    // rejected on ownership grounds — the ride must NOT be completed.
+    const bobCookie = await loginAs(BOB)
+    const res = await postComplete(bobCookie, rideId, { totalRideTime: 1.5 })
+    expect([403, 404]).toContain(res.status)
+
+    const after = (await getRides(adminCookie)).find((r) => r.id === rideId)
+    expect(after!.status).toBe('ASSIGNED')
+  })
+
+  it('rejects completion with missing or zero totalRideTime (400 — mirrors the issue #10 guard), ride not completed', async () => {
+    const adminCookie = await loginAs(ADMIN)
+    const bobVolId = await volunteerIdByEmail(adminCookie, BOB)
+    const rideId = await freshAssignedRideFor(adminCookie, bobVolId)
+
+    // Owner (bob) but bogus duration: the #10 guard must reject it so a ride
+    // can't be completed with null/zero hours (which skews the hours metrics).
+    const bobCookie = await loginAs(BOB)
+    const missing = await postComplete(bobCookie, rideId, {})
+    expect(missing.status).toBe(400)
+    const zero = await postComplete(bobCookie, rideId, { totalRideTime: 0 })
+    expect(zero.status).toBe(400)
+
+    const after = (await getRides(adminCookie)).find((r) => r.id === rideId)
+    expect(after!.status).toBe('ASSIGNED')
+  })
+
+  it('non-regression: an admin can still complete a ride via PUT /api/put/rides/[id]', async () => {
+    const adminCookie = await loginAs(ADMIN)
+    const bobVolId = await volunteerIdByEmail(adminCookie, BOB)
+    const rideId = await freshAssignedRideFor(adminCookie, bobVolId)
+
+    const updated = await put(adminCookie, rideId, { status: 'COMPLETED', totalRideTime: 2 })
+    expect(updated.status).toBe('COMPLETED')
+    expect(updated.totalRideTime).toBe(2)
+  })
+})


### PR DESCRIPTION
## What was broken

The ride-detail page (`app/pages/rides/[id].vue`) shows **Mark as Completed** to the assigned volunteer, but the completion modal called `PUT /api/put/rides/[id]`. The global auth middleware only allows volunteer writes matching `VOLUNTEER_WRITE_ALLOW` (signup, unsignup, `put/volunteers/bySession`), so a volunteer `PUT` to a ride returned **403 "Admin access required"** → toast "Failed to complete ride", ride stayed `ASSIGNED`. Since completed-hours metrics depend on the volunteer-reported `totalRideTime`, the core volunteer workflow was entirely broken (only admins could complete rides).

## What changed (Option 2 — dedicated self-service endpoint)

- **New `POST /api/post/rides/[id]/complete`** (`server/api/post/rides/[id]/complete.ts`), consistent with the existing `signup`/`unsignup` self-service endpoints. Authorization is enforced **in the handler** via `getAuth(event)`: allowed if the caller is an ADMIN **or** the volunteer actually assigned to the ride (`ride.volunteer.userId === session.user.id`); a logged-in non-owner gets **404** (not 403) so the endpoint doesn't reveal another volunteer's assignment (mirrors the `GET rides/byId` scoping, #41). It mirrors the admin PUT completion semantics:
  - state guard: only an `ASSIGNED` ride can be completed (`CREATED`/`COMPLETED`/`CANCELLED` → 409); soft-deleted rides → 404 (#27).
  - input guard: body `{ totalRideTime }` validated `z.number().min(0.1)` — the same issue #10 guard as `put/rides/[id].ts` (reject bogus/missing/zero duration → 400).
  - atomic transition guarded on **both `status: 'ASSIGNED'` and `volunteerId`** (as `unsignup` pins `volunteerId`), so a concurrent unassign/reassign can't race it or mis-credit hours → P2025 maps to 409.
  - side-effects: writes a `RIDE_COMPLETED` audit log (#28) and sends the `RIDE_COMPLETED` notification + admin emails — the same effects the admin PUT COMPLETED transition performs.
- **Middleware** (`server/middleware/auth.ts`): one new `VOLUNTEER_WRITE_ALLOW` entry `/^\/api\/post\/rides\/[^/]+\/complete$/`. ⚠️ **This is an auth-config change** — flagged for human review (expected).
- **UI** (`app/pages/rides/[id].vue`): repoint only the completion modal's `handleComplete` from `PUT /api/put/rides/[id]` `{status, totalRideTime}` to `POST /api/post/rides/[id]/complete` `{totalRideTime}`. The admin edit/assign/cancel/delete calls are untouched.

Admin completion still works via **both** the new endpoint (allows ADMIN) and the existing `PUT /api/put/rides/[id]` (unchanged; still used by the admin edit flow and existing API tests).

## Verification

New regression test: **`tests/e2e/rides-volunteer-complete.test.ts`** (4 tests, all green; full suite **147 passed / 38 files**; `nuxt build` succeeds). Ride ids/assignments are discovered dynamically as admin via `GET /api/get/rides?pageSize=100` (no hard-coded ids/timestamps).

- `lets the assigned volunteer complete their ride (200) and persists COMPLETED + totalRideTime` — **headline; fails pre-fix, passes post-fix.** Pre-fix (endpoint absent + middleware blocks the volunteer POST) the observed failure was:
  ```
  AssertionError: expected 403 to be 200
   ❯ tests/e2e/rides-volunteer-complete.test.ts:94
       expect(res.status).toBe(200)
  ```
  i.e. bob's `POST /api/post/rides/<id>/complete` returned **403 "Admin access required"** from the middleware. Post-fix it returns 200 and the ride is `COMPLETED` with `totalRideTime` 1.5.
- `rejects a volunteer completing a ride assigned to a different volunteer (alice)` — bob → 403/404, ride stays `ASSIGNED` (handler ownership check).
- `rejects completion with missing or zero totalRideTime (400 — mirrors the issue #10 guard)` — owner + bogus duration → 400, ride stays `ASSIGNED`.
- `non-regression: an admin can still complete a ride via PUT /api/put/rides/[id]` — admin PUT completion path unchanged.

**Coverage note:** this is an API-level test and does not drive the browser, so the one-line UI repoint (`PUT`→`POST`) is verified by inspection rather than by the regression (reverting only that line would leave the suite green). The "Mark as Completed" button is correctly gated (`isVolunteer && isAssignedToMe && ride.status === 'ASSIGNED'`) and now points at the working endpoint.

## Behavior decisions

- **Notification kept:** the endpoint sends the `RIDE_COMPLETED` notification + admin emails, matching the admin PUT path (not omitted).
- **Admin path:** admins can use the new endpoint *and* still use `PUT /api/put/rides/[id]`; the PUT path is intentionally left in place (admin edit flow + existing tests).
- **404 vs 403 for non-owner:** chose 404 to avoid revealing another volunteer's ride assignment, consistent with `GET rides/byId` (#41).

## Follow-ups (not in scope here)
- A soft-deleted volunteer (#27) holding a live session and still assigned to an `ASSIGNED` ride could complete it here (the `sendNotification` re-lookup already no-ops for archived users, so impact is negligible) — session-invalidation for archived volunteers belongs with #27, not this fix.

Fixes #87