### PR TITLE
Fix #113: pin server notification/email times to the org timezone

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -163,6 +163,7 @@ is not documentation that can rot — it is enforced.
 | R-194 | Broadcasts go only to AVAILABLE, non-deleted volunteers; sends run parallel via allSettled (one failure never aborts the rest) | `broadcastNotification` | auto | `ride-broadcast-nonblocking.test.ts` |
 | R-195 | `sendEmail` returns boolean and never throws; under TEST_HOOKS it's a strict no-op seam; in prod it always really sends (#25) | `server/utils/email.ts` | auto | `otp-send-failure.test.ts` + code inspection |
 | R-196 | Notification dates render as real calendar dates/times, not bare weekdays (#9) | `server/utils/datetime.ts` | auto | `notification-datetime.test.ts` |
+| R-197 | Server-rendered notification/email/reminder times use the pinned org timezone (`America/Chicago`) via `formatNotificationDateTime`, not the host TZ (UTC in prod) — signup/unsignup email bodies + the RIDE_REMINDER `time` field (#113) | `server/utils/datetime.ts`, `signup.ts`, `unsignup.ts`, `scheduler.ts` | auto | `notification-timezone.test.ts` |
 
 ## 11. Reminder cron
 

--- a/server/api/post/rides/[id]/signup.ts
+++ b/server/api/post/rides/[id]/signup.ts
@@ -153,7 +153,7 @@ export default defineEventHandler(async (event) => {
         <p><strong>Ride Details:</strong></p>
         <p><strong>From:</strong> ${ride.pickupDisplay}</p>
         <p><strong>To:</strong> ${ride.dropoffDisplay}</p>
-        <p><strong>Time:</strong> ${new Date(ride.scheduledTime).toLocaleString()}</p>
+        <p><strong>Time:</strong> ${formatNotificationDateTime(new Date(ride.scheduledTime))}</p>
       `
     ))
   })

--- a/server/api/post/rides/[id]/unsignup.ts
+++ b/server/api/post/rides/[id]/unsignup.ts
@@ -122,7 +122,7 @@ export default defineEventHandler(async (event) => {
         <p>You have successfully unsigned from the following ride:</p>
         <p><strong>From:</strong> ${ride.pickupDisplay}</p>
         <p><strong>To:</strong> ${ride.dropoffDisplay}</p>
-        <p><strong>Time:</strong> ${new Date(ride.scheduledTime).toLocaleString()}</p>
+        <p><strong>Time:</strong> ${formatNotificationDateTime(new Date(ride.scheduledTime))}</p>
       `
     ))
   }
@@ -138,7 +138,7 @@ export default defineEventHandler(async (event) => {
         <p><strong>Ride Details:</strong></p>
         <p><strong>From:</strong> ${ride.pickupDisplay}</p>
         <p><strong>To:</strong> ${ride.dropoffDisplay}</p>
-        <p><strong>Time:</strong> ${new Date(ride.scheduledTime).toLocaleString()}</p>
+        <p><strong>Time:</strong> ${formatNotificationDateTime(new Date(ride.scheduledTime))}</p>
       `
     ))
   })

--- a/server/utils/datetime.ts
+++ b/server/utils/datetime.ts
@@ -33,6 +33,15 @@ const timeFormatter = new Intl.DateTimeFormat('en-US', {
   minute: '2-digit',
 })
 
+const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: TIME_ZONE,
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+})
+
 /** e.g. "February 16, 2026" */
 export function formatNotificationDate(date: Date): string {
   return dateFormatter.format(date)
@@ -41,4 +50,16 @@ export function formatNotificationDate(date: Date): string {
 /** e.g. "9:00 AM" */
 export function formatNotificationTime(date: Date): string {
   return timeFormatter.format(date)
+}
+
+/**
+ * Combined calendar date + clock time, e.g. "February 16, 2026 at 9:00 AM"
+ * (issue #113). Server-side email/reminder bodies previously used a bare
+ * `new Date(x).toLocaleString()`, which renders in the host process timezone —
+ * UTC in the prod container — so volunteers/admins saw UTC times. Pinning to
+ * `America/Chicago` (matching the other formatters above) keeps the rendered
+ * time in the org timezone regardless of the host environment.
+ */
+export function formatNotificationDateTime(date: Date): string {
+  return dateTimeFormatter.format(date)
 }

--- a/server/utils/scheduler.ts
+++ b/server/utils/scheduler.ts
@@ -2,6 +2,7 @@ import { Prisma } from '../../prisma/generated/client'
 import { prisma } from './prisma'
 import { sendNotification } from './notification'
 import { maybeFault } from './testHooks'
+import { formatNotificationDateTime } from './datetime'
 
 export async function processReminders() {
   const now = new Date()
@@ -97,7 +98,7 @@ export async function processReminders() {
               client: ride.client.user.name,
               pickup: ride.pickupDisplay,
               dropoff: ride.dropoffDisplay,
-              time: scheduledTime.toLocaleString(),
+              time: formatNotificationDateTime(scheduledTime),
               notes: ride.notes || 'None',
               link: `${process.env.APP_URL || 'http://localhost:3000'}/rides/${ride.id}`,
             })

--- a/tests/e2e/notification-timezone.test.ts
+++ b/tests/e2e/notification-timezone.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { fetch as appFetch } from '@nuxt/test-utils/e2e'
+import { randomUUID } from 'node:crypto'
+import Database from 'better-sqlite3'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+import { formatNotificationDateTime } from '../../server/utils/datetime'
+
+await bootShared()
+
+// Regression coverage for R-197 / issue #113.
+//
+// The bug: several server-side email/reminder bodies rendered a ride's
+// scheduled time with a bare `new Date(x).toLocaleString()` (no fixed
+// locale/timezone). `toLocaleString()` uses the HOST process timezone, which is
+// UTC in the prod container, so volunteers/admins received UTC wall-clock times
+// instead of the org timezone (America/Chicago). The four sites were:
+//   - server/api/post/rides/[id]/signup.ts   (admin email body)
+//   - server/api/post/rides/[id]/unsignup.ts (volunteer + admin email bodies)
+//   - server/utils/scheduler.ts              (RIDE_REMINDER `time` field)
+//
+// The fix routes all four through the pinned helper `formatNotificationDateTime`
+// in server/utils/datetime.ts (America/Chicago, en-US), matching the #9
+// convention already used by signup.ts's RIDE_ASSIGNED notification.
+
+// ---------------------------------------------------------------------------
+// 1. Helper unit test (genuine, host-TZ-independent revert-check).
+//
+// `formatNotificationDateTime` does not exist pre-fix, so this file fails to
+// compile/import against the reverted tree (same shape as the #9 and #21
+// helper-absence checks). It asserts the output equals the CENTRAL wall clock
+// for a known UTC instant — a bare `.toLocaleString()` on a UTC host would emit
+// the UTC wall clock instead, which these assertions reject. Because the helper
+// pins `timeZone: 'America/Chicago'` in Intl.DateTimeFormat, the result is the
+// same on any host, so this is stable across CI/dev/prod timezones.
+// ---------------------------------------------------------------------------
+describe('R-197: formatNotificationDateTime pins the org timezone (#113)', () => {
+  it('R-197: renders a known winter (CST, UTC-6) instant in Central, not UTC', () => {
+    // 2026-02-16T15:00:00Z -> 09:00 in America/Chicago (CST). UTC wall clock is 3:00 PM.
+    const out = formatNotificationDateTime(new Date('2026-02-16T15:00:00Z'))
+    expect(out).toMatch(/February 16, 2026/)
+    expect(out).toMatch(/9:00/)
+    expect(out).toMatch(/AM/)
+    // Must NOT be the UTC wall clock (the pre-fix bare-toLocaleString behavior on
+    // a UTC host).
+    expect(out).not.toMatch(/3:00/)
+    expect(out).not.toMatch(/PM/)
+    // Explicitly host-independent: differs from a UTC-pinned render of the same
+    // instant.
+    const utcRender = new Date('2026-02-16T15:00:00Z').toLocaleString('en-US', {
+      timeZone: 'UTC',
+    })
+    expect(out).not.toBe(utcRender)
+  })
+
+  it('R-197: honors DST for a summer (CDT, UTC-5) instant', () => {
+    // 2026-07-15T18:00:00Z -> 13:00 in America/Chicago (CDT).
+    const out = formatNotificationDateTime(new Date('2026-07-15T18:00:00Z'))
+    expect(out).toMatch(/July 15, 2026/)
+    expect(out).toMatch(/1:00/)
+    expect(out).toMatch(/PM/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. Reminder-cron integration for the scheduler.ts site.
+//
+// The scheduler feeds its `time` field into sendNotification('RIDE_REMINDER'),
+// which renders the template body and hands it to sendEmail. Under TEST_HOOKS
+// sendEmail is a strict no-op with NO outbox/capture, so the rendered `time`
+// STRING is not observable from the harness (the same limitation applies to the
+// signup/unsignup email bodies). We therefore do NOT assert the emitted string
+// here; the genuine string-level revert-check for the helper is the unit test
+// above. What this integration proves is that the fixed call path on
+// scheduler.ts executes end-to-end on a genuinely-due reminder — i.e. the new
+// `formatNotificationDateTime(scheduledTime)` call is wired into the live cron
+// path and the reminder is claimed/processed without error.
+// ---------------------------------------------------------------------------
+const dbPath = (process.env.DATABASE_URL ?? '').replace(/^file:/, '')
+const suffix = randomUUID()
+const userId = `t113-user-${suffix}`
+const volunteerId = `t113-vol-${suffix}`
+const reminderId = `t113-rem-${suffix}`
+const rideId = `t113-ride-${suffix}`
+const reminderType = '120' // minutesBefore, also the SentReminder.type value
+
+function db() {
+  return new Database(dbPath)
+}
+
+beforeAll(() => {
+  const conn = db()
+  try {
+    const now = Date.now()
+    const iso = (ms: number) => new Date(ms).toISOString()
+
+    const clientId = (
+      conn
+        .prepare(
+          `SELECT c.id AS id FROM client c
+             JOIN user u ON u.id = c.userId
+            WHERE u.email = 'martha@example.com'`,
+        )
+        .get() as { id: string }
+    ).id
+
+    conn
+      .prepare(
+        `INSERT INTO user (id, name, email, emailVerified, role, createdAt, updatedAt)
+         VALUES (?, ?, ?, 1, 'VOLUNTEER', ?, ?)`,
+      )
+      .run(userId, 'Reminder TZ Vol', `tz-${suffix}@example.com`, iso(now), iso(now))
+
+    conn
+      .prepare(
+        `INSERT INTO volunteer (id, userId, status) VALUES (?, ?, 'AVAILABLE')`,
+      )
+      .run(volunteerId, userId)
+
+    // Due now: scheduledTime is +1h (future, so the scan includes it) but
+    // minutesBefore is 120, so the threshold = scheduledTime - 2h = ~1h ago.
+    conn
+      .prepare(
+        `INSERT INTO reminder (id, volunteerId, minutesBefore, type, createdAt, updatedAt)
+         VALUES (?, ?, ?, 'email', ?, ?)`,
+      )
+      .run(reminderId, volunteerId, Number(reminderType), iso(now), iso(now))
+
+    conn
+      .prepare(
+        `INSERT INTO ride (id, status, clientId, volunteerId, pickupDisplay, dropoffDisplay, scheduledTime, createdAt, updatedAt)
+         VALUES (?, 'ASSIGNED', ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        rideId,
+        clientId,
+        volunteerId,
+        'Pickup 113',
+        'Dropoff 113',
+        iso(now + 3600000),
+        iso(now),
+        iso(now),
+      )
+  } finally {
+    conn.close()
+  }
+})
+
+afterAll(() => {
+  const conn = db()
+  try {
+    conn.prepare(`DELETE FROM sent_reminder WHERE rideId = ?`).run(rideId)
+    conn.prepare(`DELETE FROM ride WHERE id = ?`).run(rideId)
+    conn.prepare(`DELETE FROM reminder WHERE id = ?`).run(reminderId)
+    conn.prepare(`DELETE FROM volunteer WHERE id = ?`).run(volunteerId)
+    conn.prepare(`DELETE FROM user WHERE id = ?`).run(userId)
+  } finally {
+    conn.close()
+  }
+})
+
+function sentRows(): number {
+  const conn = db()
+  try {
+    const row = conn
+      .prepare(`SELECT COUNT(*) AS n FROM sent_reminder WHERE rideId = ? AND type = ?`)
+      .get(rideId, reminderType) as { n: number }
+    return row.n
+  } finally {
+    conn.close()
+  }
+}
+
+describe('R-197: reminder cron renders through the pinned helper (#113)', () => {
+  it('R-197: a due RIDE_REMINDER is processed via the pinned datetime path', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+
+    expect(sentRows()).toBe(0)
+
+    const res = await appFetch('/api/_test/run-reminders', {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    // The scheduler's new formatNotificationDateTime() call is on this path;
+    // a green run proves it executes end-to-end without error.
+    expect(res.status).toBe(200)
+
+    // The reminder was claimed + processed (the claim precedes the send, so this
+    // holds even though the email itself is a no-op in the harness).
+    expect(sentRows()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Root cause

Several server-side email/reminder bodies rendered a ride's scheduled time with a bare `new Date(x).toLocaleString()` — no fixed locale or timezone. `toLocaleString()` formats in the **host process** timezone, which is **UTC in the prod container**, so volunteers and admins received UTC wall-clock times in their emails and reminders instead of the org's timezone. This is inconsistent with the #9 convention already used elsewhere in `signup.ts` (its `RIDE_ASSIGNED` notification uses `formatNotificationDate`/`formatNotificationTime`, pinned to `America/Chicago`).

## Fix

Added a single pinned helper `formatNotificationDateTime(date: Date)` to `server/utils/datetime.ts` (`America/Chicago`, `en-US`, combined date+time — mirrors the existing formatters' options) and routed all four sites through it:

- `server/api/post/rides/[id]/signup.ts:156` — admin notification email body
- `server/api/post/rides/[id]/unsignup.ts:125` — volunteer email body
- `server/api/post/rides/[id]/unsignup.ts:141` — admin email body
- `server/utils/scheduler.ts:100` — the `time:` field passed to `sendNotification('RIDE_REMINDER', …)`

Nothing else in those handlers changed. Net: +27 non-test lines.

## Pins

Added **R-197** to `REQUIREMENTS.md` (§10 Notifications & templates): "Server-rendered notification/email/reminder times use the pinned org timezone (`America/Chicago`) via `formatNotificationDateTime`, not the host TZ (UTC in prod)". Status `auto`, covered by `tests/e2e/notification-timezone.test.ts`.

## Verification — per site (mixed, stated honestly)

**Helper unit test (genuine revert-check).** `R-197: formatNotificationDateTime pins the org timezone` asserts a known winter instant `2026-02-16T15:00:00Z` renders as Central `February 16, 2026 … 9:00 AM` (not the UTC wall clock `3:00 PM`) and a summer instant `2026-07-15T18:00:00Z` as `1:00 PM` (DST). Because the helper pins `timeZone: 'America/Chicago'` in `Intl.DateTimeFormat`, the output is host-TZ-independent. The helper does not exist pre-fix, so the file fails to import against the reverted tree (same shape as the #9/#21 helper-absence checks) — this is the real string-level revert-check.

**Reminder-notification e2e (`scheduler.ts` site).** `R-197: a due RIDE_REMINDER is processed via the pinned datetime path` seeds a genuinely-due reminder and drives the gated `POST /api/_test/run-reminders` seam, asserting the run is green (200) and the `SentReminder` row is claimed — i.e. the new `formatNotificationDateTime(scheduledTime)` call is wired into the live cron path and executes end-to-end. **Caveat (honest):** the scheduler feeds `time` into `sendNotification('RIDE_REMINDER', …)`, which renders the template body and hands it to `sendEmail`, a **strict no-op with no outbox/capture under `TEST_HOOKS=1`**. So the *rendered `time` string* is not observable from the harness, and this test does not string-revert-check that specific site (reverting `scheduler.ts:100` to `.toLocaleString()` still produces a valid string + row). The string-level guarantee comes from the helper unit test above; I did **not** add a test-only email-capture seam (out of scope).

**Direct email bodies (`signup.ts:156`, `unsignup.ts:125`/`:141`).** These also funnel through the no-op `sendEmail`, so the email HTML body is not assertable in the harness. They are a **mechanical substitution** of the identical pinned helper on the same `new Date(ride.scheduledTime)` input, verified by inspection.

**Suite / trace / build:** `pnpm test` → 45 files, **199 tests, 0 failed**. `pnpm trace` → 121/121 covered ✔ (R-197 matched). `pnpm build` → succeeds.

## Risk files touched

None. `server/utils/datetime.ts` is a plain formatting util (not auth/schema/CI/docker/deps).

Fixes #113