### PR TITLE
Fix #89/#90/#91: input validation + presence-aware updates + clean conflict errors on write endpoints

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -62,9 +62,9 @@ is not documentation that can rot — it is enforced.
 | R-042 | Creating a second client profile for the same user → 400 "already a client" | `post/clients/index.ts` | auto | `requirements-flows.test.ts` |
 | R-043 | Blank/whitespace phone is stored as NULL so multiple blank-phone records don't trip the unique constraint (#15, #53) | `server/utils/sanitize.ts` | auto | `empty-phone.test.ts`, `admin-empty-phone.test.ts` |
 | R-044 | Client home address is deduped onto the `matchKey` unique (case/whitespace variants collapse; display casing preserved, state uppercased) (#16, #57) | `server/utils/address.ts` | auto | `address-normalization.test.ts`, `address-matchkey-display.test.ts` |
-| R-045 | A partial update (`{name}` only) must NOT wipe email/phone — omitted fields are no-ops | `put/clients/[id].ts` et al | pin [#89](https://github.com/UTDallasEPICS/wcoa/issues/89) | `known-bugs.test.ts` |
+| R-045 | A partial update (`{name}` only) must NOT wipe email/phone — omitted fields are no-ops | `put/clients/[id].ts` et al | auto | `known-bugs.test.ts` |
 | R-046 | Update/delete of an unknown or archived client → 404 | `put/clients/[id].ts` | auto | `requirements-flows.test.ts` |
-| R-047 | Setting a client's email to another user's email → clean 4xx conflict, not 500 | `put/clients/[id].ts` | pin [#91](https://github.com/UTDallasEPICS/wcoa/issues/91) | `known-bugs.test.ts` |
+| R-047 | Setting a client's email to another user's email → clean 4xx conflict, not 500 | `put/clients/[id].ts` | auto | `known-bugs.test.ts` |
 | R-048 | People creates on an email that belongs to a different active profile type are rejected (no dual profiles, no silent role upgrades) | `post/clients`, `post/volunteers` | pin [#92](https://github.com/UTDallasEPICS/wcoa/issues/92) | `known-bugs.test.ts` |
 | R-049 | Deleting a client with active (non-deleted) rides is blocked with 409 (#23) | `delete/clients/[id].ts` | auto | `safe-delete.test.ts` |
 | R-050 | Client soft-delete archives user+client, releases email/phone to `deletedEmail/deletedPhone` (reusable), revokes sessions, hides from lists, preserves metrics history (#27) | `delete/clients/[id].ts` | auto | `soft-deletes.test.ts` |
@@ -76,7 +76,7 @@ is not documentation that can rot — it is enforced.
 | R-060 | Volunteer create requires name + email (400 otherwise) | `post/volunteers/index.ts` | auto | `requirements-flows.test.ts` |
 | R-061 | Duplicate volunteer profile → 400 "already a volunteer" | `post/volunteers/index.ts` | auto | `requirements-flows.test.ts` |
 | R-062 | Welcome email on volunteer create is fire-and-forget (a send failure never fails the request) | `post/volunteers/index.ts` | auto | `requirements-flows.test.ts` |
-| R-063 | `status` on volunteer create/update is validated against the VolunteerStatus enum (400 on bogus values) — admin endpoints, matching the already-validated bySession endpoint | `post/volunteers`, `put/volunteers/[id]` | pin [#90](https://github.com/UTDallasEPICS/wcoa/issues/90) | `known-bugs.test.ts` |
+| R-063 | `status` on volunteer create/update is validated against the VolunteerStatus enum (400 on bogus values) — admin endpoints, matching the already-validated bySession endpoint | `post/volunteers`, `put/volunteers/[id]` | auto | `known-bugs.test.ts` |
 | R-064 | Volunteer soft-delete: ASSIGNED rides return to the pool (`CREATED`, volunteerId NULL), user archived, email/phone released, sessions revoked, hidden from lists (#7, #23, #27) | `delete/volunteers/[id].ts` | auto | `safe-delete.test.ts`, `soft-deletes.test.ts` |
 | R-065 | `put/volunteers/bySession/status` accepts only valid enum values (400 otherwise) and updates only the session volunteer | bySession/status.ts | auto | `requirements-flows.test.ts` |
 | R-066 | `put/volunteers/bySession/reminders` replaces the reminder set atomically; zod-validated (`minutesBefore` positive int) | bySession/reminders.ts | auto | `requirements-flows.test.ts` |
@@ -88,7 +88,7 @@ is not documentation that can rot — it is enforced.
 | ID | Requirement | Source | Status | Coverage |
 |---|---|---|---|---|
 | R-080 | Admin create requires name+email; promoting an existing user writes a `USER_ROLE_CHANGED` audit row (#28) | `post/admins/index.ts` | auto | `audit-log.test.ts`, `requirements-flows.test.ts` |
-| R-081 | Admin update of an unknown id → 404, not 500 | `put/admins/[id].ts` | pin [#91](https://github.com/UTDallasEPICS/wcoa/issues/91) | `known-bugs.test.ts` |
+| R-081 | Admin update of an unknown id → 404, not 500 | `put/admins/[id].ts` | auto | `known-bugs.test.ts` |
 | R-082 | `delete/admins` only archives users whose role is ADMIN (404 otherwise) | `delete/admins/[id].ts` | auto | `known-bugs.test.ts` |
 | R-083 | An admin cannot delete their own account, and the last remaining admin cannot be deleted (lockout guard) | `delete/admins/[id].ts` | auto | `known-bugs.test.ts` |
 | R-084 | Admin soft-delete releases email/phone, revokes sessions; double-delete 404s | `delete/admins/[id].ts` | auto | `admin-delete.test.ts`, `soft-deletes.test.ts` |
@@ -101,7 +101,7 @@ is not documentation that can rot — it is enforced.
 | R-101 | Ride create resolves both addresses through the matchKey upsert (no duplicate Address rows) | `post/rides/index.ts` | auto | `address-normalization.test.ts` |
 | R-102 | Ride create with volunteerId starts ASSIGNED; without starts CREATED | `post/rides/index.ts` | auto | `requirements-flows.test.ts` |
 | R-103 | The RIDE_CREATED broadcast is fire-and-forget: a slow/failing broadcast neither delays nor fails ride creation (#32) | `post/rides/index.ts` | auto | `ride-broadcast-nonblocking.test.ts` |
-| R-104 | Ride create validates input shape (bad clientId / non-object addresses / invalid date → 400, never 500) | `post/rides/index.ts` | pin [#90](https://github.com/UTDallasEPICS/wcoa/issues/90) | `known-bugs.test.ts` |
+| R-104 | Ride create validates input shape (bad clientId / non-object addresses / invalid date → 400, never 500) | `post/rides/index.ts` | auto | `known-bugs.test.ts` |
 | R-105 | Ride update accepts ONLY whitelisted fields; unknown keys 400 via `.strict()` (mass-assignment guard, #31) | `put/rides/[id].ts` | auto | `ride-input-validation.test.ts` |
 | R-106 | Unassigning a volunteer (volunteerId → null/"") auto-resets status to CREATED — but only when the ride was ASSIGNED and no explicit status was sent (#7) | `put/rides/[id].ts` | auto | `unassign-status.test.ts` |
 | R-107 | Completing a ride requires totalRideTime ≥ 0.1 (on the request or already stored) (#10) | `put/rides/[id].ts` | auto | `complete-requires-ridetime.test.ts` |

--- a/server/api/post/admins/index.ts
+++ b/server/api/post/admins/index.ts
@@ -1,14 +1,19 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
+import { readValidatedBody } from '../../../utils/validation'
+
+// Validate the create payload (issue #90): name + email are required, phone is
+// optional, and unknown keys are rejected via .strict().
+const createAdminSchema = z
+  .object({
+    name: z.string().min(1),
+    email: z.string().min(1),
+    phone: z.string().nullable().optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-
-  if (!body.name || !body.email) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'Name and Email are required',
-    })
-  }
+  const body = await readValidatedBody(event, createAdminSchema)
 
   // Check if user exists
   const existingUser = await prisma.user.findUnique({
@@ -16,13 +21,14 @@ export default defineEventHandler(async (event) => {
   })
 
   if (existingUser) {
-    // If user exists, update role to ADMIN
+    // If user exists, promote to ADMIN. Update phone only when the caller sent
+    // it (issue #89) so promoting a user without a phone field doesn't wipe it.
     const updated = await prisma.user.update({
       where: { id: existingUser.id },
       data: {
         role: 'ADMIN',
         name: body.name,
-        phone: emptyToNull(body.phone),
+        ...(body.phone !== undefined ? { phone: emptyToNull(body.phone) } : {}),
       },
     })
     // Audit (issue #28): a user was promoted to ADMIN — a privileged change.

--- a/server/api/post/clients/index.ts
+++ b/server/api/post/clients/index.ts
@@ -21,10 +21,14 @@ export default defineEventHandler(async (event) => {
   const body = await readValidatedBody(event, createClientSchema)
 
   // 1. Upsert User
+  // Normalize the email once (issue #15/#89 semantics) so the lookup and the
+  // stored value agree — otherwise a padded "a@b.com " would miss the untrimmed
+  // lookup yet collide with the trimmed stored value on insert (P2002 -> 500).
+  const email = emptyToNull(body.email)
   let user = null
-  if (body.email) {
+  if (email) {
     user = await prisma.user.findUnique({
-      where: { email: body.email }
+      where: { email }
     })
   }
 
@@ -32,7 +36,7 @@ export default defineEventHandler(async (event) => {
     user = await prisma.user.create({
       data: {
         name: body.name,
-        email: emptyToNull(body.email),
+        email,
         phone: emptyToNull(body.phone),
         role: 'CLIENT'
       }

--- a/server/api/post/clients/index.ts
+++ b/server/api/post/clients/index.ts
@@ -1,14 +1,24 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
+import { readValidatedBody } from '../../../utils/validation'
+
+// Validate the create payload (issue #90): name + a full address are required,
+// email is optional (a client may have none), and unknown keys are rejected via
+// .strict().
+const createClientSchema = z
+  .object({
+    name: z.string().min(1),
+    email: z.string().nullable().optional(),
+    phone: z.string().nullable().optional(),
+    street: z.string().min(1),
+    city: z.string().min(1),
+    state: z.string().min(1),
+    zip: z.string().min(1),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-
-  if (!body.name || !body.street || !body.city || !body.state || !body.zip) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'Missing required fields',
-    })
-  }
+  const body = await readValidatedBody(event, createClientSchema)
 
   // 1. Upsert User
   let user = null
@@ -22,17 +32,20 @@ export default defineEventHandler(async (event) => {
     user = await prisma.user.create({
       data: {
         name: body.name,
-        email: body.email || null,
+        email: emptyToNull(body.email),
         phone: emptyToNull(body.phone),
         role: 'CLIENT'
       }
     })
   } else {
+    // Existing user (matched by email): update name, and phone only when the
+    // caller actually sent it (issue #89) — omitting phone here must not wipe the
+    // stored number.
     await prisma.user.update({
       where: { id: user.id },
       data: {
         name: body.name,
-        phone: emptyToNull(body.phone),
+        ...(body.phone !== undefined ? { phone: emptyToNull(body.phone) } : {}),
         // Don't downgrade ADMIN/VOLUNTEER
       }
     })

--- a/server/api/post/rides/index.ts
+++ b/server/api/post/rides/index.ts
@@ -1,14 +1,69 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
 import { broadcastNotification } from '../../../utils/notification'
+import { readValidatedBody } from '../../../utils/validation'
+
+// Validate the create payload up front (issue #90) so malformed input becomes a
+// clean 400 instead of a raw 500 out of Prisma: a non-object pickup/dropoff, an
+// unparseable scheduledTime, or unknown keys are all rejected here. A
+// well-formed but nonexistent clientId/volunteerId is checked below (a bare FK
+// violation would otherwise surface as a 500). Mirrors the zod + .strict()
+// pattern established for put/rides in issue #31.
+const addressSchema = z
+  .object({
+    street: z.string().min(1),
+    city: z.string().min(1),
+    state: z.string().min(1),
+    zip: z.string().min(1),
+  })
+  .strict()
+
+const isParseableDate = (s: string) => !Number.isNaN(Date.parse(s))
+
+const createRideSchema = z
+  .object({
+    clientId: z.string().min(1),
+    pickup: addressSchema,
+    dropoff: addressSchema,
+    scheduledTime: z.string().min(1).refine(isParseableDate, 'scheduledTime must be a valid date'),
+    pickupTime: z
+      .string()
+      .refine((s) => s === '' || isParseableDate(s), 'pickupTime must be a valid date')
+      .nullable()
+      .optional(),
+    notes: z.string().nullable().optional(),
+    volunteerId: z.string().nullable().optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await readValidatedBody(event, createRideSchema)
 
-  if (!body.clientId || !body.pickup || !body.dropoff || !body.scheduledTime) {
+  // A well-formed but nonexistent clientId would trip a foreign-key violation in
+  // prisma.ride.create and surface as a 500 (issue #90). Resolve it first so the
+  // caller gets a clean 400 — and so we don't leave orphan Address rows behind
+  // from the upserts below on the failure path.
+  const client = await prisma.client.findFirst({
+    where: { id: body.clientId, deletedAt: null },
+  })
+  if (!client) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing required fields',
+      statusMessage: 'Invalid clientId: no such client',
     })
+  }
+
+  const volunteerId = body.volunteerId && body.volunteerId.trim() !== '' ? body.volunteerId : null
+  if (volunteerId) {
+    const volunteer = await prisma.volunteer.findFirst({
+      where: { id: volunteerId, deletedAt: null },
+    })
+    if (!volunteer) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Invalid volunteerId: no such volunteer',
+      })
+    }
   }
 
   // Helper to find or create address
@@ -46,9 +101,9 @@ export default defineEventHandler(async (event) => {
       dropoffAddressId: dropoffAddress.id,
       scheduledTime: new Date(body.scheduledTime),
       pickupTime: body.pickupTime ? new Date(body.pickupTime) : undefined,
-      notes: body.notes,
-      volunteerId: body.volunteerId ? body.volunteerId : undefined,
-      status: body.volunteerId ? 'ASSIGNED' : 'CREATED',
+      notes: body.notes ?? undefined,
+      volunteerId: volunteerId ?? undefined,
+      status: volunteerId ? 'ASSIGNED' : 'CREATED',
     },
   })
 

--- a/server/api/post/volunteers/index.ts
+++ b/server/api/post/volunteers/index.ts
@@ -1,15 +1,24 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
 import { sendEmail } from '../../../utils/email'
+import { readValidatedBody } from '../../../utils/validation'
+
+// Validate the create payload (issue #90). status is enum-checked against the
+// VolunteerStatus values (matching put/volunteers/bySession/status), so a bogus
+// status is a 400 instead of being silently stored and dropping the volunteer
+// out of the AVAILABLE broadcast. name/email are required; unknown keys are
+// rejected via .strict().
+const createVolunteerSchema = z
+  .object({
+    name: z.string().min(1),
+    email: z.string().min(1),
+    phone: z.string().nullable().optional(),
+    status: z.enum(['AVAILABLE', 'UNAVAILABLE']).optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-
-  if (!body.name || !body.email) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'Name and Email are required',
-    })
-  }
+  const body = await readValidatedBody(event, createVolunteerSchema)
 
   // 1. Upsert User
   // We use upsert to create if not exists, or update name/phone if exists
@@ -28,15 +37,16 @@ export default defineEventHandler(async (event) => {
       }
     })
   } else {
-    // Optionally update user info? Let's just ensure role is VOLUNTEER? 
-    // Or maybe keep as is if they are ADMIN?
-    // For simplicity, let's update name/phone and role if it was CLIENT
+    // Update name and (presence-aware, issue #89) phone; only touch phone when
+    // the caller actually sent it, so promoting an existing user to volunteer
+    // without a phone field doesn't wipe their stored number. Upgrade CLIENT to
+    // VOLUNTEER but never downgrade an ADMIN.
     await prisma.user.update({
       where: { id: user.id },
       data: {
         name: body.name,
-        phone: emptyToNull(body.phone), // Update phone
-        role: user.role === 'CLIENT' ? 'VOLUNTEER' : user.role // Upgrade CLIENT to VOLUNTEER
+        ...(body.phone !== undefined ? { phone: emptyToNull(body.phone) } : {}),
+        role: user.role === 'CLIENT' ? 'VOLUNTEER' : user.role
       }
     })
   }

--- a/server/api/put/admins/[id].ts
+++ b/server/api/put/admins/[id].ts
@@ -1,8 +1,21 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
+import { readValidatedBody } from '../../../utils/validation'
+import { throwOnPrismaWriteConflict } from '../../../utils/prismaErrors'
+
+// Validate the update payload (issue #90): unknown keys are rejected via
+// .strict(), and every field is optional so a partial update only touches what
+// it sends — an omitted contact field is a no-op, not a wipe (issue #89).
+const updateAdminSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    email: z.string().nullable().optional(),
+    phone: z.string().nullable().optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
-  const body = await readBody(event)
 
   if (!id) {
     throw createError({
@@ -11,12 +24,37 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  return await prisma.user.update({
-    where: { id },
-    data: {
-      name: body.name,
-      email: body.email,
-      phone: emptyToNull(body.phone),
-    },
+  const body = await readValidatedBody(event, updateAdminSchema)
+
+  // Existence check (issue #91): without it an unknown id fell through to
+  // prisma.user.update and surfaced the raw P2025 as a 500. 404 like the sibling
+  // update endpoints (put/clients, put/volunteers). Soft delete (issue #27): an
+  // archived user is treated as gone.
+  const existing = await prisma.user.findFirst({
+    where: { id, deletedAt: null },
   })
+  if (!existing) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Admin not found',
+    })
+  }
+
+  // Build the update only from fields the caller actually sent (issue #89):
+  // omitting email/phone leaves the stored value untouched instead of nulling it.
+  const data: { name?: string; email?: string | null; phone?: string | null } = {}
+  if (body.name !== undefined) data.name = body.name
+  if (body.email !== undefined) data.email = emptyToNull(body.email)
+  if (body.phone !== undefined) data.phone = emptyToNull(body.phone)
+
+  // Wrap the write so a unique-constraint violation (e.g. reusing another active
+  // user's email/phone) is a clean 409, not a 500 (issue #91).
+  try {
+    return await prisma.user.update({
+      where: { id },
+      data,
+    })
+  } catch (err) {
+    throwOnPrismaWriteConflict(err, { notFoundMessage: 'Admin not found' })
+  }
 })

--- a/server/api/put/clients/[id].ts
+++ b/server/api/put/clients/[id].ts
@@ -1,8 +1,25 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
+import { readValidatedBody } from '../../../utils/validation'
+import { throwOnPrismaWriteConflict } from '../../../utils/prismaErrors'
+
+// Validate the update payload (issue #90): unknown keys are rejected via
+// .strict(), and every field is optional so a partial update only touches what
+// it sends — an omitted contact field is a no-op, not a wipe (issue #89).
+const updateClientSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    email: z.string().nullable().optional(),
+    phone: z.string().nullable().optional(),
+    street: z.string().optional(),
+    city: z.string().optional(),
+    state: z.string().optional(),
+    zip: z.string().optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
-  const body = await readBody(event)
 
   if (!id) {
     throw createError({
@@ -10,6 +27,8 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'ID is required',
     })
   }
+
+  const body = await readValidatedBody(event, updateClientSchema)
 
   // Soft delete (issue #27): an archived client can't be edited — treat as 404.
   const client = await prisma.client.findFirst({
@@ -23,52 +42,60 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  return await prisma.$transaction(async (tx) => {
-    // Update User
-    if (body.name || body.email !== undefined || body.phone !== undefined) {
-      await tx.user.update({
-        where: { id: client.userId },
-        data: {
-          name: body.name,
-          email: body.email || null,
-          phone: emptyToNull(body.phone),
-        },
-      })
-    }
+  // Build the User update only from fields the caller actually sent (issue #89):
+  // omitting email/phone leaves the stored value untouched instead of nulling it.
+  const userData: { name?: string; email?: string | null; phone?: string | null } = {}
+  if (body.name !== undefined) userData.name = body.name
+  if (body.email !== undefined) userData.email = emptyToNull(body.email)
+  if (body.phone !== undefined) userData.phone = emptyToNull(body.phone)
 
-    // Update Address (Link to new/existing address)
-    if (body.street && body.city && body.state && body.zip) {
-      // Normalize first so case/whitespace-variant addresses collapse onto the
-      // unique matchKey (issues #16, #57). Display fields keep original casing.
-      const addressData = normalizeAddress({
-        street: body.street,
-        city: body.city,
-        state: body.state,
-        zip: body.zip,
-      })
+  // Wrap the writes so a unique-constraint violation (e.g. setting the email to
+  // one another active user already owns) is a clean 409, not a 500 (issue #91).
+  try {
+    return await prisma.$transaction(async (tx) => {
+      if (Object.keys(userData).length > 0) {
+        await tx.user.update({
+          where: { id: client.userId },
+          data: userData,
+        })
+      }
 
-      const address = await tx.address.upsert({
-        where: {
-          matchKey: addressData.matchKey,
-        },
-        update: {},
-        create: addressData,
-      })
+      // Update Address (Link to new/existing address)
+      if (body.street && body.city && body.state && body.zip) {
+        // Normalize first so case/whitespace-variant addresses collapse onto the
+        // unique matchKey (issues #16, #57). Display fields keep original casing.
+        const addressData = normalizeAddress({
+          street: body.street,
+          city: body.city,
+          state: body.state,
+          zip: body.zip,
+        })
 
-      await tx.client.update({
+        const address = await tx.address.upsert({
+          where: {
+            matchKey: addressData.matchKey,
+          },
+          update: {},
+          create: addressData,
+        })
+
+        await tx.client.update({
+          where: { id },
+          data: {
+            homeAddressId: address.id,
+          },
+        })
+      }
+
+      return await tx.client.findUnique({
         where: { id },
-        data: {
-          homeAddressId: address.id,
+        include: {
+          user: true,
+          homeAddress: true,
         },
       })
-    }
-
-    return await tx.client.findUnique({
-      where: { id },
-      include: {
-        user: true,
-        homeAddress: true,
-      },
     })
-  })
+  } catch (err) {
+    throwOnPrismaWriteConflict(err, { notFoundMessage: 'Client not found' })
+  }
 })

--- a/server/api/put/notifications/templates/[name].ts
+++ b/server/api/put/notifications/templates/[name].ts
@@ -1,6 +1,7 @@
 import { defineEventHandler, readBody } from 'h3'
 import { auth } from '../../../../utils/auth'
 import { prisma } from '../../../../utils/prisma'
+import { throwOnPrismaWriteConflict } from '../../../../utils/prismaErrors'
 
 export default defineEventHandler(async (event) => {
   const session = await auth.api.getSession({
@@ -21,14 +22,21 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Nothing to update' })
   }
 
-  const template = await prisma.notificationTemplate.update({
-    where: { name },
-    data: {
-      subject,
-      body,
-      enabled,
-    },
-  })
+  // An unknown template name would make prisma.notificationTemplate.update throw
+  // P2025 and surface as a 500 (issue #91). Map it to a 404. (An empty body 400s
+  // on the "nothing to update" guard above before ever reaching here.)
+  try {
+    const template = await prisma.notificationTemplate.update({
+      where: { name },
+      data: {
+        subject,
+        body,
+        enabled,
+      },
+    })
 
-  return template
+    return template
+  } catch (err) {
+    throwOnPrismaWriteConflict(err, { notFoundMessage: 'Template not found' })
+  }
 })

--- a/server/api/put/volunteers/[id].ts
+++ b/server/api/put/volunteers/[id].ts
@@ -1,8 +1,23 @@
+import { z } from 'zod'
 import { prisma } from '../../../utils/prisma'
+import { readValidatedBody } from '../../../utils/validation'
+import { throwOnPrismaWriteConflict } from '../../../utils/prismaErrors'
+
+// Validate the update payload (issue #90): status is enum-checked (a bogus value
+// is a 400, not silently stored), and unknown keys are rejected via .strict().
+// All fields are optional so a partial update only touches what it sends — an
+// omitted contact field is a no-op, not a wipe (issue #89).
+const updateVolunteerSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    email: z.string().nullable().optional(),
+    phone: z.string().nullable().optional(),
+    status: z.enum(['AVAILABLE', 'UNAVAILABLE']).optional(),
+  })
+  .strict()
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
-  const body = await readBody(event)
 
   if (!id) {
     throw createError({
@@ -10,6 +25,8 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'ID is required',
     })
   }
+
+  const body = await readValidatedBody(event, updateVolunteerSchema)
 
   // Soft delete (issue #27): an archived volunteer can't be edited — treat as 404.
   const volunteer = await prisma.volunteer.findFirst({
@@ -23,30 +40,37 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Transaction to update both
-  return await prisma.$transaction(async (tx) => {
-    // Update User
-    if (body.name || body.email || body.phone) {
-      await tx.user.update({
-        where: { id: volunteer.userId },
+  // Build the User update only from fields the caller actually sent (issue #89):
+  // omitting email/phone leaves the stored value untouched instead of nulling it.
+  const userData: { name?: string; email?: string | null; phone?: string | null } = {}
+  if (body.name !== undefined) userData.name = body.name
+  if (body.email !== undefined) userData.email = emptyToNull(body.email)
+  if (body.phone !== undefined) userData.phone = emptyToNull(body.phone)
+
+  // Transaction to update both. Wrap the writes so a unique-constraint violation
+  // (e.g. reusing another active user's email/phone) is a clean 409 (issue #91).
+  try {
+    return await prisma.$transaction(async (tx) => {
+      if (Object.keys(userData).length > 0) {
+        await tx.user.update({
+          where: { id: volunteer.userId },
+          data: userData,
+        })
+      }
+
+      return await tx.volunteer.update({
+        where: { id },
         data: {
-          name: body.name,
-          email: body.email,
-          phone: emptyToNull(body.phone),
+          // undefined leaves status unchanged; a present value is a validated enum.
+          status: body.status,
+        },
+        include: {
+          user: true,
+          reminders: true,
         },
       })
-    }
-
-    // Update Volunteer
-    return await tx.volunteer.update({
-      where: { id },
-      data: {
-        status: body.status,
-      },
-      include: {
-        user: true,
-        reminders: true,
-      },
     })
-  })
+  } catch (err) {
+    throwOnPrismaWriteConflict(err, { notFoundMessage: 'Volunteer not found' })
+  }
 })

--- a/server/utils/prismaErrors.ts
+++ b/server/utils/prismaErrors.ts
@@ -1,0 +1,34 @@
+import { Prisma } from '../../prisma/generated/client'
+
+/**
+ * Maps the two Prisma errors that ordinary user input can trigger on people /
+ * template writes onto clean HTTP responses instead of an opaque 500 (issue #91):
+ *
+ *   P2002 (unique constraint) → 409  — e.g. changing an email/phone to one that
+ *                                       already belongs to another active user.
+ *   P2025 (record not found)  → 404  — e.g. updating a record that doesn't exist.
+ *
+ * Call it from a catch block wrapping the write(s). Anything that isn't one of
+ * these two known request errors is rethrown unchanged, so genuine faults still
+ * surface as 500s.
+ */
+export function throwOnPrismaWriteConflict(
+  err: unknown,
+  opts: { notFoundMessage?: string } = {},
+): never {
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    if (err.code === 'P2002') {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'That email or phone number is already in use',
+      })
+    }
+    if (err.code === 'P2025') {
+      throw createError({
+        statusCode: 404,
+        statusMessage: opts.notFoundMessage ?? 'Not found',
+      })
+    }
+  }
+  throw err
+}

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -97,7 +97,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     if (!res.ok) await appFetch(`/api/delete/admins/${created.id}`, { method: 'DELETE', headers: json(admin) })
   })
 
-  it.fails('R-045 (#89): a partial client update does not wipe email/phone', async () => {
+  it('R-045 (#89): a partial client update does not wipe email/phone', async () => {
     const admin = await loginAs(ADMIN)
     const email = `${RUN}-89@example.com`
     const client = await createClient(admin, `${RUN} B89`, email, '5559990089')
@@ -113,7 +113,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(user.phone).toBe('5559990089')
   })
 
-  it.fails('R-063 (#90): admin volunteer update rejects a bogus status enum', async () => {
+  it('R-063 (#90): admin volunteer update rejects a bogus status enum', async () => {
     const admin = await loginAs(ADMIN)
     const created = await $fetch<{ id: string }>('/api/post/volunteers', {
       method: 'POST', headers: json(admin),
@@ -127,7 +127,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(res.status).toBe(400)
   })
 
-  it.fails('R-104 (#90): ride create rejects malformed input with 400, never 500', async () => {
+  it('R-104 (#90): ride create rejects malformed input with 400, never 500', async () => {
     const admin = await loginAs(ADMIN)
     // Currently: 500 (raw FK error surfaces).
     const badClient = await appFetch('/api/post/rides', {
@@ -142,7 +142,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(badClient.status).toBe(400)
   })
 
-  it.fails('R-081 (#91): admin update of an unknown id returns 404, not 500', async () => {
+  it('R-081 (#91): admin update of an unknown id returns 404, not 500', async () => {
     const admin = await loginAs(ADMIN)
     const res = await appFetch('/api/put/admins/nonexistent-id', {
       method: 'PUT', headers: json(admin), body: JSON.stringify({ name: 'X' }),
@@ -150,7 +150,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(res.status).toBe(404)
   })
 
-  it.fails('R-190 (#91): updating an UNKNOWN template name with a valid body returns 404, not 500', async () => {
+  it('R-190 (#91): updating an UNKNOWN template name with a valid body returns 404, not 500', async () => {
     // Found BY this framework (2026-07-14): the audit's hand probe used an empty
     // body, which 400s on validation before reaching the unhandled P2025.
     const admin = await loginAs(ADMIN)
@@ -160,7 +160,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect([400, 404]).toContain(res.status)
   })
 
-  it.fails('R-047 (#91): duplicate email on a client update returns a clean 4xx, not 500', async () => {
+  it('R-047 (#91): duplicate email on a client update returns a clean 4xx, not 500', async () => {
     const admin = await loginAs(ADMIN)
     const a = await createClient(admin, `${RUN} B91a`, `${RUN}-91a@example.com`)
     await createClient(admin, `${RUN} B91b`, `${RUN}-91b@example.com`)


### PR DESCRIPTION
## Why one PR

A single zod-validation pass over the people/ride **write** endpoints resolves all three coupled issues at once: #90 adds the validation; with presence-aware semantics that same schema work fixes #89's field-wipe; and #91's existence/conflict error-mapping lives in the very same handlers. Three separate PRs would rewrite the same 7 files and conflict, so this is intentionally combined (sanctioned by CLAUDE.md's "if a fix naturally resolves a sibling, declare `Fixes #N`"). Expect a larger-than-usual diff for that reason.

## What was broken

**#90 — no input validation (P2, validation).** `post/rides` and the people write endpoints (`post|put` for clients/volunteers/admins) used raw `readBody` with zero validation:
- `post/rides`: a bogus `clientId` (raw FK), a `pickup` sent as a string, or an unparseable `scheduledTime` all 500'd.
- `post/volunteers` + `put/volunteers/[id]`: `status: "BOGUS"` was accepted and stored, silently dropping the volunteer out of the `AVAILABLE` broadcast (only the self-service `bySession/status` endpoint validated).

**#89 — partial PUT wipes contact fields (P2, data integrity).** `email: body.email || null` and `phone: emptyToNull(body.phone)` turned an **omitted** field into an explicit NULL wipe. Any partial API call (`{name}` only) destroyed the stored email/phone.

**#91 — routine conflicts become 500s (P3, bug).** `put/admins/[id]` had no existence check (unknown id → unhandled P2025 → 500). Setting any people record's email to another user's email → unhandled P2002 → 500.

## What changed

- **Validation (#90):** each write endpoint now has a zod schema mirroring the `put/rides` pattern from #31 — `.strict()` (unknown keys → 400), enum-checked volunteer `status`, shape-validated ride addresses, and a real-date check on `scheduledTime`/`pickupTime`. `post/rides` resolves a nonexistent `clientId`/`volunteerId` to a clean **400** before touching Prisma (no raw FK 500, no orphan Address rows).
- **Presence-aware updates (#89):** a contact field is written **only when the caller actually sent it** (`if ('field' in body)` semantics via `.optional()` + a `!== undefined` guard). Omitted ≠ null. Applies to `put/{clients,volunteers,admins}` and the `post/{clients,volunteers,admins}` existing-user upsert branches. Blank/whitespace values that **are** present still normalize to null (issues #15/#53 preserved).
- **Clean conflicts (#91):** `put/admins/[id]` gains a `findFirst({ id, deletedAt: null })` → 404 like its siblings. A new shared helper `server/utils/prismaErrors.ts` maps P2002 → **409** ("email/phone already in use") and P2025 → **404**, applied to the three people updates and (trivially) the unknown-template P2025 in `put/notifications/templates/[name]`.

### Pins flipped (now permanent regression guards)
`it.fails` → `it` in `tests/e2e/known-bugs.test.ts`, and status `pin` → `auto` in `REQUIREMENTS.md`:
- **R-045** (#89 — partial client update doesn't wipe)
- **R-063** (#90 — volunteer bogus status → 400)
- **R-104** (#90 — post/rides malformed → 400)
- **R-081** (#91 — put/admins unknown id → 404)
- **R-047** (#91 — duplicate email on client update → 4xx)
- **R-190** (#91 — unknown template name + valid body → 404; done because the shared P2025 helper applied trivially)

R-048 (#92, dual profiles) is intentionally left untouched — out of scope.

## Verification

- `pnpm test` → **187 passed / 4 expected-fail / 0 failed** (baseline on `b616e32` was 181 / 10 / 0; +6 from the flipped pins, all passing). The `requirements-flows` and `requirements-authz-matrix` happy-paths still pass — the schemas accept every real payload.
- `pnpm trace` → **covered: 119/119 ✔** (5 rows moved pin → auto; R-190 was already auto).
- `pnpm build` → succeeds.
- **Revert-check:** reverting `server/` to base while keeping the flipped tests makes exactly those 6 pins fail (assertion mismatch) and pass again with the fix — confirming each is a genuine regression guard.

No risk files touched: no `prisma/schema/`, middleware, auth config, CI, Docker, or dependency changes — only route handlers, one new server util, and tests/docs.

Fixes #89
Fixes #90
Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)