### PR TITLE
Rides UX redesign — cosmetic pass (responsive list + detail)

### DIFF
--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -199,6 +199,112 @@
     }
   }
 
+  // Status → badge color, matching the rides list so the two pages agree.
+  type StatusColor = 'info' | 'warning' | 'success' | 'error' | 'neutral'
+  function statusColor(status: string): StatusColor {
+    const map: Record<string, StatusColor> = {
+      CREATED: 'info',
+      ASSIGNED: 'warning',
+      COMPLETED: 'success',
+      CANCELLED: 'error',
+    }
+    return map[status] || 'neutral'
+  }
+
+  // Role/status-gated actions defined once and rendered in two places: an inline
+  // cluster on desktop and a sticky bar on mobile. The conditions mirror the
+  // original per-button v-ifs exactly. `primary` marks the main CTA (filled and
+  // full-width on the mobile bar); by construction at most one is ever present.
+  type RideAction = {
+    key: string
+    label: string
+    icon: string
+    color: 'primary' | 'success' | 'warning' | 'error' | 'neutral'
+    variant?: 'subtle'
+    primary?: boolean
+    onClick: () => void
+  }
+
+  const actions = computed<RideAction[]>(() => {
+    const r = ride.value
+    if (!r) return []
+    const s = r.status
+    const list: RideAction[] = []
+
+    if (isVolunteer.value && !isAssignedToMe.value && s === 'CREATED') {
+      list.push({
+        key: 'signup',
+        label: 'Sign Up',
+        icon: 'i-lucide-user-plus',
+        color: 'primary',
+        primary: true,
+        onClick: () => handleVolunteerAction('signup'),
+      })
+    }
+    if (isVolunteer.value && isAssignedToMe.value && s === 'ASSIGNED') {
+      list.push({
+        key: 'complete',
+        label: 'Mark as Completed',
+        icon: 'i-lucide-check',
+        color: 'success',
+        primary: true,
+        onClick: () => handleVolunteerAction('complete'),
+      })
+      list.push({
+        key: 'unsignup',
+        label: 'Unsign Up',
+        icon: 'i-lucide-user-minus',
+        color: 'warning',
+        variant: 'subtle',
+        onClick: () => handleVolunteerAction('unsignup'),
+      })
+    }
+    if (isAdmin.value || (isVolunteer.value && isAssignedToMe.value && s === 'COMPLETED')) {
+      list.push({
+        key: 'edit',
+        label: 'Edit',
+        icon: 'i-lucide-edit',
+        color: 'neutral',
+        variant: 'subtle',
+        primary: true,
+        onClick: () => {
+          isEditModalOpen.value = true
+        },
+      })
+    }
+    if (isAdmin.value && s !== 'CANCELLED' && s !== 'COMPLETED') {
+      list.push({
+        key: 'cancel',
+        label: 'Cancel Ride',
+        icon: 'i-lucide-ban',
+        color: 'warning',
+        variant: 'subtle',
+        onClick: () => {
+          isCancelModalOpen.value = true
+        },
+      })
+    }
+    if (isAdmin.value) {
+      list.push({
+        key: 'delete',
+        label: 'Delete',
+        icon: 'i-lucide-trash',
+        color: 'error',
+        variant: 'subtle',
+        onClick: () => {
+          isDeleteModalOpen.value = true
+        },
+      })
+    }
+    return list
+  })
+
+  // Mobile bar: one filled primary + the rest as icon-only buttons.
+  const primaryAction = computed<RideAction | null>(
+    () => actions.value.find((a) => a.primary) ?? actions.value[0] ?? null
+  )
+  const secondaryActions = computed(() => actions.value.filter((a) => a !== primaryAction.value))
+
   const mapUrl = computed(() => {
     if (!ride.value) return ''
     const origin = encodeURIComponent(ride.value.pickupDisplay)
@@ -244,204 +350,205 @@
       <UButton to="/rides" label="Back to Rides" color="neutral" variant="ghost" />
     </div>
 
-    <div v-else class="grid grid-cols-1 gap-8 lg:grid-cols-3">
-      <!-- Left Column: Details -->
-      <div class="space-y-6 lg:col-span-1">
-        <UCard>
-          <template #header>
-            <div class="flex items-center justify-between">
-              <h2 class="text-xl font-bold">Ride Information</h2>
-              <UBadge
-                :color="
-                  ride.status === 'COMPLETED'
-                    ? 'success'
-                    : ride.status === 'CANCELLED'
-                      ? 'error'
-                      : 'info'
-                "
-                variant="subtle"
-              >
-                {{ ride.status }}
-              </UBadge>
-            </div>
-          </template>
-
-          <div class="space-y-4">
-            <div>
-              <p class="text-sm text-gray-500">Appointment Time</p>
-              <p class="font-medium">
-                {{ formatDateTime(ride.scheduledTime) }}
-              </p>
-            </div>
-
-            <div v-if="ride.pickupTime">
-              <p class="text-error text-sm text-gray-500">Pick Up Time</p>
-              <p class="text-error font-bold">
-                {{ formatDateTime(ride.pickupTime) }}
-              </p>
-            </div>
-
-            <div>
-              <p class="text-sm text-gray-500">Client</p>
-              <p class="font-medium">{{ ride.client?.user?.name }}</p>
-              <!-- Hide client email from volunteers if strictly needed, but let's keep it for contact -->
-              <p class="text-sm text-gray-500">{{ formatPhoneNumber(ride.client?.user?.phone) }}</p>
-            </div>
-
-            <div>
-              <p class="text-sm text-gray-500">Volunteer</p>
-              <p class="font-medium" v-if="ride.volunteer">
-                {{ ride.volunteer?.user?.name }}
-              </p>
-              <p class="text-gray-400 italic" v-else>No volunteer assigned</p>
-              <p class="text-sm text-gray-500">
-                {{ formatPhoneNumber(ride.volunteer?.user?.phone) }}
-              </p>
-            </div>
-
-            <div v-if="ride.status === 'COMPLETED' || ride.totalRideTime">
-              <p class="text-sm text-gray-500">Total Ride Time</p>
-              <p class="font-medium">{{ ride.totalRideTime || 0 }} hours</p>
-            </div>
-
-            <div v-if="ride.notes">
-              <p class="text-sm text-gray-500">Notes</p>
-              <p
-                class="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-200"
-              >
-                {{ ride.notes }}
-              </p>
-            </div>
-          </div>
-
-          <template #footer>
-            <div class="flex gap-2">
-              <UButton
-                v-if="isAdmin || (isVolunteer && isAssignedToMe && ride.status === 'COMPLETED')"
-                label="Edit"
-                icon="i-lucide-edit"
-                variant="subtle"
-                class="flex-1 justify-center"
-                @click="isEditModalOpen = true"
-              />
-              <UButton
-                v-if="isAdmin && ride.status !== 'CANCELLED' && ride.status !== 'COMPLETED'"
-                label="Cancel Ride"
-                icon="i-lucide-ban"
-                color="warning"
-                variant="subtle"
-                @click="isCancelModalOpen = true"
-              />
-              <UButton
-                v-if="isAdmin"
-                label="Delete"
-                icon="i-lucide-trash"
-                color="error"
-                variant="subtle"
-                @click="isDeleteModalOpen = true"
-              />
-              <UButton
-                v-if="isVolunteer && !isAssignedToMe && ride.status === 'CREATED'"
-                label="Sign Up"
-                icon="i-lucide-user-plus"
-                color="primary"
-                class="flex-1 justify-center"
-                @click="handleVolunteerAction('signup')"
-              />
-              <UButton
-                v-if="isVolunteer && isAssignedToMe && ride.status === 'ASSIGNED'"
-                label="Unsign Up"
-                icon="i-lucide-user-minus"
-                color="warning"
-                variant="subtle"
-                class="flex-1 justify-center"
-                @click="handleVolunteerAction('unsignup')"
-              />
-              <UButton
-                v-if="isVolunteer && isAssignedToMe && ride.status === 'ASSIGNED'"
-                label="Mark as Completed"
-                icon="i-lucide-check"
-                color="success"
-                class="flex-1 justify-center"
-                @click="handleVolunteerAction('complete')"
-              />
-            </div>
-          </template>
-        </UCard>
-      </div>
-
-      <!-- Right Column: Map and Route -->
-      <div class="space-y-6 lg:col-span-2">
-        <UCard>
-          <template #header>
-            <h2 class="text-xl font-bold">Route</h2>
-          </template>
-
-          <div class="space-y-4">
-            <div class="flex items-start gap-3">
-              <UIcon name="i-lucide-map-pin" class="text-primary mt-1 size-5" />
-              <div>
-                <p class="text-sm text-gray-500">Pickup</p>
-                <p class="font-medium">{{ ride.pickupDisplay }}</p>
-              </div>
-            </div>
-
-            <div class="flex items-start gap-3">
-              <UIcon name="i-lucide-flag" class="text-error mt-1 size-5" />
-              <div>
-                <p class="text-sm text-gray-500">Dropoff</p>
-                <p class="font-medium">{{ ride.dropoffDisplay }}</p>
-              </div>
-            </div>
-
-            <div
-              v-if="estimate && !estimate.error"
-              class="flex gap-6 rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50"
-            >
-              <div>
-                <p class="text-sm text-gray-500">Est. Duration</p>
-                <p class="font-medium">{{ estimate.duration }}</p>
-              </div>
-              <div>
-                <p class="text-sm text-gray-500">Distance</p>
-                <p class="font-medium">{{ estimate.distance }}</p>
-              </div>
-            </div>
-
+    <template v-else>
+      <!-- Identity header: who / when / status, with the desktop action cluster.
+           On mobile these actions move to a sticky bar pinned at the bottom. -->
+      <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+            {{ ride.client?.user?.name }}
+          </h1>
+          <p class="mt-1 text-sm text-gray-500">
+            {{
+              formatDateTime(ride.scheduledTime, {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              })
+            }}
+          </p>
+        </div>
+        <div class="flex items-center gap-3">
+          <UBadge :color="statusColor(ride.status)" variant="subtle" class="capitalize">
+            {{ ride.status }}
+          </UBadge>
+          <div class="hidden gap-2 lg:flex">
             <UButton
-              :to="navigateUrl"
-              target="_blank"
-              rel="noopener"
-              label="Navigate"
-              icon="i-lucide-navigation"
-              color="primary"
-              size="lg"
-              block
-              external
-              data-testid="navigate-link"
+              v-for="a in actions"
+              :key="a.key"
+              :label="a.label"
+              :icon="a.icon"
+              :color="a.color"
+              :variant="a.variant"
+              @click="a.onClick"
             />
+          </div>
+        </div>
+      </div>
 
-            <div class="aspect-video w-full overflow-hidden rounded-lg border">
-              <iframe
-                v-if="mapUrl && useRuntimeConfig().public.googleMapsApiKey"
-                width="100%"
-                height="100%"
-                frameborder="0"
-                style="border: 0"
-                :src="mapUrl"
-                allowfullscreen
-              ></iframe>
-              <div
-                v-else
-                class="flex h-full items-center justify-center bg-gray-100 text-gray-400 italic"
-              >
-                Map API Key missing or invalid address
+      <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <!-- Left Column: Details -->
+        <div class="space-y-6 lg:col-span-1">
+          <UCard>
+            <template #header>
+              <h2 class="text-xl font-bold">Ride Information</h2>
+            </template>
+
+            <div class="space-y-4">
+              <div>
+                <p class="text-sm text-gray-500">Appointment Time</p>
+                <p class="font-medium">
+                  {{ formatDateTime(ride.scheduledTime) }}
+                </p>
+              </div>
+
+              <div v-if="ride.pickupTime">
+                <p class="text-error text-sm text-gray-500">Pick Up Time</p>
+                <p class="text-error font-bold">
+                  {{ formatDateTime(ride.pickupTime) }}
+                </p>
+              </div>
+
+              <div>
+                <p class="text-sm text-gray-500">Client</p>
+                <p class="font-medium">{{ ride.client?.user?.name }}</p>
+                <!-- Hide client email from volunteers if strictly needed, but let's keep it for contact -->
+                <p class="text-sm text-gray-500">
+                  {{ formatPhoneNumber(ride.client?.user?.phone) }}
+                </p>
+              </div>
+
+              <div>
+                <p class="text-sm text-gray-500">Volunteer</p>
+                <p class="font-medium" v-if="ride.volunteer">
+                  {{ ride.volunteer?.user?.name }}
+                </p>
+                <p class="text-gray-400 italic" v-else>No volunteer assigned</p>
+                <p class="text-sm text-gray-500">
+                  {{ formatPhoneNumber(ride.volunteer?.user?.phone) }}
+                </p>
+              </div>
+
+              <div v-if="ride.status === 'COMPLETED' || ride.totalRideTime">
+                <p class="text-sm text-gray-500">Total Ride Time</p>
+                <p class="font-medium">{{ ride.totalRideTime || 0 }} hours</p>
+              </div>
+
+              <div v-if="ride.notes">
+                <p class="text-sm text-gray-500">Notes</p>
+                <p
+                  class="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-200"
+                >
+                  {{ ride.notes }}
+                </p>
               </div>
             </div>
-          </div>
-        </UCard>
+          </UCard>
+        </div>
+
+        <!-- Right Column: Map and Route -->
+        <div class="space-y-6 lg:col-span-2">
+          <UCard>
+            <template #header>
+              <h2 class="text-xl font-bold">Route</h2>
+            </template>
+
+            <div class="space-y-4">
+              <div class="flex items-start gap-3">
+                <UIcon name="i-lucide-map-pin" class="text-primary mt-1 size-5" />
+                <div>
+                  <p class="text-sm text-gray-500">Pickup</p>
+                  <p class="font-medium">{{ ride.pickupDisplay }}</p>
+                </div>
+              </div>
+
+              <div class="flex items-start gap-3">
+                <UIcon name="i-lucide-flag" class="text-error mt-1 size-5" />
+                <div>
+                  <p class="text-sm text-gray-500">Dropoff</p>
+                  <p class="font-medium">{{ ride.dropoffDisplay }}</p>
+                </div>
+              </div>
+
+              <div
+                v-if="estimate && !estimate.error"
+                class="flex gap-6 rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50"
+              >
+                <div>
+                  <p class="text-sm text-gray-500">Est. Duration</p>
+                  <p class="font-medium">{{ estimate.duration }}</p>
+                </div>
+                <div>
+                  <p class="text-sm text-gray-500">Distance</p>
+                  <p class="font-medium">{{ estimate.distance }}</p>
+                </div>
+              </div>
+
+              <UButton
+                :to="navigateUrl"
+                target="_blank"
+                rel="noopener"
+                label="Navigate"
+                icon="i-lucide-navigation"
+                color="primary"
+                size="lg"
+                block
+                external
+                data-testid="navigate-link"
+              />
+
+              <div class="aspect-video w-full overflow-hidden rounded-lg border">
+                <iframe
+                  v-if="mapUrl && useRuntimeConfig().public.googleMapsApiKey"
+                  width="100%"
+                  height="100%"
+                  frameborder="0"
+                  style="border: 0"
+                  :src="mapUrl"
+                  allowfullscreen
+                ></iframe>
+                <div
+                  v-else
+                  class="flex h-full items-center justify-center bg-gray-100 text-gray-400 italic"
+                >
+                  Map API Key missing or invalid address
+                </div>
+              </div>
+            </div>
+          </UCard>
+        </div>
       </div>
-    </div>
+
+      <!-- Mobile sticky action bar: one filled primary action (thumb-reachable)
+           plus any secondary actions as icon buttons. Hidden on lg+, where the
+           actions live inline in the header instead. -->
+      <div
+        v-if="primaryAction"
+        class="sticky bottom-4 z-10 mt-6 flex items-center gap-2 rounded-xl border border-gray-200 bg-white/90 p-2 shadow-lg backdrop-blur lg:hidden dark:border-gray-700 dark:bg-gray-900/90"
+      >
+        <UButton
+          v-for="a in secondaryActions"
+          :key="a.key"
+          :icon="a.icon"
+          :color="a.color"
+          :variant="a.variant || 'subtle'"
+          size="lg"
+          square
+          :aria-label="a.label"
+          @click="a.onClick"
+        />
+        <UButton
+          :label="primaryAction.label"
+          :icon="primaryAction.icon"
+          :color="primaryAction.color"
+          size="lg"
+          class="flex-1 justify-center"
+          @click="primaryAction.onClick"
+        />
+      </div>
+    </template>
 
     <!-- Edit Modal -->
     <UModal v-model:open="isEditModalOpen" title="Edit Ride">

--- a/app/pages/rides/[id].vue
+++ b/app/pages/rides/[id].vue
@@ -521,12 +521,16 @@
         </div>
       </div>
 
-      <!-- Mobile sticky action bar: one filled primary action (thumb-reachable)
+      <!-- Spacer so page content isn't hidden behind the fixed mobile bar. -->
+      <div v-if="primaryAction" aria-hidden="true" class="h-24 lg:hidden"></div>
+
+      <!-- Mobile action bar: docked flush to the bottom edge — full width, only
+           the top corners rounded. One filled primary action (thumb-reachable)
            plus any secondary actions as icon buttons. Hidden on lg+, where the
            actions live inline in the header instead. -->
       <div
         v-if="primaryAction"
-        class="sticky bottom-4 z-10 mt-6 flex items-center gap-2 rounded-xl border border-gray-200 bg-white/90 p-2 shadow-lg backdrop-blur lg:hidden dark:border-gray-700 dark:bg-gray-900/90"
+        class="fixed inset-x-0 bottom-0 z-20 flex items-center gap-2 rounded-t-xl border-t border-gray-200 bg-white/95 px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] shadow-[0_-4px_16px_rgba(0,0,0,0.08)] backdrop-blur lg:hidden dark:border-gray-700 dark:bg-gray-900/95"
       >
         <UButton
           v-for="a in secondaryActions"

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -10,6 +10,7 @@
   } from '../../utils/rideFilters'
 
   const UBadge = resolveComponent('UBadge')
+  const UIcon = resolveComponent('UIcon')
 
   const { data: session } = await authClient.useSession(useFetch)
   const isAdmin = computed(() => session.value?.user?.role === 'ADMIN')
@@ -272,6 +273,17 @@
     return map[status] || 'neutral'
   }
 
