### PR TITLE
Fix #95: reject invalid ride status transitions out of terminal states

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -105,7 +105,7 @@ is not documentation that can rot — it is enforced.
 | R-105 | Ride update accepts ONLY whitelisted fields; unknown keys 400 via `.strict()` (mass-assignment guard, #31) | `put/rides/[id].ts` | auto | `ride-input-validation.test.ts` |
 | R-106 | Unassigning a volunteer (volunteerId → null/"") auto-resets status to CREATED — but only when the ride was ASSIGNED and no explicit status was sent (#7) | `put/rides/[id].ts` | auto | `unassign-status.test.ts` |
 | R-107 | Completing a ride requires totalRideTime ≥ 0.1 (on the request or already stored) (#10) | `put/rides/[id].ts` | auto | `complete-requires-ridetime.test.ts` |
-| R-108 | Ride status transitions are guarded server-side (no COMPLETED→CREATED un-complete with stale totalRideTime) | `put/rides/[id].ts` | pin [#95](https://github.com/UTDallasEPICS/wcoa/issues/95) | `known-bugs.test.ts` |
+| R-108 | Ride status transitions are guarded server-side (no COMPLETED→CREATED un-complete with stale totalRideTime) | `put/rides/[id].ts` | auto | `known-bugs.test.ts` |
 | R-109 | Cancelling notifies the previously-assigned volunteer via the RIDE_CANCELLED template (#5) | `put/rides/[id].ts` | auto | `ride-cancel.test.ts` |
 | R-110 | Completing notifies the volunteer (RIDE_COMPLETED) and emails admins | `put/rides/[id].ts` | auto | `requirements-flows.test.ts` |
 | R-111 | Update/complete/signup against an archived ride → 404 (#27) | `put/rides`, signup | auto | `soft-deletes.test.ts` |

--- a/server/api/put/rides/[id].ts
+++ b/server/api/put/rides/[id].ts
@@ -56,6 +56,28 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Issue #95: COMPLETED and CANCELLED are terminal states. Reject an explicit
+  // status change *out* of one of them. e.g. sending {status:'CREATED'} to a
+  // COMPLETED ride would re-enter it into the signup pool while keeping its
+  // stale totalRideTime, silently corrupting completion metrics; CANCELLED→
+  // ASSIGNED is likewise wrong. This fires only when the caller explicitly
+  // sends a *different* status, so same-status no-op edits (e.g. editing a
+  // COMPLETED ride's notes with status:'COMPLETED') stay allowed, and the
+  // implicit ASSIGNED→CREATED unassign auto-reset below — which runs only when
+  // body.status is undefined — is untouched. Forward transitions (CREATED↔
+  // ASSIGNED, ASSIGNED→COMPLETED, CREATED/ASSIGNED→CANCELLED) all still work.
+  const TERMINAL = ['COMPLETED', 'CANCELLED']
+  if (
+    body.status !== undefined &&
+    body.status !== existingRide.status &&
+    TERMINAL.includes(existingRide.status)
+  ) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: `Cannot change the status of a ${existingRide.status.toLowerCase()} ride`,
+    })
+  }
+
   // Issue #10: a ride can only be marked COMPLETED with a valid duration.
   // The Complete modal (app/pages/rides/[id].vue) already enforces
   // totalRideTime >= 0.1 via zod, but a direct API call could complete a ride

--- a/tests/e2e/complete-requires-ridetime.test.ts
+++ b/tests/e2e/complete-requires-ridetime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { $fetch } from '@nuxt/test-utils/e2e'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
 import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
@@ -54,7 +54,15 @@ afterEach(async () => {
   if (!touchedRideIds.size) return
   const cookie = await loginAs('reachtusharwani@gmail.com')
   for (const id of touchedRideIds) {
-    await put(cookie, id, { volunteerId: '', status: 'CREATED' })
+    // Best-effort reset via non-throwing appFetch: since #95, a COMPLETED ride
+    // is terminal and its status can no longer be changed back to CREATED (that
+    // returns 409). A ride left COMPLETED here is harmless — the seed DB is
+    // reset per-file and each test picks its own untouched CREATED ride.
+    await appFetch(`/api/put/rides/${id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ volunteerId: '', status: 'CREATED' }),
+    })
   }
   touchedRideIds.clear()
 })

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -224,18 +224,20 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(byId.status).toBe(404)
   })
 
-  it.fails('R-108 (#95): a COMPLETED ride cannot be reset to CREATED', async () => {
+  it('R-108 (#95): a COMPLETED ride cannot be reset to CREATED', async () => {
     const admin = await loginAs(ADMIN)
     const client = await createClient(admin, `${RUN} B95`, `${RUN}-95@example.com`)
     const ride = await createRide(admin, client.id)
     await $fetch(`/api/put/rides/${ride.id}`, {
       method: 'PUT', headers: json(admin), body: { status: 'COMPLETED', totalRideTime: 1 },
     })
-    // Currently: 200 — the ride re-enters the pool keeping its stale totalRideTime.
+    // Fixed (#95): a COMPLETED ride is terminal, so un-completing it back to
+    // CREATED is rejected (409) instead of silently re-entering the pool with a
+    // stale totalRideTime.
     const res = await appFetch(`/api/put/rides/${ride.id}`, {
       method: 'PUT', headers: json(admin), body: JSON.stringify({ status: 'CREATED' }),
     })
-    expect(res.status).toBe(400)
+    expect([400, 409]).toContain(res.status)
   })
 
   it.fails('R-155 (#97): get/users returns a bounded pagination envelope', async () => {

--- a/tests/e2e/ride-input-validation.test.ts
+++ b/tests/e2e/ride-input-validation.test.ts
@@ -14,12 +14,16 @@ async function adminCookie() {
 }
 
 async function firstRideId(cookie: string): Promise<string> {
-  const { items: rides } = await $fetch<{ items: Array<{ id: string }> }>(
+  const { items: rides } = await $fetch<{ items: Array<{ id: string; status: string }> }>(
     '/api/get/rides?pageSize=100',
     { headers: { cookie } }
   )
-  expect(rides.length).toBeGreaterThan(0)
-  return rides[0]!.id
+  // Pick a non-terminal ride: since #95, a COMPLETED/CANCELLED ride rejects any
+  // status transition (409), so the "valid status update" case below needs a
+  // ride whose status can still legitimately change.
+  const ride = rides.find((r) => r.status === 'CREATED' || r.status === 'ASSIGNED')
+  expect(ride, 'seed should have a non-terminal ride').toBeTruthy()
+  return ride!.id
 }
 
 describe('PUT /api/put/rides/[id] input validation (#31)', () => {

--- a/tests/e2e/rides-volunteer-complete.test.ts
+++ b/tests/e2e/rides-volunteer-complete.test.ts
@@ -75,7 +75,15 @@ afterEach(async () => {
   if (!touchedRideIds.size) return
   const cookie = await loginAs(ADMIN)
   for (const id of touchedRideIds) {
-    await put(cookie, id, { volunteerId: '', status: 'CREATED' })
+    // Best-effort reset via non-throwing appFetch: since #95 a COMPLETED ride is
+    // terminal and can't be reset to CREATED (409). A ride left COMPLETED is
+    // harmless — the seed DB is reset per-file and each test picks its own
+    // untouched CREATED ride.
+    await appFetch(`/api/put/rides/${id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ volunteerId: '', status: 'CREATED' }),
+    })
   }
   touchedRideIds.clear()
 })

--- a/tests/e2e/unassign-status.test.ts
+++ b/tests/e2e/unassign-status.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { $fetch } from '@nuxt/test-utils/e2e'
+import { $fetch, fetch as appFetch } from '@nuxt/test-utils/e2e'
 import { bootShared } from '../utils/harness'
 import { loginAs } from '../utils/auth'
 
@@ -58,9 +58,15 @@ afterEach(async () => {
   if (!touchedRideIds.size) return
   const cookie = await loginAs('reachtusharwani@gmail.com')
   for (const id of touchedRideIds) {
-    // Directly reset to CREATED/unassigned (bypass the auto-CREATED behavior by
-    // sending an explicit status alongside the cleared volunteer).
-    await put(cookie, id, { volunteerId: '', status: 'CREATED' })
+    // Best-effort reset to CREATED/unassigned via non-throwing appFetch. Since
+    // #95 a COMPLETED ride is terminal, so this reset is a no-op (409) for a
+    // ride a test left COMPLETED — harmless, since the seed DB is reset per-file
+    // and every test picks its own untouched CREATED ride.
+    await appFetch(`/api/put/rides/${id}`, {
+      method: 'PUT',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ volunteerId: '', status: 'CREATED' }),
+    })
   }
   touchedRideIds.clear()
 })


