### PR TITLE
Fix #97: paginate GET /api/get/users (bounded envelope)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -134,7 +134,7 @@ is not documentation that can rot — it is enforced.
 | R-152 | Rides list: include/exclude status filter chips compose server-side; bogus status values are ignored (whitelist incl. CANCELLED) | `get/rides/index.ts` | auto | `ride-filters.test.ts` |
 | R-153 | Rides list: date range filter, end date inclusive of the whole day | `get/rides/index.ts` | auto | `ride-filters.test.ts` |
 | R-154 | Rides list: free-text search across id, displays, client name, volunteer name | `get/rides/index.ts` | auto | `ride-filters.test.ts` |
-| R-155 | `get/users` is bounded/paginated like every other list | `get/users/index.ts` | pin [#97](https://github.com/UTDallasEPICS/wcoa/issues/97) | `known-bugs.test.ts` |
+| R-155 | `get/users` is bounded/paginated like every other list | `get/users/index.ts` | auto | `known-bugs.test.ts` |
 | R-156 | `get/audit` is capped (≤100) with action/userId filters | `get/audit/index.ts` | auto | `audit-log.test.ts` |
 | R-157 | `get/addresses` is bounded and returns `{id, label, address}` for the typeahead; `/options` endpoints are bounded dropdown feeds | `get/addresses`, `*/options` | auto | `address-search.test.ts`, `pagination.test.ts` |
 | R-158 | `users/byEmail` & `users/byId` of an unknown user → 404, not 204 null | `get/users/*` | auto | `known-bugs.test.ts` |

--- a/server/api/get/users/index.ts
+++ b/server/api/get/users/index.ts
@@ -1,8 +1,25 @@
+import { Prisma } from '../../../../prisma/generated/client'
 import { prisma } from '../../../utils/prisma'
+import { getPageParams } from '../../../utils/pagination'
 
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
   // Admin management data (issue #41): the full user table is PII.
   requireAdmin(event)
+
+  const { page, pageSize, skip, take } = getPageParams(event)
+
   // Soft delete (issue #27): hide archived users from the active list.
-  return prisma.user.findMany({ where: { deletedAt: null } })
+  const where: Prisma.UserWhereInput = { deletedAt: null }
+
+  // Server-side pagination (issue #13): bounded page + matching count. This
+  // list was the one #13 missed (issue #97); mirror the volunteers/admins
+  // envelope so a growing user table can never be loaded whole into memory.
+  // `id` is a random uuid, so it also serves as a stable, deterministic sort
+  // key that keeps page walks from dropping/duplicating rows.
+  const [items, total] = await prisma.$transaction([
+    prisma.user.findMany({ where, orderBy: { id: 'asc' }, skip, take }),
+    prisma.user.count({ where }),
+  ])
+
+  return { items, total, page, pageSize }
 })

--- a/tests/e2e/delete-admins-guard.test.ts
+++ b/tests/e2e/delete-admins-guard.test.ts
@@ -33,7 +33,11 @@ type AdminRow = { id: string; email: string | null }
 type VolunteerRow = { id: string; userId: string; deletedAt: string | null; user: { email: string | null } }
 
 async function getUsers(cookie: string): Promise<UserRow[]> {
-  return await $fetch<UserRow[]>('/api/get/users', { headers: { cookie } })
+  // #97: get/users is now paginated ({items,total,...}) like the other lists.
+  const { items } = await $fetch<{ items: UserRow[] }>('/api/get/users?pageSize=100', {
+    headers: { cookie },
+  })
+  return items
 }
 
 async function getAdmins(cookie: string): Promise<AdminRow[]> {

--- a/tests/e2e/known-bugs.test.ts
+++ b/tests/e2e/known-bugs.test.ts
@@ -240,9 +240,10 @@ describe('known-bug pins (issues #87–#97) — R-IDs from REQUIREMENTS.md', () 
     expect([400, 409]).toContain(res.status)
   })
 