+  // Initials for the volunteer avatar chip (first + last word), shared shape
+  // with the mobile cards' status treatment.
+  function initials(name?: string | null): string {
+    if (!name) return '?'
+    const parts = name.trim().split(/\s+/).filter(Boolean)
+    if (!parts.length) return '?'
+    const first = parts[0][0] ?? ''
+    const last = parts.length > 1 ? parts[parts.length - 1][0] : ''
+    return (first + last).toUpperCase() || '?'
+  }
+
   const columns: TableColumn<any>[] = [
     {
       accessorKey: 'status',
@@ -288,40 +300,87 @@
         ),
     },
     {
-      id: 'volunteer',
-      header: 'Volunteer',
+      id: 'client',
+      header: 'Client',
       cell: ({ row }) => {
-        return (
-          row.original.volunteer?.user?.name ||
-          h('span', { class: 'text-gray-400 italic' }, 'Unassigned')
-        )
+        const phone = formatPhoneNumber(row.original.client?.user?.phone)
+        return h('div', { class: 'leading-tight' }, [
+          h(
+            'div',
+            { class: 'font-medium text-gray-900 dark:text-white' },
+            row.original.client?.user?.name
+          ),
+          phone ? h('div', { class: 'text-xs text-gray-500' }, phone) : null,
+        ])
+      },
+    },
+    {
+      id: 'route',
+      header: 'Route',
+      // Pickup and dropoff collapse into one cell so origin -> destination reads
+      // at a glance instead of two separate, truncated address columns.
+      cell: ({ row }) => {
+        const leg = (icon: string, iconClass: string, text: string) =>
+          h('div', { class: 'flex items-center gap-2' }, [
+            h(UIcon, { name: icon, class: `${iconClass} size-3.5 shrink-0` }),
+            h(
+              'span',
+              { class: 'max-w-[240px] truncate text-gray-600 dark:text-gray-300', title: text },
+              text
+            ),
+          ])
+        return h('div', { class: 'flex flex-col gap-1 text-sm' }, [
+          leg('i-lucide-map-pin', 'text-primary', row.original.pickupDisplay),
+          leg('i-lucide-flag', 'text-error', row.original.dropoffDisplay),
+        ])
       },
     },
     {
       accessorKey: 'scheduledTime',
-      header: 'Date',
+      header: 'When',
       cell: ({ row }) => {
         // Pinned locale + timezone so SSR and client agree (issue #98).
-        return formatDateTime(row.getValue('scheduledTime'), {
-          day: 'numeric',
-          month: 'short',
-          year: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit',
-        })
+        const t = row.getValue('scheduledTime') as string
+        return h('div', { class: 'leading-tight' }, [
+          h(
+            'div',
+            { class: 'font-medium text-gray-900 dark:text-white' },
+            formatDateTime(t, { weekday: 'short', month: 'short', day: 'numeric' })
+          ),
+          h(
+            'div',
+            { class: 'text-xs text-gray-500' },
+            formatDateTime(t, { hour: '2-digit', minute: '2-digit' })
+          ),
+        ])
       },
     },
     {
-      accessorKey: 'client.user.name',
-      header: 'Client',
+      id: 'volunteer',
+      header: 'Volunteer',
+      cell: ({ row }) => {
+        const name = row.original.volunteer?.user?.name
+        if (!name) return h('span', { class: 'text-sm text-gray-400 italic' }, 'Unassigned')
+        return h('div', { class: 'flex items-center gap-2' }, [
+          h(
+            'span',
+            {
+              class:
+                'flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+            },
+            initials(name)
+          ),
+          h('span', { class: 'text-sm' }, name),
+        ])
+      },
     },
     {
-      accessorKey: 'pickupDisplay',
-      header: 'Pickup',
-    },
-    {
-      accessorKey: 'dropoffDisplay',
-      header: 'Dropoff',
+      id: 'chevron',
+      header: '',
+      cell: () =>
+        h('div', { class: 'flex justify-end' }, [
+          h(UIcon, { name: 'i-lucide-chevron-right', class: 'size-4 text-gray-400' }),
+        ]),
     },
   ]
 

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -557,8 +557,13 @@
           >
             <span
               v-if="ride.volunteer?.user?.name"
