### PR TITLE
Fix #98: resolve SSR hydration mismatch in date rendering

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -208,7 +208,7 @@ is not documentation that can rot — it is enforced.
 | R-301 | Settings (volunteer): profile card, status selector, per-type notification toggles, reminder editor — all persisted via bySession endpoints | `app/pages/settings.vue` | auto | browser: `volunteer-flows.spec.ts` |
 | R-302 | Admin notification page: 5 template cards with Edit/Disable reflecting `enabled` | `app/pages/admin/notifications.vue` | auto | browser: `admin-flows.spec.ts` |
 | R-303 | Admin audit page: bounded table, action/user filters | `app/pages/admin/audit.vue` | auto | browser: `admin-flows.spec.ts` |
-| R-304 | Pages hydrate without mismatches (SSR output == client render) | layout | manual [#98](https://github.com/UTDallasEPICS/wcoa/issues/98) | browser: `admin-flows.spec.ts` non-gating diagnostic (mismatch reproduces intermittently; observed in audit) |
+| R-304 | Pages hydrate without mismatches (SSR output == client render): SSR-rendered dates are timezone-stable so server (UTC) and browser (local TZ) agree | `app/utils/datetime.ts`, rides/index.vue, rides/[id].vue, admin/audit.vue | auto [#98](https://github.com/UTDallasEPICS/wcoa/issues/98) | `hydration-datetime.test.ts` (server-side determinism) + browser: `admin-flows.spec.ts` (`/rides` hydrates clean) |
 | R-305 | Success/error toasts on every mutating UI action | all pages | auto | browser specs (asserted on key flows) |
 
 ## Known non-requirements / accepted behavior

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,7 +31,9 @@ untagged requirement turns CI red** — that's what keeps the catalog honest ins
 The 2026-07-14 audit found 12 open defects (issues #87–#98). Each has a pin that asserts the
 **correct** behavior, wrapped so today's wrong behavior is "expected":
 - API pins use `it.fails(...)` in `known-bugs.test.ts`.
-- UI pins use `test.fail()` in the browser specs (R-135/#87, and the R-304/#98 diagnostic).
+- UI pins use `test.fail()` in the browser specs (R-135/#87). The R-304/#98 hydration check is now a
+  hard assertion (`/rides` hydrates clean) — its server-side determinism is guarded by
+  `tests/e2e/hydration-datetime.test.ts`.
 
 **When you fix a bug, its pin starts failing** (because the assertion now passes). That is the signal to:
 1. remove the `.fails` / `test.fail()`, and

--- a/app/pages/admin/audit.vue
+++ b/app/pages/admin/audit.vue
@@ -76,7 +76,7 @@ function formatDetails(details: unknown): string {
             :key="log.id"
             class="border-t border-gray-100 dark:border-gray-800"
           >
-            <td class="px-3 py-2 whitespace-nowrap">{{ new Date(log.createdAt).toLocaleString() }}</td>
+            <td class="px-3 py-2 whitespace-nowrap">{{ formatDateTime(log.createdAt) }}</td>
             <td class="px-3 py-2">
               <UBadge variant="subtle">{{ log.action }}</UBadge>
             </td>

--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -270,14 +270,14 @@
             <div>
               <p class="text-sm text-gray-500">Appointment Time</p>
               <p class="font-medium">
-                {{ new Date(ride.scheduledTime).toLocaleString() }}
+                {{ formatDateTime(ride.scheduledTime) }}
               </p>
             </div>
 
             <div v-if="ride.pickupTime">
               <p class="text-error text-sm text-gray-500">Pick Up Time</p>
               <p class="text-error font-bold">
-                {{ new Date(ride.pickupTime).toLocaleString() }}
+                {{ formatDateTime(ride.pickupTime) }}
               </p>
             </div>
 

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -291,7 +291,8 @@
       accessorKey: 'scheduledTime',
       header: 'Date',
       cell: ({ row }) => {
-        return new Date(row.getValue('scheduledTime')).toLocaleString('en-US', {
+        // Pinned locale + timezone so SSR and client agree (issue #98).
+        return formatDateTime(row.getValue('scheduledTime'), {
           day: 'numeric',
           month: 'short',
           year: 'numeric',

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -1,0 +1,35 @@
+/**
+ * Client-side date/time formatting for values that are rendered during SSR and
+ * then hydrated in the browser (issue #98).
+ *
+ * The pages used bare `new Date(x).toLocaleString()` /
+ * `toLocaleString('en-US', { … })` with NO fixed `timeZone`. `toLocaleString`
+ * resolves the timezone (and, without a locale argument, the locale) from the
+ * host environment — so the server (UTC in the production container) and the
+ * viewer's browser (their local timezone) format the SAME instant into
+ * DIFFERENT strings. Vue then reports
+ * "Hydration completed but contains mismatches." on every page that renders a
+ * date during SSR (/rides, /rides/[id], /admin/audit).
+ *
+ * Pinning both the locale and the timezone makes the string deterministic, so
+ * the server render and the client render agree and hydration is clean. The
+ * timezone matches the org (North Texas) and the server-side convention in
+ * server/utils/datetime.ts (issue #9).
+ */
+
+export const APP_TIME_ZONE = 'America/Chicago'
+
+/**
+ * Format an instant in the app's fixed locale + timezone. Extra
+ * `Intl.DateTimeFormatOptions` are merged in so each call site keeps its own
+ * date/time style; only the locale and timezone are forced.
+ */
+export function formatDateTime(
+  value: string | number | Date,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  return new Date(value).toLocaleString('en-US', {
+    timeZone: APP_TIME_ZONE,
+    ...options,
+  })
+}

--- a/tests/browser/admin-flows.spec.ts
+++ b/tests/browser/admin-flows.spec.ts
@@ -121,13 +121,20 @@ test('R-303: audit page renders the trail of this suite\'s own actions', async (
   await expect(page.getByText('RIDE_CANCELLED').first()).toBeVisible()
 })
 
-// R-304 / issue #98: hydration-mismatch diagnostic. The mismatch was observed
-// in the audit but reproduces intermittently (it did not surface on this
-// separate prod build), so this is a NON-GATING diagnostic that records the
-// count rather than a flaky negative pin. R-304 is tracked as `manual` in
-// REQUIREMENTS.md against #98; tighten this to a hard assertion once the fix
-// makes the page reliably clean.
-test('R-304 (#98): hydration-mismatch diagnostic (non-gating)', async ({ page }) => {
+// R-304 / issue #98: /rides must hydrate without mismatches. Root cause was
+// timezone-dependent date formatting: the "Date" column used
+// `toLocaleString('en-US', { … })` with NO fixed timeZone, so the server (UTC
+// in prod) and the browser (viewer's local TZ) rendered the same instant into
+// different strings. The fix pins locale + timezone (app/utils/datetime.ts), so
+// the page is now reliably clean — this is a hard assertion rather than the old
+// non-gating diagnostic.
+//
+// Caveat: this Playwright suite runs the Nuxt server and the browser on the
+// SAME machine (same TZ), so it does not, on its own, exercise the UTC-vs-local
+// divergence that produced the audit mismatch; the server-side determinism is
+// pinned by tests/e2e/hydration-datetime.test.ts. This assertion still guards
+// against any OTHER hydration mismatch reappearing on the shell/route.
+test('R-304 (#98): /rides hydrates without mismatches', async ({ page }) => {
   const errors: string[] = []
   page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text())
@@ -135,6 +142,5 @@ test('R-304 (#98): hydration-mismatch diagnostic (non-gating)', async ({ page })
   await page.goto('/rides')
   await page.waitForLoadState('networkidle')
   const hydration = errors.filter((e) => /hydration/i.test(e))
-  if (hydration.length) console.warn(`[R-304/#98] hydration mismatches on /rides: ${hydration.length}`)
-  expect(true).toBe(true)
+  expect(hydration).toEqual([])
 })

--- a/tests/e2e/hydration-datetime.test.ts
+++ b/tests/e2e/hydration-datetime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { APP_TIME_ZONE, formatDateTime } from '../../app/utils/datetime'
+
+// Issue #98: Vue logged "Hydration completed but contains mismatches." on every
+// SSR page that rendered a date. The pages formatted dates with bare
+// `toLocaleString()` / `toLocaleString('en-US', { … })` and NO fixed timeZone,
+// so the server (UTC in the production container) and the browser (viewer's
+// local timezone) turned the SAME instant into DIFFERENT strings — e.g. the
+// /rides "Date" column rendered "Jul 19, 2026, 04:52 AM" on the server and
+// "Jul 18, 2026, 11:52 PM" in a US-Central browser. `formatDateTime` pins the
+// locale + timezone so both renders agree.
+//
+// This is a pure-function revert-check (cf. issue #9's
+// notification-datetime.test.ts): the helper does not exist on origin/main, so
+// this file fails to import/compile pre-fix. The assertions below also prove
+// the behaviour is timezone-stable — they hold on any host TZ because the
+// helper pins the zone rather than reading the process's.
+describe('formatDateTime (issue #98 SSR hydration mismatch)', () => {
+  // 2026-07-19T04:52:00Z is 11:52 PM the PREVIOUS calendar day in
+  // America/Chicago (CDT, UTC-5 in July). A host in UTC would render "Jul 19";
+  // the pinned formatter must render the Chicago view instead.
+  const instant = new Date('2026-07-19T04:52:00Z')
+
+  it('pins the app timezone to America/Chicago', () => {
+    expect(APP_TIME_ZONE).toBe('America/Chicago')
+  })
+
+  it('renders the /rides column style deterministically (not the UTC instant)', () => {
+    const formatted = formatDateTime(instant, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    expect(formatted).toContain('Jul 18, 2026')
+    expect(formatted).toMatch(/11:52\s?PM/)
+    // Must NOT leak the UTC calendar day the server would otherwise emit.
+    expect(formatted).not.toContain('Jul 19')
+  })
+
+  it('is stable for the default style used by ride detail + audit', () => {
+    // No options → en-US default ("M/D/YYYY, h:mm:ss AM/PM"), still Chicago.
+    const formatted = formatDateTime(instant)
+    expect(formatted).toContain('7/18/2026')
+    expect(formatted).not.toContain('7/19/2026')
+  })
+})


### PR DESCRIPTION
## What was broken

Every SSR page that renders a date logged `[error] Hydration completed but contains mismatches.` This is a **frontend/SSR** fix.

**Root cause (exact node):** the pages formatted dates with bare `new Date(x).toLocaleString()` / `toLocaleString('en-US', { … })` and **no fixed `timeZone`**. `toLocaleString` reads the timezone (and, with no locale arg, the locale) from the host, so the server (UTC in the prod container) and the viewer's browser (their local TZ) turn the *same instant* into *different strings*. Concretely the `/rides` **"Date" column `<td>`** rendered `Jul 19, 2026, 04:52 AM` on a UTC server vs `Jul 18, 2026, 11:52 PM` in a US‑Central browser — Vue sees the text differ and re-renders on the client. Same pattern in `rides/[id].vue` (appointment + pickup time) and `admin/audit.vue` (createdAt).

**Why it looked layout-level / "2× / intermittent":** it only manifests when the server TZ ≠ browser TZ (prod UTC vs local browser), so a same‑TZ build shows nothing (matching the prior R‑304 note). Vue caps the mismatch log to one message per app instance, and that single message **persists in the console across the app's client-side (SPA) route changes**, so after visiting `/rides` it appeared to linger on pages that render no dates (dashboard, notifications). The "2×" is the devtools double-reporting a single log (observed directly).

## The fix

New client helper `app/utils/datetime.ts` — `formatDateTime(value, options?)` pins the locale (`en-US`) and timezone (`America/Chicago`, the org's zone, matching the server-side convention in `server/utils/datetime.ts` from #9). Server and client now format identically → clean hydration. Each call site keeps its own date/time style. Non-test change: **+35 / -6 across 4 files** (`app/utils/datetime.ts` new; `rides/index.vue`, `rides/[id].vue`, `admin/audit.vue` swapped to the helper).

## Verification

**Empirical browser before/after (prod build: `node .output/server/index.mjs`, server `TZ=UTC`, browser `America/Chicago`):**
- **BEFORE** (origin/main code, fresh `/rides` load): console showed
  ```
  [error] Hydration completed but contains mismatches.
  [error] Hydration completed but contains mismatches.
  ```
  and the "Date" cell was `Jul 19, 2026, 04:52 AM` (SSR/UTC) vs `Jul 18, 2026, 11:52 PM` (client/Central).
- **AFTER** (this branch, identical conditions): console **clean** (verified capture was live), and SSR + client both render `Jul 18, 2026, 11:52 PM`.

**Regression test:** `tests/e2e/hydration-datetime.test.ts` — a pure-function pin (cf. #9's `notification-datetime.test.ts`) asserting the helper renders an instant in `America/Chicago` **regardless of host TZ** (verified identical output under `TZ=UTC` and `TZ=Asia/Tokyo`). It fails to import pre-fix (helper absent), so a revert of this commit turns it red.

**Suite + build:** `pnpm test` → 44 files, 194 passed + 1 pre-existing expected-fail. `pnpm build` succeeds.

**Browser pin (R‑304):** tightened from a non-gating diagnostic (`expect(true).toBe(true)`) to a hard assertion (`expect(hydration).toEqual([])`) in `tests/browser/admin-flows.spec.ts`; `REQUIREMENTS.md`/`TESTING.md` updated. **UNVERIFIED here** — Playwright (`pnpm test:browser`) isn't runnable in this environment. Note the Playwright suite runs the Nuxt server and browser on the same machine (same TZ), so it does not itself exercise the UTC-vs-local divergence; the server-side determinism is what `hydration-datetime.test.ts` guards.

**Evidence level:** empirical browser before/after achieved (via a deliberately induced server-TZ≠browser-TZ) + inspection argument + green suite. The one gap is the live Playwright R‑304 run.

Fixes #98