### PR TITLE
Rides: DB-backed filter preference + single status toggle

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,3 +1,39 @@
-@import "tailwindcss";
-@import "@nuxt/ui";
+@import 'tailwindcss';
+@import '@nuxt/ui';
 
+/* --- Scrollbar ---
+   The platform default is a chunky, high-contrast track that reads as visual
+   noise over the dark UI. Desktop gets a slim, subtle bar; mobile hides it
+   entirely (touch / overlay scrolling still works) for a cleaner app feel.
+   Breakpoint matches the app's `lg` table<->cards switch (1024px). */
+@media (min-width: 1024px) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(120, 128, 145, 0.4) transparent;
+  }
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: rgba(120, 128, 145, 0.4);
+    border-radius: 9999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(120, 128, 145, 0.6);
+  }
+}
+
+@media (max-width: 1023.98px) {
+  * {
+    scrollbar-width: none;
+  }
+  ::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
+  }
+}

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -134,10 +134,39 @@
       : [...selectedStatuses.value, value]
   }
 
+  // Live "today" key (YYYY-MM-DD in the app timezone) used to mark a date-range
+  // endpoint that falls on today. Kept reactive so the "(today)" marker appears
+  // and — crucially — disappears when the day rolls over while the page is left
+  // open. It's a client clock concern, so no server round-trip is needed; empty
+  // on the server so nothing stale renders during SSR.
+  const todayKey = ref('')
+  function currentDayKey() {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: APP_TIME_ZONE,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date())
+  }
+  let dayTimer: ReturnType<typeof setInterval> | undefined
+  onMounted(() => {
+    todayKey.value = currentDayKey()
+    // Re-check each minute; that's imperceptibly close to the midnight edge and
+    // far cheaper than any push mechanism for a once-a-day change.
+    dayTimer = setInterval(() => {
+      const key = currentDayKey()
+      if (key !== todayKey.value) todayKey.value = key
+    }, 60_000)
+  })
+  onUnmounted(() => {
+    if (dayTimer) clearInterval(dayTimer)
+  })
+
   // Human-readable summary of the (transient, unsaved) date-range filter, shown
   // on the popover trigger — "All dates" when unset. Formats the YYYY-MM-DD as a
-  // local date so the app timezone can't shift it a day; only renders after a
-  // client-side pick, so there's no SSR/hydration concern.
+  // local date so the app timezone can't shift it a day, and marks an endpoint
+  // that is today with "(today)". Only renders after a client-side pick, so
+  // there's no SSR/hydration concern.
   const dateRangeLabel = computed(() => {
     const fmt = (s: string) => {
       const [y, m, d] = s.split('-').map(Number)
@@ -147,9 +176,11 @@
         year: 'numeric',
       })
     }
-    if (startDate.value && endDate.value) return `${fmt(startDate.value)} – ${fmt(endDate.value)}`
-    if (startDate.value) return `From ${fmt(startDate.value)}`
-    if (endDate.value) return `Until ${fmt(endDate.value)}`
+    const withToday = (s: string) => `${fmt(s)}${s === todayKey.value ? ' (today)' : ''}`
+    if (startDate.value && endDate.value)
+      return `${withToday(startDate.value)} – ${withToday(endDate.value)}`
+    if (startDate.value) return `From ${withToday(startDate.value)}`
+    if (endDate.value) return `Until ${withToday(endDate.value)}`
     return 'All dates'
   })
 

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -536,15 +536,13 @@
             :class="{ 'text-primary font-medium': startDate || endDate }"
           />
           <template #content>
-            <div class="w-72 space-y-3 p-3">
-              <div class="flex items-end gap-2">
-                <UFormField label="From" class="flex-1">
-                  <UInput v-model="startDate" type="date" class="w-full" />
-                </UFormField>
-                <UFormField label="To" class="flex-1">
-                  <UInput v-model="endDate" type="date" class="w-full" />
-                </UFormField>
-              </div>
+            <div class="w-72 max-w-[calc(100vw-2rem)] space-y-3 p-3">
+              <UFormField label="From">
+                <UInput v-model="startDate" type="date" class="w-full" />
+              </UFormField>
+              <UFormField label="To">
+                <UInput v-model="endDate" type="date" class="w-full" />
+              </UFormField>
               <div class="flex justify-end">
                 <UButton
                   label="Clear"

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -4,9 +4,12 @@
   import * as z from 'zod'
   import { authClient } from '../../utils/auth-client'
   import {
-    BASE_FILTER_OPTIONS,
-    DEFAULT_EXCLUDED_FILTERS,
-    sanitizeSavedFilters,
+    RIDE_STATUS_OPTIONS,
+    DEFAULT_RIDE_STATUSES,
+    sanitizeStatuses,
+    buildRidesInclude,
+    legacyCookieToStatuses,
+    type RideStatus,
   } from '../../utils/rideFilters'
 
   const UBadge = resolveComponent('UBadge')
@@ -22,18 +25,26 @@
   const { data: volunteers } = await useFetch('/api/get/volunteers/options')
 
   const search = ref('')
-  const savedSort = useCookie<string>('ride-sort', { default: () => 'desc' })
-  const sort = ref(savedSort.value)
 