-              class="text-sm text-gray-600 dark:text-gray-300"
+              class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
             >
+              <span
+                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+              >
+                {{ initials(ride.volunteer.user.name) }}
+              </span>
               {{ ride.volunteer.user.name }}
             </span>
             <span v-else class="text-sm text-gray-400 italic">Unassigned</span>

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -259,23 +259,33 @@
   // (issue #13) so they compose with pagination. The table binds directly to
   // the returned page (`rides`) — no client-side filtering pass.
 
+  // Status → badge color, shared by the desktop table and the mobile cards so
+  // the two breakpoints can never drift apart.
+  type StatusColor = 'info' | 'warning' | 'success' | 'error' | 'neutral'
+  function statusColor(status: string): StatusColor {
+    const map: Record<string, StatusColor> = {
+      CREATED: 'info',
+      ASSIGNED: 'warning',
+      COMPLETED: 'success',
+      CANCELLED: 'error',
+    }
+    return map[status] || 'neutral'
+  }
+
   const columns: TableColumn<any>[] = [
     {
       accessorKey: 'status',
       header: 'Status',
-      cell: ({ row }) => {
-        const color =
+      cell: ({ row }) =>
+        h(
+          UBadge,
           {
-            CREATED: 'info' as const,
-            ASSIGNED: 'warning' as const,
-            COMPLETED: 'success' as const,
-            CANCELLED: 'error' as const,
-          }[row.getValue('status') as string] || 'neutral'
-
-        return h(UBadge, { class: 'capitalize', variant: 'subtle', color }, () =>
-          row.getValue('status')
-        )
-      },
+            class: 'capitalize',
+            variant: 'subtle',
+            color: statusColor(row.getValue('status') as string),
+          },
+          () => row.getValue('status')
+        ),
     },
     {
       id: 'volunteer',
@@ -416,13 +426,88 @@
       </div>
     </div>
 
+    <!-- Desktop (lg+): the full table. Below lg it would overflow sideways, so
+         it's hidden in favour of the ride cards below. -->
     <UTable
       :data="rides"
       :columns="columns"
       :loading="status === 'pending'"
-      class="w-full cursor-pointer"
+      class="hidden w-full cursor-pointer lg:block"
       @select="onSelect"
     />
+
+    <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
+         same navigation target — only the presentation differs. -->
+    <div class="lg:hidden">
+      <div v-if="status === 'pending'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <USkeleton v-for="n in 4" :key="n" class="h-44 w-full rounded-xl" />
+      </div>
+
+      <div
+        v-else-if="rides.length === 0"
+        class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200 py-16 text-center text-gray-500 dark:border-gray-700"
+      >
+        <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
+        <p class="font-medium">No rides found</p>
+        <p class="text-sm">Try adjusting your search or filters</p>
+      </div>
+
+      <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <NuxtLink
+          v-for="ride in rides"
+          :key="ride.id"
+          :to="`/rides/${ride.id}`"
+          class="focus-visible:ring-primary block rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 focus:outline-none focus-visible:ring-2 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
+        >
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <UBadge :color="statusColor(ride.status)" variant="subtle" class="capitalize">
+              {{ ride.status }}
+            </UBadge>
+            <span class="text-xs font-medium text-gray-500">
+              {{
+                formatDateTime(ride.scheduledTime, {
+                  weekday: 'short',
+                  month: 'short',
+                  day: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })
+              }}
+            </span>
+          </div>
+
+          <p class="font-semibold text-gray-900 dark:text-white">
+            {{ ride.client?.user?.name }}
+          </p>
+
+          <div class="mt-3 space-y-1.5">
+            <div class="flex items-start gap-2">
+              <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
+              <span class="text-sm text-gray-600 dark:text-gray-300">{{ ride.pickupDisplay }}</span>
+            </div>
+            <div class="flex items-start gap-2">
+              <UIcon name="i-lucide-flag" class="text-error mt-0.5 size-4 shrink-0" />
+              <span class="text-sm text-gray-600 dark:text-gray-300">{{
+                ride.dropoffDisplay
+              }}</span>
+            </div>
+          </div>
+
+          <div
+            class="mt-3 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-800"
+          >
+            <span
+              v-if="ride.volunteer?.user?.name"
+              class="text-sm text-gray-600 dark:text-gray-300"
+            >
+              {{ ride.volunteer.user.name }}
+            </span>
+            <span v-else class="text-sm text-gray-400 italic">Unassigned</span>
+            <UIcon name="i-lucide-chevron-right" class="size-4 text-gray-400" />
+          </div>
+        </NuxtLink>
+      </div>
+    </div>
 
     <div v-if="total > PAGE_SIZE" class="mt-4 flex justify-end">
       <UPagination

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -435,7 +435,13 @@
 
 <template>
   <UContainer class="py-10">
-    <div class="mb-6 flex items-center justify-end">
+    <!-- Page header: title + live result count, with Create Ride inline (was a
+         lone right-aligned button on its own row). -->
+    <div class="mb-6 flex items-end justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Rides</h1>
+        <p class="mt-1 text-sm text-gray-500">{{ total }} {{ total === 1 ? 'ride' : 'rides' }}</p>
+      </div>
       <UButton
         v-if="isAdmin"
         label="Create Ride"
@@ -445,43 +451,48 @@
       />
     </div>
 
-    <div class="mb-6 flex flex-wrap items-center gap-3">
+    <!-- Toolbar: search keeps the full row width; the filter controls group and
+         wrap together beside it on wide screens instead of each stacking into a
+         tall full-width column. -->
+    <div class="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center">
       <UInput
         v-model="search"
         icon="i-lucide-search"
-        placeholder="Search..."
-        class="w-full min-w-[200px] flex-1 sm:w-auto"
+        placeholder="Search rides..."
+        class="w-full lg:max-w-xs lg:flex-1"
       />
-      <USelect
-        v-model="sort"
-        :items="[
-          { label: 'Oldest First', value: 'asc' },
-          { label: 'Newest First', value: 'desc' },
-        ]"
-        class="w-36"
-      />
-      <USelectMenu
-        v-model="activeFilters"
-        :items="filterOptions"
-        multiple
-        :searchable="false"
-        :ui="{ input: 'hidden' }"
-        placeholder="Include Status"
-        class="w-full sm:w-64"
-      />
-      <USelectMenu
-        v-model="excludedFilters"
-        :items="filterOptions"
-        multiple
-        :searchable="false"
-        :ui="{ input: 'hidden' }"
-        placeholder="Exclude Status"
-        class="w-full sm:w-64"
-      />
-      <div class="flex items-center gap-2">
-        <UInput v-model="startDate" type="date" placeholder="Start" class="w-full sm:w-auto" />
-        <span class="text-gray-400">-</span>
-        <UInput v-model="endDate" type="date" placeholder="End" class="w-full sm:w-auto" />
+      <div class="flex flex-wrap items-center gap-3">
+        <USelect
+          v-model="sort"
+          :items="[
+            { label: 'Oldest First', value: 'asc' },
+            { label: 'Newest First', value: 'desc' },
+          ]"
+          class="w-full sm:w-40"
+        />
+        <USelectMenu
+          v-model="activeFilters"
+          :items="filterOptions"
+          multiple
+          :searchable="false"
+          :ui="{ input: 'hidden' }"
+          placeholder="Include status"
+          class="w-full sm:w-52"
+        />
+        <USelectMenu
+          v-model="excludedFilters"
+          :items="filterOptions"
+          multiple
+          :searchable="false"
+          :ui="{ input: 'hidden' }"
+          placeholder="Exclude status"
+          class="w-full sm:w-52"
+        />
+        <div class="flex flex-1 items-center gap-2">
+          <UInput v-model="startDate" type="date" class="w-full sm:w-auto" />
+          <span class="text-gray-400">–</span>
+          <UInput v-model="endDate" type="date" class="w-full sm:w-auto" />
+        </div>
       </div>
     </div>
 
