### PR TITLE
Fix #92: reject cross-type profile creates (enforce singular roles)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -65,7 +65,7 @@ is not documentation that can rot — it is enforced.
 | R-045 | A partial update (`{name}` only) must NOT wipe email/phone — omitted fields are no-ops | `put/clients/[id].ts` et al | auto | `known-bugs.test.ts` |
 | R-046 | Update/delete of an unknown or archived client → 404 | `put/clients/[id].ts` | auto | `requirements-flows.test.ts` |
 | R-047 | Setting a client's email to another user's email → clean 4xx conflict, not 500 | `put/clients/[id].ts` | auto | `known-bugs.test.ts` |
-| R-048 | People creates on an email that belongs to a different active profile type are rejected (no dual profiles, no silent role upgrades) | `post/clients`, `post/volunteers` | pin [#92](https://github.com/UTDallasEPICS/wcoa/issues/92) | `known-bugs.test.ts` |
+| R-048 | People creates on an email that belongs to a different active profile type are rejected (no dual profiles, no silent role upgrades) | `post/clients`, `post/volunteers` | auto | `known-bugs.test.ts` |
 | R-049 | Deleting a client with active (non-deleted) rides is blocked with 409 (#23) | `delete/clients/[id].ts` | auto | `safe-delete.test.ts` |
 | R-050 | Client soft-delete archives user+client, releases email/phone to `deletedEmail/deletedPhone` (reusable), revokes sessions, hides from lists, preserves metrics history (#27) | `delete/clients/[id].ts` | auto | `soft-deletes.test.ts` |
 

--- a/server/api/post/clients/index.ts
+++ b/server/api/post/clients/index.ts
@@ -28,7 +28,8 @@ export default defineEventHandler(async (event) => {
   let user = null
   if (email) {
     user = await prisma.user.findUnique({
-      where: { email }
+      where: { email },
+      include: { volunteer: true }
     })
   }
 
@@ -42,6 +43,21 @@ export default defineEventHandler(async (event) => {
       }
     })
   } else {
+    // Singular-role guard (issue #92): reject creating a client profile on an
+    // email that already belongs to a volunteer or admin account. Roles are
+    // singular here; without this the user would end up with BOTH a volunteer
+    // and a client profile while role stays VOLUNTEER — a dual profile invisible
+    // to the role model that delete/volunteers would strand. An existing CLIENT
+    // (or a plain user with no profile) is unaffected and falls through to the
+    // "already a client" 400 / normal create below.
+    const hasActiveVolunteer = !!user.volunteer && user.volunteer.deletedAt === null
+    if (user.role === 'VOLUNTEER' || user.role === 'ADMIN' || hasActiveVolunteer) {
+      const accountType = user.role === 'ADMIN' ? 'an admin' : 'a volunteer'
+      throw createError({
+        statusCode: 409,
+        statusMessage: `That email belongs to ${accountType} account`,
+      })
+    }
     // Existing user (matched by email): update name, and phone only when the
     // caller actually sent it (issue #89) — omitting phone here must not wipe the
     // stored number.

--- a/server/api/post/volunteers/index.ts
+++ b/server/api/post/volunteers/index.ts
@@ -24,7 +24,8 @@ export default defineEventHandler(async (event) => {
   // We use upsert to create if not exists, or update name/phone if exists
   // Ideally, we might check if they are already a volunteer
   let user = await prisma.user.findUnique({
-    where: { email: body.email }
+    where: { email: body.email },
+    include: { client: true }
   })
 
   if (!user) {
@@ -37,16 +38,27 @@ export default defineEventHandler(async (event) => {
       }
     })
   } else {
+    // Singular-role guard (issue #92): reject creating a volunteer profile on an
+    // email that already belongs to a client account, instead of silently
+    // upgrading CLIENT -> VOLUNTEER while the client profile + rides remain
+    // stranded under a now-VOLUNTEER user. An existing VOLUNTEER falls through to
+    // the "already a volunteer" 400 below.
+    const hasActiveClient = !!user.client && user.client.deletedAt === null
+    if (user.role === 'CLIENT' || hasActiveClient) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'That email belongs to a client account',
+      })
+    }
     // Update name and (presence-aware, issue #89) phone; only touch phone when
-    // the caller actually sent it, so promoting an existing user to volunteer
-    // without a phone field doesn't wipe their stored number. Upgrade CLIENT to
-    // VOLUNTEER but never downgrade an ADMIN.
+    // the caller actually sent it, so re-posting an existing user without a phone
+    // field doesn't wipe their stored number. Role is left untouched (never
+    // downgrade an ADMIN; CLIENT is already rejected above).
     await prisma.user.update({
       where: { id: user.id },
       data: {
         name: body.name,
         ...(body.phone !== undefined ? { phone: emptyToNull(body.phone) } : {}),
-        role: user.role === 'CLIENT' ? 'VOLUNTEER' : user.role
       }
     })
   }

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -22,6 +22,7 @@ await bootShared()
 
 const ADMIN = 'reachtusharwani@gmail.com'
 const BOB = 'bob@example.com'
+const GEORGE = 'george@example.com'
 const json = (cookie: string) => ({ 'content-type': 'application/json', cookie })
 const RUN = `kb${Date.now().toString(36)}`
 
@@ -171,16 +172,27 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect([400, 409]).toContain(res.status)
   })
 