-  watch(sort, (newVal) => {
-    savedSort.value = newVal
-  })
+  // --- Cross-device preferences (DB-backed filter preference) ---
+  // The list filter/sort used to live in browser cookies. It now lives per-user
+  // in the DB (GET/PUT /api/*/preferences) so the same view follows the user
+  // across devices. Seed the controls from the saved preference, falling back to
+  // sensible defaults when the user has never saved one.
+  const { data: prefs } = await useFetch('/api/get/preferences')
+
+  const selectedStatuses = ref<string[]>(
+    prefs.value?.rideStatusFilter != null
+      ? sanitizeStatuses(prefs.value.rideStatusFilter)
+      : [...DEFAULT_RIDE_STATUSES]
+  )
+  const sort = ref<string>(prefs.value?.rideSort ?? 'desc')
+  const assignedToMe = ref<boolean>(prefs.value?.rideAssignedToMeOnly ?? false)
 
   // --- Server-side pagination (issue #13) ---
-  // The rides list used to load the entire table and filter it client-side.
-  // Filtering, sorting and pagination now all happen on the server, so the
-  // table binds directly to the returned page. Debounce search so typing
-  // doesn't fire a request per keystroke.
+  // Filtering, sorting and pagination all happen on the server so the table
+  // binds directly to the returned page. Debounce search so typing doesn't fire
+  // a request per keystroke.
   const PAGE_SIZE = 20
   const page = ref(1)
   const debouncedSearch = ref('')
@@ -44,38 +55,11 @@
   const startDate = ref('')
   const endDate = ref('')
 
-  // Persisted State
-  const savedActiveFilters = useCookie<{ label: string; value: string }[]>('ride-active-filters', {
-    default: () => [],
-  })
-  const savedExcludedFilters = useCookie<{ label: string; value: string }[]>(
-    'ride-excluded-filters',
-    {
-      default: () => [...DEFAULT_EXCLUDED_FILTERS], // Default exclude (see issue #22)
-    }
-  )
-
-  // All values the UI can actually toggle. Includes `assign:ME` because it is a
-  // valid (volunteer-only) filter; base status options are always valid. Any
-  // saved value outside this set (e.g. the stale `status:CANCELLED`) is stripped
-  // on load so existing users aren't stuck with an un-toggleable filter (#22).
-  const knownFilterValues = [...BASE_FILTER_OPTIONS.map((o) => o.value), 'assign:ME']
-
-  const activeFilters = ref<{ label: string; value: string }[]>(
-    sanitizeSavedFilters(savedActiveFilters.value, knownFilterValues)
-  )
-  const excludedFilters = ref<{ label: string; value: string }[]>(
-    sanitizeSavedFilters(savedExcludedFilters.value, knownFilterValues)
-  )
-
-  // Include/exclude filter chips are sent to the backend as comma-separated
-  // values (e.g. "status:CREATED,assign:ME"); the server applies them so they
-  // compose with pagination instead of only filtering the current page (#13).
+  // Selected statuses (+ the volunteer-only "assigned to me" toggle) become the
+  // server `include` param so filtering composes with pagination (#13). There is
+  // no exclude param now — an empty selection means "all statuses".
   const includeParam = computed(() =>
-    activeFilters.value.map((f) => f.value).join(',')
-  )
-  const excludeParam = computed(() =>
-    excludedFilters.value.map((f) => f.value).join(',')
+    buildRidesInclude(selectedStatuses.value as RideStatus[], !isAdmin.value && assignedToMe.value)
   )
 
   // useFetch watches these reactive query refs and refetches automatically, so
@@ -92,8 +76,7 @@
       search: computed(() => debouncedSearch.value || undefined),
       startDate: computed(() => startDate.value || undefined),
       endDate: computed(() => endDate.value || undefined),
-      include: computed(() => includeParam.value || undefined),
-      exclude: computed(() => excludeParam.value || undefined),
+      include: includeParam,
     },
   })
 
@@ -102,35 +85,78 @@
 
   // Any filter/search/sort change should return to the first page so results
   // aren't hidden on a page that no longer exists.
