### PR TITLE
Fix #88: guard DELETE /api/delete/admins/[id] (role check, self-delete, last-admin)

### DIFF
--- a/server/api/delete/admins/[id].ts
+++ b/server/api/delete/admins/[id].ts
@@ -11,23 +11,61 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Issue #88: reject self-delete. An admin archiving their own account (and, in
+  // particular, the last admin — see the count guard below) can permanently lock
+  // the org out of user management, since only an ADMIN can create/promote
+  // admins (POST /api/post/admins is admin-only). The caller's session is
+  // resolved by the global auth middleware onto event.context.auth.
+  const session = getAuth(event)
+  if (session?.user?.id === id) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'You cannot delete your own admin account',
+    })
+  }
+
+  // Issue #88: this endpoint deletes ADMINs only. Without the role filter it
+  // would archive ANY user (e.g. a VOLUNTEER's user row), leaving a half-archived
+  // inconsistent state — the volunteer profile stays active and their ASSIGNED
+  // rides are never released, unlike a proper delete/volunteers. Scope the lookup
+  // to role: 'ADMIN' so a non-admin id resolves to "not found" (404).
+  //
   // Soft delete (issue #27): archive the user instead of destroying it. Read the
   // current contact values so we can RELEASE them: copy email -> deletedEmail and
   // phone -> deletedPhone, then null out email/phone so the same email/phone can
   // be reused by a new record without a unique violation (decision #2). Guard on
   // deletedAt: null so a second delete 404s (P2025) rather than re-archiving.
   const existing = await prisma.user.findFirst({
-    where: { id, deletedAt: null },
+    where: { id, role: 'ADMIN', deletedAt: null },
     select: { email: true, phone: true },
   })
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: 'Admin not found' })
   }
 