-  it.fails('R-048 (#92): creating a client with an existing VOLUNTEER email is rejected', async () => {
+  it('R-048 (#92): creating a client with an existing VOLUNTEER email is rejected', async () => {
     const admin = await loginAs(ADMIN)
-    // Currently: 200 — bob becomes a dual volunteer+client profile (and loses
-    // his phone via the #89 wipe on the upsert branch).
+    // Before the fix: 200 — bob became a dual volunteer+client profile (and lost
+    // his phone via the #89 wipe on the upsert branch). Now: 409, roles singular.
     const res = await appFetch('/api/post/clients', {
       method: 'POST', headers: json(admin),
       body: JSON.stringify({
         name: 'Bob Tester', email: BOB,
         street: `${RUN} 3 Pin St`, city: 'Plano', state: 'TX', zip: '75074',
       }),
+    })
+    expect([400, 409]).toContain(res.status)
+  })
+
+  it('R-048 (#92): creating a volunteer with an existing CLIENT email is rejected', async () => {
+    const admin = await loginAs(ADMIN)
+    // Before the fix: 200 — george (a seeded CLIENT) was silently upgraded to
+    // VOLUNTEER while his client profile + rides remained. Now: 409, no upgrade.
+    const res = await appFetch('/api/post/volunteers', {
+      method: 'POST', headers: json(admin),
+      body: JSON.stringify({ name: 'George Tester', email: GEORGE }),
     })
     expect([400, 409]).toContain(res.status)
   })


### PR DESCRIPTION
## What was broken

Roles are singular everywhere in the app, but the two people-create endpoints let a single user acquire two profile types:

- `POST /api/post/clients` with an **existing volunteer's** email returned **200** and left the user with BOTH a volunteer and a client profile while `role` stayed `VOLUNTEER`. The client half was invisible to the role model, and `delete/volunteers` would strand it (the `#89` phone-wipe also fired on the upsert branch).
- `POST /api/post/volunteers` with an **existing client's** email returned **200** and **silently upgraded** `role` CLIENT→VOLUNTEER (`role: user.role === 'CLIENT' ? 'VOLUNTEER' : user.role`) while the client profile and its rides remained.

## Decision — singular roles

The issue notes "everything else assumes roles are singular." This PR enforces that on create: a create is **rejected with 409** when the email belongs to a user who already has a *different* active profile type. `post/admins` is intentionally unchanged (promoting an existing user to ADMIN is intended — R-080).

## What changed

- `server/api/post/clients/index.ts`: include the `volunteer` relation on the lookup; in the existing-user branch, **409** "That email belongs to a volunteer/admin account" when the user has an active (`deletedAt: null`) volunteer profile **or** role `VOLUNTEER`/`ADMIN`. An existing CLIENT (or a plain user with no profile) is unaffected and still falls through to the existing "already a client" **400** (R-042) / normal create.
- `server/api/post/volunteers/index.ts`: include the `client` relation; **409** "That email belongs to a client account" when the user has an active client profile **or** role `CLIENT`, instead of upgrading. Dropped the silent CLIENT→VOLUNTEER role bump. An existing VOLUNTEER still hits "already a volunteer" **400** (R-061).

Both guards throw before any DB mutation (and before the address upsert on the client path), so a rejected create leaves the target account untouched. The UI (`app/pages/people.vue`) already toasts `statusMessage`, so the 409 message surfaces cleanly.

## Pins flipped

- `tests/e2e/known-bugs.test.ts`: R-048 pin flipped `it.fails(` → `it(`, and added an adjacent R-048 case for the **post/volunteers** direction (existing CLIENT `george@example.com` → 409).
- `REQUIREMENTS.md`: R-048 status `pin [#92]` → `auto`.

## Verification

- `pnpm test` → **43 files, 189 passed | 3 expected-fail | 0 failed** (baseline was 187/4/0; +1 from the flipped R-048, +1 from the new post/volunteers case).
- `pnpm trace` → **119/119 covered ✔** (R-048 now counts as auto: 109 auto / 4 pin).
- `pnpm build` → succeeds.
- **Revert-check**: with the two server files reverted, both flipped R-048 tests fail as expected — pre-fix assertion:
  `× R-048 (#92): creating a client with an existing VOLUNTEER email is rejected` and `× R-048 (#92): creating a volunteer with an existing CLIENT email is rejected` (both returned 200, expected `[400,409]`). They pass with the fix.

## Follow-up (out of scope)

`POST /api/post/volunteers` with an **admin's** email still creates a volunteer profile for the admin (role kept ADMIN) — a pre-existing admin dual-profile edge the issue scopes to the CLIENT direction; left for a separate decision rather than widening this diff.

Fixes #92