### PR TITLE
Fix #105: scope put/admins/[id] to ADMIN targets (404 for non-admins)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -92,6 +92,7 @@ is not documentation that can rot — it is enforced.
 | R-082 | `delete/admins` only archives users whose role is ADMIN (404 otherwise) | `delete/admins/[id].ts` | auto | `known-bugs.test.ts` |
 | R-083 | An admin cannot delete their own account, and the last remaining admin cannot be deleted (lockout guard) | `delete/admins/[id].ts` | auto | `known-bugs.test.ts` |
 | R-084 | Admin soft-delete releases email/phone, revokes sessions; double-delete 404s | `delete/admins/[id].ts` | auto | `admin-delete.test.ts`, `soft-deletes.test.ts` |
+| R-085 | `put/admins` only edits users whose role is ADMIN (404 otherwise), mirroring delete/admins (#105) | `put/admins/[id].ts` | auto | `known-bugs.test.ts` |
 
 ## 6. Rides — CRUD & lifecycle
 

--- a/server/api/put/admins/[id].ts
+++ b/server/api/put/admins/[id].ts
@@ -30,8 +30,14 @@ export default defineEventHandler(async (event) => {
   // prisma.user.update and surfaced the raw P2025 as a 500. 404 like the sibling
   // update endpoints (put/clients, put/volunteers). Soft delete (issue #27): an
   // archived user is treated as gone.
+  //
+  // Issue #105: this endpoint edits ADMINs only — the update-side analogue of
+  // #88 on delete/admins. Without the role filter it would edit ANY user (e.g. a
+  // CLIENT's or VOLUNTEER's user row) by id, bypassing put/clients / put/volunteers
+  // and their own validation. Scope the lookup to role: 'ADMIN' so a non-admin id
+  // resolves to "not found" (404), mirroring delete/admins/[id].ts.
   const existing = await prisma.user.findFirst({
-    where: { id, deletedAt: null },
+    where: { id, role: 'ADMIN', deletedAt: null },
   })
   if (!existing) {
     throw createError({
@@ -51,7 +57,10 @@ export default defineEventHandler(async (event) => {
   // user's email/phone) is a clean 409, not a 500 (issue #91).
   try {
     return await prisma.user.update({
-      where: { id },
+      // role: 'ADMIN' mirrors the findFirst guard above (issue #105,
+      // defense-in-depth) so this write can never edit a non-admin, matching
+      // delete/admins/[id].ts.
+      where: { id, role: 'ADMIN', deletedAt: null },
       data,
     })
   } catch (err) {

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -98,6 +98,29 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     if (!res.ok) await appFetch(`/api/delete/admins/${created.id}`, { method: 'DELETE', headers: json(admin) })
   })
 
+  it('R-085 (#105): put/admins refuses to edit a non-admin user', async () => {
+    const admin = await loginAs(ADMIN)
+    const bob = await loginAs(BOB)
+    // Resolve bob's (a VOLUNTEER) userId and snapshot his current name.
+    const bobVol = await $fetch<{ userId: string }>('/api/get/volunteers/bySession', {
+      headers: { cookie: bob },
+    })
+    const before = await $fetch<{ name: string }>(`/api/get/users/byId/${bobVol.userId}`, {
+      headers: { cookie: admin },
+    })
+    // Before the fix: 200 — put/admins edits ANY user by id (no role filter),
+    // renaming the volunteer's user row. Now: 404, mirroring delete/admins.
+    const res = await appFetch(`/api/put/admins/${bobVol.userId}`, {
+      method: 'PUT', headers: json(admin), body: JSON.stringify({ name: `${RUN} SHOULD-NOT-APPLY` }),
+    })
+    expect(res.status).toBe(404)
+    // The volunteer's user must be untouched.
+    const after = await $fetch<{ name: string }>(`/api/get/users/byId/${bobVol.userId}`, {
+      headers: { cookie: admin },
+    })
+    expect(after.name).toBe(before.name)
+  })
+
   it('R-045 (#89): a partial client update does not wipe email/phone', async () => {
     const admin = await loginAs(ADMIN)
     const email = `${RUN}-89@example.com`


### PR DESCRIPTION
## What was broken

`PUT /api/put/admins/[id]` looked up its target with `findFirst({ id, deletedAt: null })` — **no `role: 'ADMIN'` filter** — and then updated `where: { id }`. So an admin could edit a CLIENT's or VOLUNTEER's user row by id, bypassing `put/clients` / `put/volunteers` and their own validation. This is the update-side analogue of #88 (which scoped `delete/admins` to ADMIN).

## What changed

`server/api/put/admins/[id].ts` (+11/-2):
- Added `role: 'ADMIN'` to the existence-check `findFirst` → a non-admin id now resolves to 404 "Admin not found".
- Added `role: 'ADMIN', deletedAt: null` to the `prisma.user.update` `where` too (defense-in-depth, mirroring `delete/admins/[id].ts`). A concurrent role-change/soft-delete makes the write match no row → P2025 → 404 via the existing `throwOnPrismaWriteConflict`.
- Unchanged: the #91 P2002→409 / P2025→404 mapping and the #89/#90 presence-aware field building.

## Regression pin

- `REQUIREMENTS.md`: new row **R-085** — "`put/admins` only edits users whose role is ADMIN (404 otherwise), mirroring delete/admins (#105)", source `put/admins/[id].ts`, status `auto`, coverage `known-bugs.test.ts`.
- `tests/e2e/known-bugs.test.ts`: `R-085 (#105): put/admins refuses to edit a non-admin user` — as admin, resolve bob's (VOLUNTEER) userId via `/api/get/volunteers/bySession`, snapshot his name, `PUT /api/put/admins/<userId>` `{name:'…'}` → asserts **404** and that the volunteer's user name is unchanged.

## Verification

- `pnpm test` → **192 passed | 1 expected-fail | 0 failed** (baseline + my new passing test).
- `pnpm trace` → **covered 120/120 ✔** (R-085 added).
- `pnpm build` → succeeds.
- **Revert-check**: with `put/admins/[id].ts` reverted to `origin/main`, the new test fails with `AssertionError: expected 200 to be 404` (the endpoint returns 200 and renames the volunteer). With the fix it passes and the user is untouched. Fail-before / pass-after confirmed.
- `/code-review` (xhigh) → no findings.

Fixes #105