-  watch([debouncedSearch, startDate, endDate, includeParam, excludeParam, sort], () => {
+  watch([debouncedSearch, startDate, endDate, includeParam, sort], () => {
     page.value = 1
   })
 
-  // Sync state back to cookies
-  watch(
-    activeFilters,
-    (newVal) => {
-      savedActiveFilters.value = newVal
-    },
-    { deep: true }
-  )
-  watch(
-    excludedFilters,
-    (newVal) => {
-      savedExcludedFilters.value = newVal
-    },
-    { deep: true }
-  )
+  // Persist filter/sort changes to the DB, debounced so a burst of toggles
+  // collapses into one write. The watch never fires on the initial seed — only
+  // on a real user change.
+  const savePreferences = debounce(() => {
+    $fetch('/api/put/preferences', {
+      method: 'PUT',
+      body: {
+        rideStatusFilter: sanitizeStatuses(selectedStatuses.value),
+        rideSort: sort.value,
+        rideAssignedToMeOnly: !isAdmin.value && assignedToMe.value,
+      },
+    }).catch((err) => console.error('Failed to save preferences', err))
+  }, 400)
+  watch([selectedStatuses, sort, assignedToMe], () => savePreferences(), { deep: true })
+
+  // One-time migration off the old cookie model: if the user has no saved DB
+  // preference yet but a legacy cookie exists, convert it, persist once, and
+  // clear the cookies so the DB becomes the single source of truth.
+  const legacyActive = useCookie<unknown>('ride-active-filters')
+  const legacyExcluded = useCookie<unknown>('ride-excluded-filters')
+  const legacySort = useCookie<string | null>('ride-sort')
+  onMounted(() => {
+    const prefUnset =
+      !prefs.value ||
+      (prefs.value.rideStatusFilter == null &&
+        prefs.value.rideSort == null &&
+        !prefs.value.rideAssignedToMeOnly)
+    const hasLegacy = !!(legacyActive.value || legacyExcluded.value || legacySort.value)
+    if (!prefUnset || !hasLegacy) return
+    selectedStatuses.value = legacyCookieToStatuses(legacyActive.value, legacyExcluded.value)
+    if (legacySort.value === 'asc' || legacySort.value === 'desc') sort.value = legacySort.value
+    savePreferences()
+    legacyActive.value = null
+    legacyExcluded.value = null
+    legacySort.value = null
+  })
 
   const isCreateModalOpen = ref(false)
 
-  const filterOptions = computed(() => {
-    const options = [...BASE_FILTER_OPTIONS]
-    if (!isAdmin.value) {
-      options.push({ label: 'Assigned to Me', value: 'assign:ME' })
+  function toggleStatus(value: string) {
+    selectedStatuses.value = selectedStatuses.value.includes(value)
+      ? selectedStatuses.value.filter((s) => s !== value)
+      : [...selectedStatuses.value, value]
+  }
+
+  // Human-readable summary of the (transient, unsaved) date-range filter, shown
+  // on the popover trigger — "All dates" when unset. Formats the YYYY-MM-DD as a
+  // local date so the app timezone can't shift it a day; only renders after a
+  // client-side pick, so there's no SSR/hydration concern.
+  const dateRangeLabel = computed(() => {
+    const fmt = (s: string) => {
+      const [y, m, d] = s.split('-').map(Number)
+      return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
     }
-    return options
+    if (startDate.value && endDate.value) return `${fmt(startDate.value)} – ${fmt(endDate.value)}`
+    if (startDate.value) return `From ${fmt(startDate.value)}`
+    if (endDate.value) return `Until ${fmt(endDate.value)}`
+    return 'All dates'
   })
+
+  function clearDateRange() {
+    startDate.value = ''
+    endDate.value = ''
+  }
 
   // --- Schema ---
   const addressSchema = z.object({
@@ -461,38 +487,77 @@
         placeholder="Search rides..."
         class="w-full lg:max-w-xs lg:flex-1"
       />
-      <div class="flex flex-wrap items-center gap-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <!-- Status filter: toggle which statuses to show. Selecting none shows
+             all. The active chip takes its status' badge colour. -->
+        <div class="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by status">
+          <UButton
+            v-for="opt in RIDE_STATUS_OPTIONS"
+            :key="opt.value"
+            :label="opt.label"
+            size="sm"
+            :color="selectedStatuses.includes(opt.value) ? statusColor(opt.value) : 'neutral'"
+            :variant="selectedStatuses.includes(opt.value) ? 'subtle' : 'ghost'"
+            :aria-pressed="selectedStatuses.includes(opt.value)"
+            @click="toggleStatus(opt.value)"
+          />
+          <UButton
+            v-if="!isAdmin"
+            label="Assigned to me"
+            icon="i-lucide-user-check"
+            size="sm"
+            :color="assignedToMe ? 'primary' : 'neutral'"
+            :variant="assignedToMe ? 'subtle' : 'ghost'"
+            :aria-pressed="assignedToMe"
+            @click="assignedToMe = !assignedToMe"
+          />
+        </div>
+
         <USelect
           v-model="sort"
+          size="sm"
           :items="[
             { label: 'Oldest First', value: 'asc' },
             { label: 'Newest First', value: 'desc' },
           ]"
           class="w-full sm:w-40"
         />
-        <USelectMenu
-          v-model="activeFilters"
-          :items="filterOptions"
-          multiple
-          :searchable="false"
-          :ui="{ input: 'hidden' }"
-          placeholder="Include status"
-          class="w-full sm:w-52"
-        />
-        <USelectMenu
-          v-model="excludedFilters"
-          :items="filterOptions"
-          multiple
-          :searchable="false"
-          :ui="{ input: 'hidden' }"
-          placeholder="Exclude status"
-          class="w-full sm:w-52"
-        />
-        <div class="flex flex-1 items-center gap-2">
-          <UInput v-model="startDate" type="date" class="w-full sm:w-auto" />
-          <span class="text-gray-400">–</span>
-          <UInput v-model="endDate" type="date" class="w-full sm:w-auto" />
-        </div>
+
+        <!-- Date range: one control reading "All dates" when unset; opens the
+             From/To pickers in a popover. This filter is transient (per-visit),
+             not persisted like status/sort. -->
+        <UPopover>
+          <UButton
+            icon="i-lucide-calendar"
+            :label="dateRangeLabel"
+            size="sm"
+            color="neutral"
+            variant="outline"
+            :class="{ 'text-primary font-medium': startDate || endDate }"
+          />
+          <template #content>
+            <div class="w-72 space-y-3 p-3">
+              <div class="flex items-end gap-2">
+                <UFormField label="From" class="flex-1">
+                  <UInput v-model="startDate" type="date" class="w-full" />
+                </UFormField>
+                <UFormField label="To" class="flex-1">
+                  <UInput v-model="endDate" type="date" class="w-full" />
+                </UFormField>
+              </div>
+              <div class="flex justify-end">
+                <UButton
+                  label="Clear"
+                  size="sm"
+                  color="neutral"
+                  variant="ghost"
+                  :disabled="!startDate && !endDate"
+                  @click="clearDateRange"
+                />
+              </div>
+            </div>
+          </template>
+        </UPopover>
       </div>
     </div>
 
@@ -593,11 +658,7 @@
     </div>
 
     <div v-if="total > PAGE_SIZE" class="mt-4 flex justify-end">
-      <UPagination
-        v-model:page="page"
-        :total="total"
-        :items-per-page="PAGE_SIZE"
-      />
+      <UPagination v-model:page="page" :total="total" :items-per-page="PAGE_SIZE" />
     </div>
 
     <!-- Create Ride Modal -->

--- a/app/utils/rideFilters.ts
+++ b/app/utils/rideFilters.ts
@@ -1,48 +1,70 @@
-// Pure, testable logic for the Rides dashboard status filters (issue #22).
+// Pure, testable logic for the Rides list status filter.
 //
-// Background: the "Exclude Status" dropdown used to default to excluding a
-// `status:CANCELLED` filter, but CANCELLED is not a real RideStatus and is not
-// among the toggleable `filterOptions`. That left the filter active in the
-// dropdown header with no checkbox to turn it off — an un-toggleable, stuck
-// filter. These helpers keep the persisted cookie state in sync with the set of
-// filter values the UI can actually toggle.
+// The list used to carry two filters — an "include" set and an "exclude" set —
+// persisted as browser cookies. That's now a single "which statuses to show"
+// selection, persisted per-user in the DB (see /api/{get,put}/preferences) so it
+// follows the user across devices. These helpers convert that selection to the
+// rides API's `include` query param and defend against unknown stored values.
 
-export type RideFilter = { label: string; value: string }
+export type RideStatus = 'CREATED' | 'ASSIGNED' | 'COMPLETED' | 'CANCELLED'
 
-/**
- * The base status filter values that always exist in the UI. Volunteer-only
- * options (e.g. `assign:ME`) are appended at runtime in the component and are
- * treated as valid there via the `validValues` argument to sanitize.
- */
-export const BASE_FILTER_OPTIONS: RideFilter[] = [
-  { label: 'Created', value: 'status:CREATED' },
-  { label: 'Assigned', value: 'status:ASSIGNED' },
-  { label: 'Completed', value: 'status:COMPLETED' },
-  { label: 'Cancelled', value: 'status:CANCELLED' },
+// Every ride status with a display label, for the status filter toggles.
+export const RIDE_STATUS_OPTIONS: { label: string; value: RideStatus }[] = [
+  { label: 'Created', value: 'CREATED' },
+  { label: 'Assigned', value: 'ASSIGNED' },
+  { label: 'Completed', value: 'COMPLETED' },
+  { label: 'Cancelled', value: 'CANCELLED' },
 ]
 
-/**
- * Default excluded filters for new users. Excludes finished rides (Completed and
- * Cancelled) so the dashboard defaults to active work. Both are valid, toggleable
- * options in BASE_FILTER_OPTIONS, so a user can always turn the exclusion off
- * (unlike the pre-#5 stale `status:CANCELLED` default, which had no toggle — #22).
- */
-export const DEFAULT_EXCLUDED_FILTERS: RideFilter[] = [
-  { label: 'Completed', value: 'status:COMPLETED' },
-  { label: 'Cancelled', value: 'status:CANCELLED' },
-]
+export const ALL_RIDE_STATUSES: RideStatus[] = RIDE_STATUS_OPTIONS.map((o) => o.value)
+
+// Default view for a user who has never saved a preference: active work only
+// (hide Completed/Cancelled). Matches the pre-DB cookie default (issue #22).
+export const DEFAULT_RIDE_STATUSES: RideStatus[] = ['CREATED', 'ASSIGNED']
 
 /**
- * Drop any saved filter whose value is not among the currently toggleable
- * options. This frees existing users whose `ride-excluded-filters` cookie still
- * contains `status:CANCELLED` (or any other stale value) so they aren't stuck
- * with an active-but-unmanageable filter.
+ * Keep only known ride statuses. Defensive when hydrating a saved preference so
+ * a stale/renamed value can never drive the UI or reach the API.
  */
-export function sanitizeSavedFilters(
-  saved: RideFilter[] | null | undefined,
-  validValues: string[]
-): RideFilter[] {
+export function sanitizeStatuses(saved: unknown): RideStatus[] {
   if (!Array.isArray(saved)) return []
-  const valid = new Set(validValues)
-  return saved.filter((f) => f && valid.has(f.value))
+  const valid = new Set<string>(ALL_RIDE_STATUSES)
+  return saved.filter((s): s is RideStatus => typeof s === 'string' && valid.has(s))
+}
+
+/**
+ * Build the rides API `include` param from the selected statuses plus the
+ * volunteer-only "assigned to me" toggle. An empty selection returns undefined:
+ * the server treats "no include" as "all statuses", which is the intuitive
+ * meaning of clearing every status filter.
+ */
+export function buildRidesInclude(
+  statuses: RideStatus[],
+  assignedToMe: boolean
+): string | undefined {
+  const parts = sanitizeStatuses(statuses).map((s) => `status:${s}`)
+  if (assignedToMe) parts.push('assign:ME')
+  return parts.length ? parts.join(',') : undefined
+}
+
+/**
+ * One-time migration of the legacy cookie filter model (an include set and an
+ * exclude set of `status:X` values, stored as `{ label, value }[]`) into the new
+ * "shown statuses" selection. Effective shown set = (included statuses, or all
+ * statuses if none were included) minus the excluded statuses. Tolerates either
+ * the raw cookie object shape or plain strings.
+ */
+export function legacyCookieToStatuses(active: unknown, excluded: unknown): RideStatus[] {
+  const values = (raw: unknown): string[] =>
+    Array.isArray(raw)
+      ? raw
+          .map((x) => (typeof x === 'string' ? x : (x as { value?: string })?.value))
+          .filter((v): v is string => typeof v === 'string')
+      : []
+  const strip = (v: string) => (v.startsWith('status:') ? v.slice('status:'.length) : v)
+
+  const included = sanitizeStatuses(values(active).map(strip))
+  const excludedSet = new Set(sanitizeStatuses(values(excluded).map(strip)))
+  const base = included.length ? included : [...ALL_RIDE_STATUSES]
+  return base.filter((s) => !excludedSet.has(s))
 }

--- a/prisma/migrations/20260720052131_add_user_preference/migration.sql
+++ b/prisma/migrations/20260720052131_add_user_preference/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "user_preference" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "rideStatusFilter" TEXT,
+    "rideSort" TEXT,
+    "rideAssignedToMeOnly" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "user_preference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_preference_userId_key" ON "user_preference"("userId");
+

--- a/prisma/schema/preference.prisma
+++ b/prisma/schema/preference.prisma
@@ -1,0 +1,25 @@
+// Per-user, cross-device UI preferences. A sidecar to the (better-auth-managed)
+// `user` table so app preferences can be added without touching the auth
+// schema. The rides list filter/sort settings live here — previously browser
+// cookies — so a user sees the same view on every device until they change it.
+model UserPreference {
+  id     String @id @default(uuid())
+  userId String @unique
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // Comma-separated RideStatus values to SHOW in the rides list
+  // (e.g. "CREATED,ASSIGNED"). null = never set -> the client applies its
+  // default (active work: CREATED + ASSIGNED).
+  rideStatusFilter String?
+
+  // Rides list ordering: "asc" | "desc". null = client default.
+  rideSort String?
+
+  // Volunteers only: limit the rides list to rides assigned to me.
+  rideAssignedToMeOnly Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("user_preference")
+}

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -21,9 +21,10 @@ model User {
   deletedEmail String?
   deletedPhone String?
 
-  sessions  Session[]
-  volunteer Volunteer?
-  client    Client?
+  sessions   Session[]
+  volunteer  Volunteer?
+  client     Client?
+  preference UserPreference?
 
   @@unique([email])
   @@map("user")

--- a/server/api/get/preferences.ts
+++ b/server/api/get/preferences.ts
@@ -1,0 +1,27 @@
+import { prisma } from '../../utils/prisma'
+
+// The current user's cross-device UI preferences (rides list filter/sort).
+// Returns a normalised shape; a user who has never saved gets nulls/false so
+// the client applies its own sensible defaults (active work, newest first).
+//
+// Auth: the global middleware (server/middleware/auth.ts) already requires a
+// session for every /api route, so event.context.auth is present here. The
+// preference is always the caller's own — there is no id in the path.
+export default defineEventHandler(async (event) => {
+  const session = event.context.auth as { user: { id: string } } | undefined
+  const userId = session?.user?.id
+  if (!userId) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+
+  const pref = await prisma.userPreference.findUnique({ where: { userId } })
+
+  return {
+    // Stored as a CSV string (SQLite has no scalar arrays); expose an array so
+    // the client doesn't have to parse. null = never set -> client default.
+    rideStatusFilter:
+      pref?.rideStatusFilter != null ? pref.rideStatusFilter.split(',').filter(Boolean) : null,
+    rideSort: pref?.rideSort ?? null,
+    rideAssignedToMeOnly: pref?.rideAssignedToMeOnly ?? false,
+  }
+})

--- a/server/api/put/preferences.ts
+++ b/server/api/put/preferences.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { prisma } from '../../utils/prisma'
+import { readValidatedBody } from '../../utils/validation'
+
+// The RideStatus values a status filter may contain (mirrors the whitelist in
+// server/api/get/rides/index.ts so a bogus value can never be stored).
+const RIDE_STATUSES = ['CREATED', 'ASSIGNED', 'COMPLETED', 'CANCELLED'] as const
+
+// Partial upsert of the current user's rides-list preferences (issue: DB-backed
+// filter preference). Every field is optional so the client can save just what
+// changed. Unknown keys are rejected (.strict). The status filter arrives as an
+// array of known statuses and is de-duped + stored as a CSV string.
+const prefSchema = z
+  .object({
+    rideStatusFilter: z.array(z.enum(RIDE_STATUSES)).optional(),
+    rideSort: z.enum(['asc', 'desc']).optional(),
+    rideAssignedToMeOnly: z.boolean().optional(),
+  })
+  .strict()
+
+export default defineEventHandler(async (event) => {
+  const session = event.context.auth as { user: { id: string } } | undefined
+  const userId = session?.user?.id
+  if (!userId) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+
+  const body = await readValidatedBody(event, prefSchema)
+
+  // Build the write from only the keys the caller actually sent, so a partial
+  // save never clobbers an unrelated preference back to its default.
+  const data: {
+    rideStatusFilter?: string
+    rideSort?: string
+    rideAssignedToMeOnly?: boolean
+  } = {}
+  if (body.rideStatusFilter !== undefined) {
+    data.rideStatusFilter = Array.from(new Set(body.rideStatusFilter)).join(',')
+  }
+  if (body.rideSort !== undefined) data.rideSort = body.rideSort
+  if (body.rideAssignedToMeOnly !== undefined) {
+    data.rideAssignedToMeOnly = body.rideAssignedToMeOnly
+  }
+
+  const pref = await prisma.userPreference.upsert({
+    where: { userId },
+    create: { userId, ...data },
+    update: data,
+  })
+
+  return {
+    rideStatusFilter:
+      pref.rideStatusFilter != null ? pref.rideStatusFilter.split(',').filter(Boolean) : null,
+    rideSort: pref.rideSort ?? null,
+    rideAssignedToMeOnly: pref.rideAssignedToMeOnly,
+  }
+})

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -18,6 +18,10 @@ const VOLUNTEER_WRITE_ALLOW = [
   /^\/api\/post\/rides\/[^/]+\/unsignup$/,
   /^\/api\/post\/rides\/[^/]+\/complete$/,
   /^\/api\/put\/volunteers\/bySession(\/|$)/,
+  // Saving your own UI preferences is a self-service write. The handler scopes
+  // strictly to the session user (no id in the path), so there's nothing to
+  // escalate — a volunteer can only ever write their own preference row.
+  /^\/api\/put\/preferences(\/|$)/,
 ]
 
 function isWrite(method: string) {

--- a/tests/e2e/preferences.test.ts
+++ b/tests/e2e/preferences.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { $fetch } from '@nuxt/test-utils/e2e'
+import { bootShared } from '../utils/harness'
+import { loginAs } from '../utils/auth'
+
+await bootShared()
+
+// DB-backed, cross-device UI preferences (rides list filter/sort). The row is
+// always the caller's own (no id in the path); the DB is reseeded per file so
+// no preference rows exist at the start.
+type Prefs = {
+  rideStatusFilter: string[] | null
+  rideSort: string | null
+  rideAssignedToMeOnly: boolean
+}
+
+describe('user preferences API', () => {
+  it('returns defaults (nulls/false) for a user who has never saved', async () => {
+    const cookie = await loginAs('alice@example.com')
+    const res = await $fetch<Prefs>('/api/get/preferences', { headers: { cookie } })
+    expect(res.rideStatusFilter).toBeNull()
+    expect(res.rideSort).toBeNull()
+    expect(res.rideAssignedToMeOnly).toBe(false)
+  })
+
+  it('persists a PUT and reads it back (status filter round-trips as an array)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    const put = await $fetch<Prefs>('/api/put/preferences', {
+      method: 'PUT',
+      headers: { cookie },
+      body: { rideStatusFilter: ['CREATED', 'COMPLETED'], rideSort: 'asc' },
+    })
+    expect(put.rideStatusFilter).toEqual(['CREATED', 'COMPLETED'])
+    expect(put.rideSort).toBe('asc')
+
+    const get = await $fetch<Prefs>('/api/get/preferences', { headers: { cookie } })
+    expect(get.rideStatusFilter).toEqual(['CREATED', 'COMPLETED'])
+    expect(get.rideSort).toBe('asc')
+  })
+
+  it('is a partial upsert — an omitted field is left untouched', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    // Only change the sort; the status filter set above must survive.
+    const put = await $fetch<Prefs>('/api/put/preferences', {
+      method: 'PUT',
+      headers: { cookie },
+      body: { rideSort: 'desc' },
+    })
+    expect(put.rideSort).toBe('desc')
+    expect(put.rideStatusFilter).toEqual(['CREATED', 'COMPLETED'])
+  })
+
+  it('lets a volunteer save their own preference (self-service write, not a 403)', async () => {
+    const cookie = await loginAs('bob@example.com')
+    const res = await $fetch<Prefs>('/api/put/preferences', {
+      method: 'PUT',
+      headers: { cookie },
+      body: { rideAssignedToMeOnly: true },
+    })
+    expect(res.rideAssignedToMeOnly).toBe(true)
+  })
+
+  it('scopes preferences per user', async () => {
+    // bob (above) set assignedToMe=true and never set a status filter; the
+    // admin's saved status filter must not leak into bob's row.
+    const cookie = await loginAs('bob@example.com')
+    const bob = await $fetch<Prefs>('/api/get/preferences', { headers: { cookie } })
+    expect(bob.rideAssignedToMeOnly).toBe(true)
+    expect(bob.rideStatusFilter).toBeNull()
+  })
+
+  it('rejects an invalid status with 400', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    await expect(
+      $fetch('/api/put/preferences', {
+        method: 'PUT',
+        headers: { cookie },
+        body: { rideStatusFilter: ['BOGUS'] },
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('rejects an unknown key with 400 (strict schema)', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    await expect(
+      $fetch('/api/put/preferences', {
+        method: 'PUT',
+        headers: { cookie },
+        body: { evil: true },
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('requires authentication', async () => {
+    await expect($fetch('/api/get/preferences')).rejects.toMatchObject({ statusCode: 401 })
+    await expect(
+      $fetch('/api/put/preferences', { method: 'PUT', body: { rideSort: 'asc' } }),
+    ).rejects.toMatchObject({ statusCode: 401 })
+  })
+})

--- a/tests/e2e/ride-filters.test.ts
+++ b/tests/e2e/ride-filters.test.ts
@@ -1,58 +1,79 @@
 import { describe, expect, it } from 'vitest'
 import {
-  BASE_FILTER_OPTIONS,
-  DEFAULT_EXCLUDED_FILTERS,
-  sanitizeSavedFilters,
+  ALL_RIDE_STATUSES,
+  DEFAULT_RIDE_STATUSES,
+  RIDE_STATUS_OPTIONS,
+  buildRidesInclude,
+  legacyCookieToStatuses,
+  sanitizeStatuses,
 } from '../../app/utils/rideFilters'
 
-// Pure-function unit test for the rides status-filter helpers (issue #22).
-// Intentionally does NOT call setup() — it exercises pure helpers and must not
-// boot the Nuxt app, so it stays fast (mirrors trusted-origins.test.ts).
-describe('ride filter helpers (#22)', () => {
-  const validValues = BASE_FILTER_OPTIONS.map((o) => o.value)
-
-  it('has no default excluded filter that is absent from the toggleable options', () => {
-    // Pins the bug: `status:CANCELLED` was a default exclusion but is not a
-    // toggleable filter option, leaving the UI stuck with an un-removable filter.
-    for (const f of DEFAULT_EXCLUDED_FILTERS) {
-      expect(validValues).toContain(f.value)
-    }
+// Pure-function unit test for the rides status-filter helpers. Intentionally
+// does NOT call setup() — it exercises pure helpers and must not boot the Nuxt
+// app, so it stays fast (mirrors trusted-origins.test.ts).
+describe('ride filter helpers', () => {
+  it('exposes all four real ride statuses, including CANCELLED (#5)', () => {
+    expect(ALL_RIDE_STATUSES).toEqual(['CREATED', 'ASSIGNED', 'COMPLETED', 'CANCELLED'])
+    expect(RIDE_STATUS_OPTIONS.map((o) => o.value)).toEqual(ALL_RIDE_STATUSES)
   })
 
-  it('keeps the sensible Completed default exclusion', () => {
-    expect(DEFAULT_EXCLUDED_FILTERS.map((f) => f.value)).toContain('status:COMPLETED')
+  it('defaults to active work only (hides Completed/Cancelled)', () => {
+    expect(DEFAULT_RIDE_STATUSES).toEqual(['CREATED', 'ASSIGNED'])
   })
 
-  it('keeps status:CANCELLED now that it is a real, toggleable status (#5)', () => {
-    // CANCELLED became a first-class RideStatus in #5, so it is a valid filter
-    // value and must survive sanitize (it is no longer the stuck-filter bug #22).
-    expect(validValues).toContain('status:CANCELLED')
-    const saved = [
-      { label: 'Completed', value: 'status:COMPLETED' },
-      { label: 'Cancelled', value: 'status:CANCELLED' },
-    ]
-    const result = sanitizeSavedFilters(saved, validValues)
-    expect(result.map((f) => f.value)).toEqual(['status:COMPLETED', 'status:CANCELLED'])
+  describe('sanitizeStatuses', () => {
+    it('keeps known statuses and strips unknown ones', () => {
+      expect(sanitizeStatuses(['CREATED', 'BOGUS', 'COMPLETED'])).toEqual(['CREATED', 'COMPLETED'])
+    })
+    it('handles null/undefined/non-array gracefully', () => {
+      expect(sanitizeStatuses(null)).toEqual([])
+      expect(sanitizeStatuses(undefined)).toEqual([])
+      expect(sanitizeStatuses('CREATED')).toEqual([])
+    })
   })
 
-  it('strips a genuinely stale/unknown saved filter but keeps valid ones', () => {
-    const saved = [
-      { label: 'Completed', value: 'status:COMPLETED' },
-      { label: 'Bogus', value: 'status:BOGUS' },
-    ]
-    const result = sanitizeSavedFilters(saved, validValues)
-    expect(result.map((f) => f.value)).toEqual(['status:COMPLETED'])
-    expect(result.map((f) => f.value)).not.toContain('status:BOGUS')
+  describe('buildRidesInclude', () => {
+    it('maps selected statuses to prefixed include values', () => {
+      expect(buildRidesInclude(['CREATED', 'ASSIGNED'], false)).toBe(
+        'status:CREATED,status:ASSIGNED'
+      )
+    })
+    it('appends assign:ME when assignedToMe is set', () => {
+      expect(buildRidesInclude(['CREATED'], true)).toBe('status:CREATED,assign:ME')
+    })
+    it('returns undefined for an empty selection (server treats it as all)', () => {
+      expect(buildRidesInclude([], false)).toBeUndefined()
+    })
+    it('assign:ME alone still produces a param', () => {
+      expect(buildRidesInclude([], true)).toBe('assign:ME')
+    })
+    it('drops unknown statuses before building', () => {
+      expect(buildRidesInclude(['CREATED', 'BOGUS'] as never, false)).toBe('status:CREATED')
+    })
   })
 
-  it('keeps runtime-valid values that are passed in validValues (e.g. assign:ME)', () => {
-    const saved = [{ label: 'Assigned to Me', value: 'assign:ME' }]
-    const result = sanitizeSavedFilters(saved, [...validValues, 'assign:ME'])
-    expect(result.map((f) => f.value)).toEqual(['assign:ME'])
-  })
-
-  it('handles null/undefined saved cookie gracefully', () => {
-    expect(sanitizeSavedFilters(null, validValues)).toEqual([])
-    expect(sanitizeSavedFilters(undefined, validValues)).toEqual([])
+  describe('legacyCookieToStatuses (cookie -> DB migration)', () => {
+    it('converts the default cookie state (exclude Completed+Cancelled) to active work', () => {
+      const excluded = [
+        { label: 'Completed', value: 'status:COMPLETED' },
+        { label: 'Cancelled', value: 'status:CANCELLED' },
+      ]
+      expect(legacyCookieToStatuses([], excluded)).toEqual(['CREATED', 'ASSIGNED'])
+    })
+    it('intersects an explicit include with the exclude set', () => {
+      const active = [
+        { label: 'Created', value: 'status:CREATED' },
+        { label: 'Completed', value: 'status:COMPLETED' },
+      ]
+      const excluded = [{ label: 'Completed', value: 'status:COMPLETED' }]
+      expect(legacyCookieToStatuses(active, excluded)).toEqual(['CREATED'])
+    })
+    it('with no include and no exclude, shows every status', () => {
+      expect(legacyCookieToStatuses([], [])).toEqual(ALL_RIDE_STATUSES)
+    })
+    it('tolerates plain strings and null cookies', () => {
+      expect(legacyCookieToStatuses(['status:ASSIGNED'], null)).toEqual(['ASSIGNED'])
+      expect(legacyCookieToStatuses(null, undefined)).toEqual(ALL_RIDE_STATUSES)
+    })
   })
 })


### PR DESCRIPTION
Phase B of the rides UX work: move the rides-list filter/sort out of browser cookies into a per-user DB preference so it follows the user across devices, and replace the confusing Include/Exclude dropdowns with a single status toggle.

### Backend
- New `UserPreference` model — a sidecar 1:1 with the better-auth `user` table (committed migration `add_user_preference`) storing `rideStatusFilter` (CSV of RideStatus), `rideSort`, `rideAssignedToMeOnly`.
- `GET /api/get/preferences` — the caller's own prefs, normalised (status filter as an array; nulls when unset so the client applies defaults).
- `PUT /api/put/preferences` — validated (`.strict`, enum-checked statuses), session-scoped partial upsert. Unknown keys / bad statuses are 400s.
- Volunteer self-service write to `PUT /api/put/preferences` allowlisted in the auth middleware (no id in the path — a volunteer can only ever write their own row).

### Frontend
- `rideFilters.ts` reworked from include+exclude to a single "shown statuses" model (`RIDE_STATUS_OPTIONS`, `DEFAULT_RIDE_STATUSES`, `sanitizeStatuses`, `buildRidesInclude`, `legacyCookieToStatuses`).
- The two status dropdowns → one **status toggle group** (each active chip takes its status' badge colour) + a volunteer-only **"Assigned to me"** toggle. Filter/sort load from and save to the DB (debounced). A one-time cookie→DB migration converts any legacy cookie and clears it. Empty selection = all statuses.
- **Date range** restyled into an **"All dates" popover** (still transient / per-visit, not persisted) — reads sensibly when empty, stacks From/To so it fits, and marks an endpoint that is today with a live **"(today)"** (reactive, clears at midnight).
- Scrollbar restyled (slim on desktop, hidden on mobile).

### Tests
- Rewrote `ride-filters.test.ts` for the new helpers; added `preferences.test.ts` e2e (defaults, persist/round-trip, partial upsert, volunteer self-service, per-user scoping, 400s, 401).
- Full e2e suite green (46 files / 214 tests) on a production build.

Follows phase A (#115) on the `stage` line. Deferred: per-status counts in the toggle.