### PR DESCRIPTION
## What was broken
`PUT /api/put/rides/[id]` accepted **any** status transition. A COMPLETED ride (with a `totalRideTime` set) sent `{"status":"CREATED"}` returned `200`: it silently re-entered the volunteer signup pool while keeping its stale `totalRideTime`, corrupting completion metrics. `CANCELLED→ASSIGNED` and other un-cancels were likewise accepted. Flagged as an owner judgment call in PR #77 but never filed until #95.

## The fix (minimal, safe terminal-state guard)
Added a guard immediately after the `existingRide` null-check in `server/api/put/rides/[id].ts`. `COMPLETED` and `CANCELLED` are terminal: an **explicit** status change to a **different** status is rejected with **409 Conflict** (consistent with the codebase's other state-conflict responses — #87/#88/#92).

```ts
const TERMINAL = ['COMPLETED', 'CANCELLED']
if (body.status !== undefined && body.status !== existingRide.status && TERMINAL.includes(existingRide.status)) {
  throw createError({ statusCode: 409, statusMessage: `Cannot change the status of a ${existingRide.status.toLowerCase()} ride` })
}
```

Why this is minimal and low-risk:
- Fires **only** when `body.status` is sent **and** differs from the current status, so **same-status no-op edits** (e.g. editing a COMPLETED ride's notes/totalRideTime with `status:'COMPLETED'`) stay allowed.
- The implicit `ASSIGNED→CREATED` unassign auto-reset (#7) runs only when `body.status` is `undefined`, so the guard never touches it.
- Forward transitions `CREATED↔ASSIGNED`, `ASSIGNED→COMPLETED`, `CREATED/ASSIGNED→CANCELLED` all still work.
- The #10 completion guard, #14 cache invalidation, #28 audit logging, and notifications are untouched.

Net non-test change: **+11 lines of code** (+9 comment) in one route handler. The fuller state-machine suggested in the issue is deliberately deferred — this directly fixes the reported bug with the least regression surface.

## Pin flipped
- `tests/e2e/known-bugs.test.ts`: R-108 `it.fails(` → `it(`, assertion widened `expect(res.status).toBe(400)` → `expect([400, 409]).toContain(res.status)` (409 chosen).
- `REQUIREMENTS.md`: R-108 `pin` → `auto`.

## Necessary test-hygiene adaptation (please note)
Four ride test files recycled seed rides through the **exact** `COMPLETED→CREATED` transition this fix now (correctly) rejects, in their `afterEach` teardown or fixture selection. Because the R-108 pin requires that transition to be *rejected*, these teardowns can no longer perform it — there is no guard formulation that both rejects the bug and lets the teardown do it (a `volunteerId`-based exemption would just be an exploitable loophole). The teardowns are made **tolerant** (non-throwing `appFetch`, mirroring the existing `ride-cancel.test.ts` pattern), and `ride-input-validation` now selects a non-terminal ride for its valid-update case. **No feature assertions changed** — only cleanup/fixture mechanics:
- `complete-requires-ridetime.test.ts` (R-107), `unassign-status.test.ts` (R-106), `rides-volunteer-complete.test.ts` (#87): `afterEach` reset via non-throwing `appFetch`.
- `ride-input-validation.test.ts` (R-105): `firstRideId` picks a `CREATED`/`ASSIGNED` ride.

## Verification
- `pnpm test`: **43 files, 190 passed / 2 expected-fail / 0 failed** (baseline on `origin/main` was 189 / 3 / 0; R-108 flipped from expected-fail to passing).
- Explicitly confirmed still green: R-105 (`ride-input-validation`), R-106 (`unassign-status`), R-107 (`complete-requires-ridetime`), R-109 (`ride-cancel`), #87 (`rides-volunteer-complete`), and the requirements-flows ride lifecycle.
- `pnpm trace`: **119/119 covered** (R-108 now `auto`; 3 pins remain).
- `pnpm build`: succeeds.
- **Revert-check:** with the handler guard removed but the flipped test in place, R-108 fails with `AssertionError: expected [ 400, 409 ] to include 200` (buggy handler returns 200); with the guard restored it passes. Fail-before / pass-after confirmed.

Fixes #95