### PR TITLE
test: reconcile #100 known-bug pins with the merged #87/#88/#93 fixes (green baseline)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -48,7 +48,7 @@ is not documentation that can rot — it is enforced.
 | R-024 | Bulk-PII listings are admin-only: clients(+options), volunteers(+options), users(×3), admins, addresses, metrics(×3), audit, templates (#3, #41) | `requireAdmin` in each handler | auto | `requirements-authz-matrix.test.ts`, `pii-scoping.test.ts` |
 | R-025 | Record-level scoping on `get/rides/byId`: non-admin sees only CREATED rides or rides assigned to them; others 404 (not 403 — no existence leak) (#41) | `get/rides/byId/[id].ts` | auto | `record-scoping.test.ts` |
 | R-026 | `get/rides` list scoping: volunteer receives only CREATED + own rides; fails closed if userId missing (#3) | `get/rides/index.ts` | auto | `pii-scoping.test.ts` |
-| R-027 | `get/rides/estimate/[id]` applies the same record-level scoping as byId | `estimate/[id].ts` | pin [#93](https://github.com/UTDallasEPICS/wcoa/issues/93) | `known-bugs.test.ts` |
+| R-027 | `get/rides/estimate/[id]` applies the same record-level scoping as byId | `estimate/[id].ts` | auto | `known-bugs.test.ts` |
 | R-028 | Frontend route guard: non-admin is redirected away from admin pages (`/`, `/people`, `/admin/**` → `/rides`); unauthenticated → `/auth` (#4) | `app/middleware/auth.global.ts` | auto | `route-guard.test.ts`, browser: `volunteer-flows.spec.ts` |
 | R-029 | `/api/_test/**` seams return 404 unless `TEST_HOOKS=1` (strict prod no-op) | `server/utils/testHooks.ts` | auto | `fault-injection-seam.test.ts` + manual prod-mode boot (audit) |
 | R-030 | Volunteer self-service lookups never trust a session alone — archived volunteer profiles are re-checked (`deletedAt: null`) on signup/unsignup/bySession (#27) | those 5 handlers | auto | `soft-deletes.test.ts` |
@@ -89,8 +89,8 @@ is not documentation that can rot — it is enforced.
 |---|---|---|---|---|
 | R-080 | Admin create requires name+email; promoting an existing user writes a `USER_ROLE_CHANGED` audit row (#28) | `post/admins/index.ts` | auto | `audit-log.test.ts`, `requirements-flows.test.ts` |
 | R-081 | Admin update of an unknown id → 404, not 500 | `put/admins/[id].ts` | pin [#91](https://github.com/UTDallasEPICS/wcoa/issues/91) | `known-bugs.test.ts` |
-| R-082 | `delete/admins` only archives users whose role is ADMIN (404 otherwise) | `delete/admins/[id].ts` | pin [#88](https://github.com/UTDallasEPICS/wcoa/issues/88) | `known-bugs.test.ts` |
-| R-083 | An admin cannot delete their own account, and the last remaining admin cannot be deleted (lockout guard) | `delete/admins/[id].ts` | pin [#88](https://github.com/UTDallasEPICS/wcoa/issues/88) | `known-bugs.test.ts` |
+| R-082 | `delete/admins` only archives users whose role is ADMIN (404 otherwise) | `delete/admins/[id].ts` | auto | `known-bugs.test.ts` |
+| R-083 | An admin cannot delete their own account, and the last remaining admin cannot be deleted (lockout guard) | `delete/admins/[id].ts` | auto | `known-bugs.test.ts` |
 | R-084 | Admin soft-delete releases email/phone, revokes sessions; double-delete 404s | `delete/admins/[id].ts` | auto | `admin-delete.test.ts`, `soft-deletes.test.ts` |
 
 ## 6. Rides — CRUD & lifecycle
@@ -123,7 +123,7 @@ is not documentation that can rot — it is enforced.
 | R-132 | Signup is only possible on a CREATED, non-archived ride (400/404) | `signup.ts` | auto | `requirements-flows.test.ts` |
 | R-133 | Unsignup allowed only for the assigned volunteer (403) and only from ASSIGNED (400); atomic like signup | `unsignup.ts` | auto | `requirements-flows.test.ts` |
 | R-134 | Signup/unsignup notify the volunteer and admins; failures never fail the request | `signup.ts`, `unsignup.ts` | auto | `requirements-flows.test.ts` |
-| R-135 | **A volunteer can complete their OWN assigned ride** (with totalRideTime) through the UI's "Mark as Completed" flow | middleware + `put/rides` | pin [#87](https://github.com/UTDallasEPICS/wcoa/issues/87) | `known-bugs.test.ts`, browser: `volunteer-flows.spec.ts` |
+| R-135 | **A volunteer can complete their OWN assigned ride** (with totalRideTime) through the UI's "Mark as Completed" flow | middleware + `post/rides/[id]/complete` | auto | `known-bugs.test.ts`, browser: `volunteer-flows.spec.ts` |
 
 ## 8. List endpoints — pagination, filtering, search
 

--- a/tests/browser/volunteer-flows.spec.ts
+++ b/tests/browser/volunteer-flows.spec.ts
@@ -52,11 +52,10 @@ test('R-299: signup then unsignup on a CREATED ride through the UI', async ({ pa
   expect(released?.volunteerId).toBeNull()
 })
 
-// R-135 pins issue #87 end-to-end: the UI offers "Mark as Completed" but the
-// middleware 403s the PUT. `test.fail` flips when #87 lands — then remove the
-// annotation and this becomes the permanent volunteer-completion regression test.
+// R-135 (#87, landed): the assigned volunteer completes through the UI's "Mark
+// as Completed" flow, which now calls POST /api/post/rides/[id]/complete. This
+// is the permanent volunteer-completion regression test.
 test('R-135 (#87): a volunteer completes their own ride through the UI', async ({ page }) => {
-  test.fail()
   const ride = dbGet<{ id: string }>(
     `SELECT id FROM ride WHERE status = 'CREATED' AND deletedAt IS NULL ORDER BY scheduledTime LIMIT 1`
   )

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -5,15 +5,19 @@ import { loginAs } from '../utils/auth'
 
 await bootShared()
 
-// Pins for the KNOWN OPEN BUGS found by the 2026-07-14 exhaustive audit
+// Pins for the KNOWN BUGS found by the 2026-07-14 exhaustive audit
 // (issues #87–#97). Each `it.fails` test asserts the *correct* behavior from
-// REQUIREMENTS.md, so today it fails (and `it.fails` turns that into a pass).
+// REQUIREMENTS.md, so while the bug is open it fails (and `it.fails` turns that
+// into a pass).
 //
 // WHEN YOU FIX ONE OF THESE ISSUES: its pin will start "failing" (because the
 // assertions now pass). That is the signal to (1) change `it.fails` → `it`,
 // and (2) keep the test forever as the regression guard for your fix.
 //
-// The one plain `it` at the bottom pins CURRENT behavior for the open
+// Already fixed + flipped to plain `it` (kept here as permanent regression
+// guards): R-135 (#87), R-082/R-083 (#88), R-027 (#93).
+//
+// The plain `it` at the bottom (R-173) pins CURRENT behavior for the open
 // completionRate decision (#96) — flip its assertions when the owner decides.
 
 const ADMIN = 'reachtusharwani@gmail.com'
@@ -43,23 +47,25 @@ async function createRide(cookie: string, clientId: string) {
 }
 
 describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () => {
-  it.fails('R-135 (#87): a volunteer can complete their OWN assigned ride', async () => {
+  it('R-135 (#87): a volunteer can complete their OWN assigned ride', async () => {
     const admin = await loginAs(ADMIN)
     const bob = await loginAs(BOB)
     const client = await createClient(admin, `${RUN} B87`, `${RUN}-87@example.com`)
     const ride = await createRide(admin, client.id)
     await $fetch(`/api/post/rides/${ride.id}/signup`, { method: 'POST', headers: json(bob) })
 
-    // Currently: 403 "Admin access required" from the global middleware.
-    const res = await appFetch(`/api/put/rides/${ride.id}`, {
-      method: 'PUT',
+    // #87 fixed via a dedicated self-service endpoint: the assigned volunteer
+    // completes through POST /api/post/rides/[id]/complete (the UI's "Mark as
+    // Completed" now calls this). PUT /api/put/rides stays admin-only.
+    const res = await appFetch(`/api/post/rides/${ride.id}/complete`, {
+      method: 'POST',
       headers: json(bob),
-      body: JSON.stringify({ status: 'COMPLETED', totalRideTime: 1.5 }),
+      body: JSON.stringify({ totalRideTime: 1.5 }),
     })
     expect(res.status).toBe(200)
   })
 
-  it.fails('R-082 (#88): delete/admins refuses to archive a non-ADMIN user', async () => {
+  it('R-082 (#88): delete/admins refuses to archive a non-ADMIN user', async () => {
     const admin = await loginAs(ADMIN)
     const bob = await loginAs(BOB)
     const bobUser = await $fetch<{ userId: string }>('/api/get/volunteers/bySession', {
@@ -74,7 +80,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(res.status).toBe(404)
   })
 
-  it.fails('R-083 (#88): an admin cannot delete their own account', async () => {
+  it('R-083 (#88): an admin cannot delete their own account', async () => {
     const admin = await loginAs(ADMIN)
     const email = `${RUN}-selfdel@example.com`
     const created = await $fetch<{ id: string }>('/api/post/admins', {
@@ -179,7 +185,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect([400, 409]).toContain(res.status)
   })
 
-  it.fails('R-027 (#93): estimate applies byId record-scoping for volunteers', async () => {
+  it('R-027 (#93): estimate applies byId record-scoping for volunteers', async () => {
     const admin = await loginAs(ADMIN)
     const alice = await loginAs('alice@example.com')
     const bob = await loginAs(BOB)


### PR DESCRIPTION
## Why

PR #100 (requirement-driven testing framework) was merged **on top of** the already-merged fixes for **#87** (PR #101), **#88** (#102), and **#93** (#99) — but without flipping those bugs' known-bug pins. Each pin in `tests/e2e/known-bugs.test.ts` uses `it.fails(...)` to assert the **correct** behavior, so the moment its bug is fixed the assertion passes and `it.fails` turns that into a **failure** (that's the framework's intended "flip loudly when fixed" signal, per `TESTING.md`).

Result: `pnpm test` on `main` is **red** — 3 failures — which blocks all further `/issue-loop` work (every new branch inherits them):

```
Test Files  1 failed | 42 passed (43)
     Tests  3 failed | 177 passed | 11 expected fail (191)
  × R-082 (#88): delete/admins refuses to archive a non-ADMIN user
  × R-083 (#88): an admin cannot delete their own account
  × R-027 (#93): estimate applies byId record-scoping for volunteers
```

## What this does (the flip the framework's own contract asks for)

- **Flip `R-082`, `R-083` (#88) and `R-027` (#93)** from `it.fails` → `it` — they now pass and become permanent regression guards for the merged fixes.
- **Repoint `R-135` (#87)** at the endpoint the fix actually added — `POST /api/post/rides/[id]/complete` — instead of the old `PUT /api/put/rides` path, and flip it to `it`. The old pin tested the PUT path (which stays admin-only by design), so it was **stale**: green via `it.fails` but not actually guarding the #87 fix.
- **Remove the `R-135` `test.fail()`** in `tests/browser/volunteer-flows.spec.ts` — its own comment said to do exactly this once #87 lands; the UI flow it drives now works end-to-end.
- **`REQUIREMENTS.md`**: mark `R-027`/`R-082`/`R-083`/`R-135` `pin` → `auto`, and point R-135's Source at the new endpoint.

No source/behavior changes — this is test + catalog reconciliation only.

## Verification

- **`pnpm test`** → `43 files, 181 passed | 10 expected fail | 0 failed` (was 3 failed). ✅ baseline green.
- **`pnpm trace`** → `119/119 covered ✔` (103 auto, 10 pin, 5 manual, 1 decision). ✅
- ⚠️ **Browser layer not run here**: `pnpm test:browser` (Playwright/Chromium) isn't runnable in this environment. The `R-135` browser-pin change follows its documented contract (remove `test.fail()` on a now-passing flow) but should be confirmed with `pnpm test:browser` before/at merge.

## Notes

- Authored directly by the issue-loop orchestrator as test-infra repair (same as #62), verified by running the suite + traceability. It cannot auto-merge (agents can't push `main`).
- The remaining 10 `it.fails` pins (#89/#90/#91/#92/#94/#95/#97) are untouched and correctly still "expected fail".
- Optional future polish (per `TESTING.md`): move the four now-passing guards out of `known-bugs.test.ts` next to their feature suites. Left in place here to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)