### PR TITLE
Fix #96: exclude CANCELLED rides from the completionRate denominator

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -146,7 +146,7 @@ is not documentation that can rot — it is enforced.
 | R-170 | All three metrics are admin-only (#41) | metrics handlers | auto | `requirements-authz-matrix.test.ts` |
 | R-171 | completionRate = completed/total ×100 rounded, with optional date range; returns zeros for an empty range | completionRate | auto | `metrics-date-range.test.ts`, `requirements-flows.test.ts` |
 | R-172 | Metrics deliberately INCLUDE soft-deleted rows (history preservation is the point of soft-delete, #27) | all metrics | auto | `soft-deletes.test.ts` |
-| R-173 | Whether CANCELLED rides belong in the completionRate denominator | completionRate | decision [#96](https://github.com/UTDallasEPICS/wcoa/issues/96) | `known-bugs.test.ts` (pins current include-CANCELLED behavior) |
+| R-173 | CANCELLED rides are excluded from the completionRate denominator (soft-deleted rides still counted, #27) | completionRate | auto | `known-bugs.test.ts` |
 | R-174 | hours = sum of totalRideTime over COMPLETED rides in range | hours | auto | `requirements-flows.test.ts` |
 | R-175 | topRiders: top 5 clients by completed rides, default year-to-date, batched lookup (no N+1, #24) | topRiders | auto | `topRiders-n1.test.ts` |
 | R-176 | Date ranges: endDate inclusive of the entire end day (#18) | `server/utils/dateRange.ts` | auto | `metrics-date-range.test.ts` |

--- a/server/api/get/metrics/completionRate/index.ts
+++ b/server/api/get/metrics/completionRate/index.ts
@@ -13,8 +13,13 @@ export default defineEventHandler(async (event) => {
   // Soft delete (issue #27): metrics DELIBERATELY do NOT filter deletedAt —
   // soft-deleted rides must still count so historical completion rate is
   // preserved. Preserving history is the entire point of soft-delete here.
+  //
+  // CANCELLED rides ARE excluded from the denominator (issue #96): a cancelled
+  // ride is not a missed completion, so counting it would drag the dashboard
+  // completion % down as if a volunteer no-showed. Soft-deleted rides are still
+  // counted (that is deliberate, #27) — only status CANCELLED drops out.
   const totalRides = await prisma.ride.count({
-    where: dateFilter
+    where: { ...dateFilter, status: { not: 'CANCELLED' } }
   })
   
   if (totalRides === 0) {

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -248,8 +248,8 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect(typeof res.total).toBe('number')
   })
 
-  // ---- Decision pin (not a bug pin): flips when the owner decides #96.
-  it('R-173 (#96): CURRENT behavior — CANCELLED rides count in the completionRate denominator', async () => {
+  // ---- #96 decision implemented: CANCELLED is excluded from the denominator.
+  it('R-173 (#96): CANCELLED rides are excluded from the completionRate denominator', async () => {
     const admin = await loginAs(ADMIN)
     const before = await $fetch<{ total: number; completed: number }>(
       '/api/get/metrics/completionRate', { headers: { cookie: admin } }
@@ -262,10 +262,10 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     const after = await $fetch<{ total: number; completed: number }>(
       '/api/get/metrics/completionRate', { headers: { cookie: admin } }
     )
-    // If you are here because this started failing: the denominator decision
-    // (#96) was implemented. Update this assertion to `before.total` and move
-    // the test into requirements-flows.test.ts.
-    expect(after.total).toBe(before.total + 1)
+    // The created-then-cancelled ride nets zero in the denominator: +1 while it
+    // was CREATED, −1 once CANCELLED (now excluded, #96). Soft-deleted rides are
+    // still counted (that part is deliberate, #27).
+    expect(after.total).toBe(before.total)
     expect(after.completed).toBe(before.completed)
   })
 })


### PR DESCRIPTION
## What was broken
`GET /api/get/metrics/completionRate` counted **all** rides in `total` (`prisma.ride.count({ where: dateFilter })`), including CANCELLED ones. Cancelling a ride therefore dragged the dashboard completion percentage down exactly as if a volunteer had no-showed (issue reporter observed 27% -> 25% from cancelling a single ride). A cancelled ride is not a missed completion, so it should not be in the denominator.

## Decision (needs owner sign-off)
This implements the option the #77/#80 reviewers recommended: **exclude CANCELLED from the denominator**. This **changes a user-visible dashboard metric** — completion percentages will read higher wherever cancelled rides exist — so it warrants owner sign-off before deploy.

Deliberately **kept**: soft-deleted rides are still counted (issue #27 — preserving history is the point of soft-delete; no `deletedAt` filter was added). `completedRides` (status COMPLETED) and the percentage/early-return logic are unchanged.

## What changed
- `server/api/get/metrics/completionRate/index.ts` — the `totalRides` count now filters `status: { not: 'CANCELLED' }` (one `where` change, plus an explanatory comment). Net non-test change: 1 logic line.
- `tests/e2e/known-bugs.test.ts` — R-173 flips from pinning the old include-CANCELLED behavior to asserting the fixed behavior: a created-then-cancelled ride nets zero in the denominator (`after.total === before.total`). Kept the `R-173` tag so `pnpm trace` still matches.
- `REQUIREMENTS.md` — R-173 status `decision` -> `auto`; text updated to "CANCELLED rides are excluded from the completionRate denominator (soft-deleted rides still counted, #27)".

## Verification
- `pnpm test` -> **189 passed | 3 expected fail | 0 failed** (43 files). No other completionRate assertion needed changing: `metrics-date-range.test.ts:90` and `requirements-flows.test.ts:326` exercise CREATED/COMPLETED rides, not CANCELLED, so the exclusion doesn't affect them.
- `pnpm trace` -> **119/119 covered ✔**.
- `pnpm build` -> succeeds.
- **Revert-check:** with the handler reverted to `where: dateFilter` (test assertion left flipped), R-173 fails with `AssertionError: expected 13 to be 12` (the cancelled ride inflates `after.total`); with the fix, it passes. Confirmed fail-before / pass-after.

Fixes #96