-  it.fails('R-155 (#97): get/users returns a bounded pagination envelope', async () => {
+  it('R-155 (#97): get/users returns a bounded pagination envelope', async () => {
     const admin = await loginAs(ADMIN)
-    // Currently: a bare unbounded array.
+    // Fixed (#97): a bounded {items,total,page,pageSize} envelope (was a bare
+    // unbounded array) — mirrors the volunteers/admins list from #13.
     const res = await $fetch<{ items: unknown[]; total: number }>('/api/get/users', {
       headers: { cookie: admin },
     })

--- a/tests/e2e/orphaned-users.test.ts
+++ b/tests/e2e/orphaned-users.test.ts
@@ -15,10 +15,12 @@ await bootShared()
 const uniq = () => Math.random().toString(36).slice(2, 10)
 
 async function getUsers(cookie: string) {
-  return await $fetch<Array<{ id: string; email: string | null }>>(
-    '/api/get/users',
+  // #97: get/users is now paginated ({items,total,...}) like the other lists.
+  const { items } = await $fetch<{ items: Array<{ id: string; email: string | null }> }>(
+    '/api/get/users?pageSize=100',
     { headers: { cookie } }
   )
+  return items
 }
 
 describe('issue #8 — deletion removes the parent User (no orphans)', () => {


### PR DESCRIPTION
## What was broken
`server/api/get/users/index.ts` was an unbounded `prisma.user.findMany({ where: { deletedAt: null } })` — no `take`, no pagination envelope. Issue #13 gave rides/clients/volunteers/admins the `{items,total,page,pageSize}` treatment (default 20, hard cap 100, stable sort), but this admin-only list was the one it missed, so it grows with the user table forever. Admin-only (PII already scoped by #41), so blast radius is bounded, but unbounded reads still scale badly.

## What changed
Mirror the established #13 pattern exactly (see `get/volunteers/index.ts` / `get/admins/index.ts`):
- Parse `getPageParams(event)` (the shared helper: default pageSize 20, hard cap 100, clamps all garbage input).
- Run a single `prisma.$transaction([findMany({ where, orderBy: { id: 'asc' }, skip, take }), count({ where })])` for a consistent page slice + matching total.
- Return `{ items, total, page, pageSize }`.
- `requireAdmin(event)` and the `deletedAt: null` filter are unchanged. `id` is a random uuid, so it doubles as a stable, deterministic sort key (no drop/duplicate across page walks).

Net non-test change: `server/api/get/users/index.ts` +19 lines.

## No frontend consumer
Grep-confirmed there is **no** consumer of the `/api/get/users` LIST endpoint in `app/` — the people page uses the paginated `/api/get/clients|volunteers|admins`; only `users/byId` and `users/byEmail` are consumed elsewhere and are untouched. Zero `.vue` files changed.

## Pin flipped
- `tests/e2e/known-bugs.test.ts`: R-155 `it.fails(...)` → `it(...)` (the fix makes it pass).
- `REQUIREMENTS.md`: R-155 status `pin` → `auto`.

## Test consumers updated
Two e2e helpers read `/api/get/users` as a bare array and would break on the envelope; both now read `.items` with `?pageSize=100`, matching their sibling `getAdmins`/`getVolunteers` helpers in the same files:
- `tests/e2e/delete-admins-guard.test.ts`
- `tests/e2e/orphaned-users.test.ts`

(`record-scoping`, `requirements-authz-matrix`, `auth-middleware` only assert status codes / definedness — unaffected.)

## Verification
- `pnpm test`: **43 files, 192 passed / 0 failed** (baseline on main was ~191 passed + 1 expected-fail R-155; R-155 is now a regular passing test).
- `pnpm trace`: 119/119 requirements covered ✔ (R-155 now `auto`).
- `pnpm build`: succeeds.
- **Revert-check (fail-before / pass-after):** with `get/users/index.ts` reverted to the bare array, R-155 fails at `known-bugs.test.ts:250` — `expect(Array.isArray(res.items)).toBe(true)` → `AssertionError: expected false to be true`. With the fix it passes.

## Follow-up (non-blocking, low severity)
`orphaned-users.test.ts` Test 3 asserts seeded martha's user is *present* in the list. Pre-fix this read the unbounded array; post-fix it reads the first 100 by random-uuid order. It's green today (active users stay well under 100) and consistent with the existing `?pageSize=100` convention, but a targeted `users/byId` lookup would be more robust if that suite ever crosses 100 active users.

Fixes #97