+  // Issue #88: never delete the last remaining admin. In practice this is almost
+  // always a self-delete (only an admin can call this, and the sole admin
+  // deleting themselves is caught above), so this early check is mainly a clear,
+  // fast error for the common sequential case. It is NOT sufficient on its own:
+  // two admins deleting EACH OTHER concurrently are not self-deletes and could
+  // both read count > 1 here before either archive commits — so the invariant is
+  // re-checked inside the write-serialized transaction below.
+  const activeAdmins = await prisma.user.count({
+    where: { role: 'ADMIN', deletedAt: null },
+  })
+  if (activeAdmins <= 1) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'Cannot delete the last remaining admin',
+    })
+  }
+
   try {
     const updated = await prisma.$transaction(async (tx) => {
       const u = await tx.user.update({
-        where: { id, deletedAt: null },
+        // role: 'ADMIN' mirrors the findFirst guard above (issue #88,
+        // defense-in-depth) so this path can never archive a non-admin.
+        where: { id, role: 'ADMIN', deletedAt: null },
         data: {
           deletedAt: new Date(),
           deletedEmail: existing.email,
@@ -40,6 +78,21 @@ export default defineEventHandler(async (event) => {
       // to the session table and log the user out. Soft delete must do the same
       // explicitly, or an archived user's live cookie would keep API access.
       await tx.session.deleteMany({ where: { userId: id } })
+      // Concurrency backstop for the last-admin guard (issue #88): re-count
+      // admins AFTER this archive, inside the transaction. better-sqlite3
+      // serializes write transactions, so a concurrent cross-delete has already
+      // committed (and is counted) or is still blocked; either way, if archiving
+      // this admin would leave zero admins, roll back with the same 409 rather
+      // than lock the org out.
+      const remainingAdmins = await tx.user.count({
+        where: { role: 'ADMIN', deletedAt: null },
+      })
+      if (remainingAdmins < 1) {
+        throw createError({
+          statusCode: 409,
+          statusMessage: 'Cannot delete the last remaining admin',
+        })
+      }
       return u
     })
 

--- a/tests/e2e/delete-admins-guard.test.ts
+++ b/tests/e2e/delete-admins-guard.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// Issue #88: DELETE /api/delete/admins/[id] was unguarded.
+//   1. No role check — it looked up the target `user` by id with no
+//      role: 'ADMIN' filter, so pointing it at a VOLUNTEER's user id returned
+//      200 and archived that user while the `volunteer` row stayed active (a
+//      half-archived state; ASSIGNED rides were NOT released, unlike a proper
+//      delete/volunteers).
+//   2. Self-delete was allowed — an admin could archive their own account.
+//   3. No last-admin guard — nothing stopped archiving the final ADMIN, which
+//      can permanently lock the org out of user management (only admins can
+//      create admins via the admin-only POST /api/post/admins).
+//
+// Seeded (prisma/seed.ts): TWO admins — reachtusharwani@gmail.com (ADMIN_A) and
+// tmw220003@utdallas.edu — plus volunteers bob@ / alice@.
+//
+// The DB is restored to the seed snapshot once per file (tests/setup-reset-db.ts),
+// but tests within this file share state and run in order. These tests archive
+// users (destructive), so they operate on disposable admins and only ever touch
+// the seeded ADMIN_A / seeded volunteers non-destructively (or in the LAST test,
+// which is allowed to leave ADMIN_A archived in a pre-fix run).
+
+const ADMIN_A = 'reachtusharwani@gmail.com'
+const uniq = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+type UserRow = { id: string; email: string | null; role: string; deletedAt: string | null }
+type AdminRow = { id: string; email: string | null }
+type VolunteerRow = { id: string; userId: string; deletedAt: string | null; user: { email: string | null } }
+
+async function getUsers(cookie: string): Promise<UserRow[]> {
+  return await $fetch<UserRow[]>('/api/get/users', { headers: { cookie } })
+}
+
+async function getAdmins(cookie: string): Promise<AdminRow[]> {
+  const { items } = await $fetch<{ items: AdminRow[] }>('/api/get/admins?pageSize=100', {
+    headers: { cookie },
+  })
+  return items
+}
+
+async function getVolunteers(cookie: string): Promise<VolunteerRow[]> {
+  const { items } = await $fetch<{ items: VolunteerRow[] }>('/api/get/volunteers?pageSize=100', {
+    headers: { cookie },
+  })
+  return items
+}
+
+describe('DELETE /api/delete/admins/[id] guards (#88)', () => {
+  // HEADLINE (must FAIL pre-fix / pass post-fix): the endpoint must refuse to
+  // archive a non-admin. Pre-fix this returns 200 and archives the volunteer's
+  // user row; post-fix the role: 'ADMIN' filter makes it a 404 and leaves the
+  // volunteer fully intact.
+  it('refuses to archive a non-admin (volunteer) user → 404, volunteer untouched', async () => {
+    const cookie = await loginAs(ADMIN_A)
+
+    const volunteers = await getVolunteers(cookie)
+    const bob = volunteers.find((v) => v.user.email === 'bob@example.com')
+    expect(bob, 'seeded volunteer bob should exist').toBeTruthy()
+    const bobUserId = bob!.userId
+    expect(bobUserId, 'volunteer should expose its underlying userId').toBeTruthy()
+
+    const res = await appFetch(`/api/delete/admins/${bobUserId}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+
+    // Pre-fix: 200 (the user is archived through the admin endpoint). This is the
+    // headline failing assertion — quoted in the PR.
+    expect(res.status, 'deleting a non-admin via the admin endpoint must 404').toBe(404)
+
+    // The volunteer's user must still be active (no half-archive): still listed
+    // among active users, and still in the volunteer roster (deletedAt null).
+    const users = await getUsers(cookie)
+    const bobUser = users.find((u) => u.id === bobUserId)
+    expect(bobUser, 'volunteer user must still be active (not archived)').toBeTruthy()
+    expect(bobUser!.role).toBe('VOLUNTEER')
+
+    const volunteersAfter = await getVolunteers(cookie)
+    const bobAfter = volunteersAfter.find((v) => v.userId === bobUserId)
+    expect(bobAfter, 'volunteer profile must still be in the active roster').toBeTruthy()
+    expect(bobAfter!.deletedAt, 'volunteer must not be archived').toBeNull()
+  })
+
+  // Self-delete guard, ISOLATED from the last-admin guard: with a disposable 2nd
+  // admin plus the two seeded admins, deleting your own account is rejected 409
+  // even though you are clearly not the last admin.
+  it('rejects an admin deleting their own account → 409, account stays active', async () => {
+    const adminCookie = await loginAs(ADMIN_A)
+
+    const email = `disposable-selfdelete-${uniq()}@example.com`
+    const created = await $fetch<{ id: string }>('/api/post/admins', {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: { name: 'Disposable Self-Delete Admin', email },
+    })
+    expect(created.id).toBeTruthy()
+
+    // Log in AS the disposable admin and have them delete themselves.
+    const selfCookie = await loginAs(email)
+    const res = await appFetch(`/api/delete/admins/${created.id}`, {
+      method: 'DELETE',
+      headers: { cookie: selfCookie },
+    })
+
+    // Pre-fix: 200 (self-delete succeeds). Post-fix: 409.
+    expect(res.status, 'self-delete must be rejected').toBe(409)
+
+    // Still active — visible in the admin roster (checked as the seeded admin).
+    const admins = await getAdmins(adminCookie)
+    expect(admins.some((a) => a.id === created.id), 'self-deleted admin must still exist').toBe(true)
+  })
+
+  // Non-regression: a legit delete of a different, non-last admin must still work
+  // (200 + archived). Proves the new guards don't over-block. Passes pre- AND
+  // post-fix (correct behavior preserved).
+  it('still archives a different, non-last admin → 200 and it is gone', async () => {
+    const cookie = await loginAs(ADMIN_A)
+
+    const email = `disposable-legit-${uniq()}@example.com`
+    const created = await $fetch<{ id: string }>('/api/post/admins', {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: { name: 'Disposable Legit Admin', email },
+    })
+    expect(created.id).toBeTruthy()
+
+    const res = await appFetch(`/api/delete/admins/${created.id}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+    expect(res.status, 'deleting a non-self, non-last admin must succeed').toBe(200)
+
+    const admins = await getAdmins(cookie)
+    expect(admins.some((a) => a.id === created.id), 'deleted admin must be gone from roster').toBe(
+      false
+    )
+  })
+
+  // Last-admin lockout guard. NOTE: this cannot be isolated from the self-delete
+  // guard at the API level — only an admin can call this endpoint, so deleting
+  // "the last admin" is necessarily the caller deleting themselves, and the
+  // self-delete guard (checked first) is what emits the 409 here. The count-based
+  // guard in the handler is belt-and-suspenders. This test proves the end-to-end
+  // guarantee: even reduced to a single admin, the org cannot be locked out.
+  //
+  // Destructive to ADMIN_A pre-fix (self-delete succeeds and archives it), so it
+  // runs LAST — no later test depends on ADMIN_A's session.
+  it('cannot delete the last remaining admin (lockout prevented) → 409', async () => {
+    const cookie = await loginAs(ADMIN_A)
+
+    // Resolve ADMIN_A's own user id, then archive every OTHER admin so ADMIN_A is
+    // the sole remaining admin.
+    let admins = await getAdmins(cookie)
+    const self = admins.find((a) => a.email === ADMIN_A)
+    expect(self, 'seeded ADMIN_A should be present').toBeTruthy()
+    const selfId = self!.id
+
+    for (const other of admins.filter((a) => a.id !== selfId)) {
+      const delRes = await appFetch(`/api/delete/admins/${other.id}`, {
+        method: 'DELETE',
+        headers: { cookie },
+      })
+      expect(delRes.status, `archiving other admin ${other.id} should succeed`).toBe(200)
+    }
+
+    admins = await getAdmins(cookie)
+    expect(admins.length, 'ADMIN_A must be the only remaining admin').toBe(1)
+    expect(admins[0]!.id).toBe(selfId)
+
+    // Now the sole admin tries to delete themselves — rejected (409). Pre-fix this
+    // returns 200 and archives the last admin, locking the org out.
+    const res = await appFetch(`/api/delete/admins/${selfId}`, {
+      method: 'DELETE',
+      headers: { cookie },
+    })
+    expect(res.status, 'deleting the last remaining admin must be rejected').toBe(409)
+
+    const adminsAfter = await getAdmins(cookie)
+    expect(adminsAfter.some((a) => a.id === selfId), 'last admin must still be active').toBe(true)
+  })
+})


### PR DESCRIPTION
## What was broken

`DELETE /api/delete/admins/[id]` looked up the target `user` by id with **no `role: 'ADMIN'` filter**, so pointing it at a non-admin (e.g. a VOLUNTEER's underlying `user.id`) returned **200 and archived that user** while the `volunteer` row stayed active and their ASSIGNED rides were never released — an inconsistent half-archived state that bypasses the invariants of `delete/volunteers`. The endpoint also allowed an admin to **self-delete** and to **delete the last remaining admin**, which can permanently lock the org out of user management (only an admin can create/promote admins via the admin-only `POST /api/post/admins`).

## What changed (`server/api/delete/admins/[id].ts` only)

- **Role check (headline):** scope the `findFirst` lookup to `role: 'ADMIN'` (and mirror it on the `tx.user.update` `where` for defense-in-depth), so a non-admin id resolves to "not found" → **404**. This stops archiving volunteers/clients through the admin endpoint.
- **Reject self-delete:** resolve the caller via `getAuth(event)`; if `id === session.user.id`, throw **409** before the transaction.
- **Reject last-admin:** a fast pre-transaction check (`count(active admins) <= 1` → 409) for the common case, **plus** a re-count *inside* the write-serialized transaction after archiving that rolls back with the same 409 if the delete would leave zero admins.

Everything the endpoint already did correctly is preserved: soft-delete via archive (deletedAt + release email/phone to deletedEmail/deletedPhone then null them), `session.deleteMany` to revoke sessions, the `writeAuditLog('ADMIN_DELETED', …)` call, and the P2025 → 404 handling. A legit delete of a different, non-last admin still returns **200** and archives.

## Verification

New regression test: **`tests/e2e/delete-admins-guard.test.ts`** (4 tests):

1. `refuses to archive a non-admin (volunteer) user → 404, volunteer untouched` — **headline; fails pre-fix, passes post-fix.**
2. `rejects an admin deleting their own account → 409, account stays active` — self-delete guard, isolated from the last-admin guard (a disposable 2nd admin + 2 seeded admins are present). Fails pre-fix.
3. `still archives a different, non-last admin → 200 and it is gone` — non-regression; passes pre- **and** post-fix, proving the guards don't over-block.
4. `cannot delete the last remaining admin (lockout prevented) → 409` — reduces to a single admin, then that admin's self-delete is rejected.

**Pre-fix run** (fix reverted, test present): 3 failed / 1 passed. Exact headline failure:

```
FAIL tests/e2e/delete-admins-guard.test.ts > refuses to archive a non-admin (volunteer) user → 404, volunteer untouched
AssertionError: deleting a non-admin via the admin endpoint must 404: expected 200 to be 404 // Object.is equality
- 404
+ 200
```

(Tests 2 and 4 also failed pre-fix with `expected 200 to be 409`; test 3 passed pre-fix as designed.)

**Post-fix run:** whole suite green — **38 files / 147 tests passed** (baseline 37/143 + 4 new).

### Notes / decisions

- **Self-delete policy:** always rejected (409), independent of how many admins exist — an admin cannot delete their own account through this endpoint.
- **Last-admin cannot be isolated from self-delete at the API level:** only an admin can call this endpoint, so deleting "the last admin" is necessarily the caller deleting themselves; the self-delete guard fires first and emits the 409. The count-based guard is therefore belt-and-suspenders. Test 4 proves the end-to-end lockout guarantee but does not isolate the count guard (documented in the test).
- **Concurrency:** the pre-transaction count alone has a TOCTOU (two admins deleting *each other* concurrently are not self-deletes and could both read count > 1). The in-transaction re-count after archiving closes it on the write-serialized better-sqlite3 adapter. This path isn't unit-tested because the harness serializes writes and the realistic lockout is already prevented by the self-delete guard.

### Risk files touched

None. The change is confined to `server/api/delete/admins/[id].ts` plus the new test file — no middleware, schema, CI, Docker, or dependency changes.

## Follow-ups

None. Sibling issues noted only where relevant in comments; no scope expansion.

Fixes #88