### PR TITLE
Fix #94: return 404 (not 204 null) for missing records

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -111,7 +111,7 @@ is not documentation that can rot — it is enforced.
 | R-111 | Update/complete/signup against an archived ride → 404 (#27) | `put/rides`, signup | auto | `soft-deletes.test.ts` |
 | R-112 | Changing pickup/dropoff display invalidates the cached Maps estimate (#14) | `put/rides/[id].ts` | auto | `estimate-cache.test.ts` |
 | R-113 | Ride delete is a soft-delete: hidden from lists/byId/estimate, row + history preserved (#27) | `delete/rides/[id].ts` | auto | `soft-deletes.test.ts` |
-| R-114 | `get/rides/byId` of a missing/archived ride → 404 for every role (currently 204 null for admins) | `get/rides/byId/[id].ts` | pin [#94](https://github.com/UTDallasEPICS/wcoa/issues/94) | `known-bugs.test.ts` |
+| R-114 | `get/rides/byId` of a missing/archived ride → 404 for every role | `get/rides/byId/[id].ts` | auto | `known-bugs.test.ts` |
 | R-115 | Estimate endpoint: serves cache when `estimatedAt` set; on miss with no server key returns a clean "not configured" payload (never the public embed key — #30) | `estimate/[id].ts` | auto | `estimate-cache.test.ts`, `maps-key-split.test.ts` |
 
 ## 7. Rides — volunteer self-service (signup / unsignup / complete)
@@ -137,7 +137,7 @@ is not documentation that can rot — it is enforced.
 | R-155 | `get/users` is bounded/paginated like every other list | `get/users/index.ts` | pin [#97](https://github.com/UTDallasEPICS/wcoa/issues/97) | `known-bugs.test.ts` |
 | R-156 | `get/audit` is capped (≤100) with action/userId filters | `get/audit/index.ts` | auto | `audit-log.test.ts` |
 | R-157 | `get/addresses` is bounded and returns `{id, label, address}` for the typeahead; `/options` endpoints are bounded dropdown feeds | `get/addresses`, `*/options` | auto | `address-search.test.ts`, `pagination.test.ts` |
-| R-158 | `users/byEmail` & `users/byId` of an unknown user → 404, not 204 null | `get/users/*` | pin [#94](https://github.com/UTDallasEPICS/wcoa/issues/94) | `known-bugs.test.ts` |
+| R-158 | `users/byEmail` & `users/byId` of an unknown user → 404, not 204 null | `get/users/*` | auto | `known-bugs.test.ts` |
 
 ## 9. Metrics
 

--- a/server/api/get/rides/byId/[id].ts
+++ b/server/api/get/rides/byId/[id].ts
@@ -28,6 +28,14 @@ export default defineEventHandler(async (event) => {
     }
   })
 
+  // Missing/archived ride is gone for everyone (issue #94): return 404 rather
+  // than falling through to a null body (which Nitro serializes as 204). The
+  // admin path skips the non-admin scoping block below, so without this check
+  // an admin would get a 204 for a truly-missing ride.
+  if (!ride) {
+    throw createError({ statusCode: 404, statusMessage: 'Ride not found' })
+  }
+
   // Record-level scoping (issue #41, same class as #3): a non-admin may only
   // retrieve a ride that is available to sign up for (CREATED) or that is
   // assigned to them — never another volunteer's ride and its client PII.

--- a/server/api/get/users/byEmail/[email].get.ts
+++ b/server/api/get/users/byEmail/[email].get.ts
@@ -23,6 +23,12 @@ export default defineEventHandler(async (event) => {
     },
   })
 
+  // Missing/archived user is gone (issue #94): return 404 rather than a null
+  // body, which Nitro serializes as 204 No Content.
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
   return user
 })
 

--- a/server/api/get/users/byId/[id].get.ts
+++ b/server/api/get/users/byId/[id].get.ts
@@ -22,5 +22,11 @@ export default defineEventHandler(async (event) => {
     },
   })
 
+  // Missing/archived user is gone (issue #94): return 404 rather than a null
+  // body, which Nitro serializes as 204 No Content.
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
   return user
 })

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -214,7 +214,7 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(estimate.status).toBe(404)
   })
 
-  it.fails('R-114/R-158 (#94): missing-record GETs return 404, not 204 null', async () => {
+  it('R-114/R-158 (#94): missing-record GETs return 404, not 204 null', async () => {
     const admin = await loginAs(ADMIN)
     const ride = await appFetch('/api/get/rides/byId/nonexistent-id', { headers: { cookie: admin } })
     expect(ride.status).toBe(404)


### PR DESCRIPTION
## What was broken
Three GET handlers returned `null` for a missing/archived record. Nitro serializes a `null` body as **204 No Content** instead of a 404, so frontends get a successful-looking empty response for a nonexistent record (e.g. the ride detail page renders against null data after an admin follows a stale link) instead of hitting an error path.

- `get/rides/byId/[id].ts`: non-admins were already 404'd by the record-scoping block (which catches the null), but the **ADMIN path skips that block and returned `null`** → 204.
- `get/users/byEmail/[email].get.ts` and `get/users/byId/[id].get.ts`: returned `null` → 204 for any unknown user.

## What changed (3 handlers)
- `get/rides/byId/[id].ts`: added a universal `if (!ride) throw createError({ statusCode: 404, ... })` immediately **after** the `findFirst` and **before** the existing non-admin scoping block. Admins (and everyone) now get a 404 for a truly-missing ride; the existing non-admin scoping (exists-but-not-yours → 404) is unchanged.
- `get/users/byId/[id].get.ts` and `get/users/byEmail/[email].get.ts`: added `if (!user) throw createError({ statusCode: 404, ... })` before returning.

The happy path (record found) is unchanged in all three. `createError` is already the auto-import used by each file's existing 400 checks — no new imports.

## Pin flipped
- `tests/e2e/known-bugs.test.ts`: `it.fails('R-114/R-158 (#94): ...')` → `it(...)` (now a permanent regression guard).
- `REQUIREMENTS.md`: R-114 and R-158 moved from `pin` → `auto`.

## Verification
- **Pre-fix (revert-check):** with the pin flipped to `it(` but the handlers unchanged, the test failed with `AssertionError: expected 204 to be 404` at the ride/byId admin assertion. With the fix, it passes.
- `pnpm test`: **190 passed / 2 expected fail / 0 failed** (baseline was 189 passed / 3 expected fail; the flipped pin accounts for the shift).
- `pnpm trace`: **119/119 covered ✔**.
- `pnpm build`: succeeds.

## Risk files
None — no schema/auth/CI/docker/deps changes. Only the 3 GET handlers, the test flip, and the REQUIREMENTS.md rows.

Fixes #94