@@ -493,7 +504,15 @@
       :loading="status === 'pending'"
       class="hidden w-full cursor-pointer lg:block"
       @select="onSelect"
-    />
+    >
+      <template #empty-state>
+        <div class="flex flex-col items-center justify-center py-12 text-center text-gray-500">
+          <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
+          <p class="font-medium">No rides found</p>
+          <p class="text-sm">Try adjusting your search or filters</p>
+        </div>
+      </template>
+    </UTable>
 
     <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
          same navigation target — only the presentation differs. -->


### PR DESCRIPTION
Phase A of the rides UX redesign: **cosmetic only** — no data model, cookie, API or schema changes. Rebuilds how the two rides screens render across mobile and desktop, keeping the existing Nuxt UI look (green primary, cards, badges).

### Rides list (`app/pages/rides/index.vue`)
- **Responsive rows:** below `lg`, each ride renders as a tap-friendly card (status + time, client, pickup→dropoff, volunteer); the desktop table stays at `lg`+. Cards stack 1-up on phones, 2-up on tablets.
- **Desktop table redesign:** Pickup + Dropoff collapse into one **Route** cell (green pin → red flag, truncation tooltips); Client gains a phone subline; **When** renders date-over-time; Volunteer gets an initials-avatar chip; trailing chevron.
- **Header + toolbar:** page heading with a live result count, Create Ride inline; toolbar regrouped so it stops stacking into a full-width wall on mobile; desktop table gets a proper empty state.

### Ride detail (`app/pages/rides/[id].vue`)
- **Identity header** (client name, full date, status badge) above the two-column grid.
- **Responsive actions:** the role/status-gated actions are defined once and rendered as an inline cluster on desktop and a **bottom-docked action bar** on mobile (primary action filled and thumb-reachable, secondary as icon buttons). Conditions mirror the previous per-button `v-if`s exactly.

### Verification
Rendered locally against the seeded DB; exercised admin and volunteer (sign-up / complete) flows. No behavioural changes — presentation only.

Targets `stage` for staging review. Follow-up (phase B) will introduce the DB-backed filter preference + single status toggle.