### PR TITLE
Rides: create wizard + bounded list, view toggle, validations

### DIFF
--- a/app/components/AddressField.vue
+++ b/app/components/AddressField.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+  import type { RideAddressForm } from '../utils/rideForm'
+
+  // Search-first address entry (issue #19 logic, extracted + streamlined). Shows
+  // a compact summary once an address is set (e.g. pre-filled from the client's
+  // home), a search box with server suggestions to pick an existing address, and
+  // an "Enter a new address" disclosure that reveals the manual fields. The v-model
+  // is the structured { street, city, state, zip } object the ride form stores.
+  const address = defineModel<RideAddressForm>({ required: true })
+
+  const props = defineProps<{
+    label: string
+    // Optional note shown under the summary, e.g. "From Martha's home address".
+    hint?: string
+  }>()
+
+  const search = ref('')
+  const options = ref<any[]>([])
+  const editing = ref(false) // user tapped Change / no address yet
+  const manual = ref(false) // manual field entry revealed
+
+  const isSet = computed(() => !!address.value.street?.trim())
+  const showSummary = computed(() => isSet.value && !editing.value)
+  const summary = computed(() =>
+    [address.value.street, address.value.city, address.value.state, address.value.zip]
+      .filter(Boolean)
+      .join(', ')
+  )
+
+  async function fetchOptions(term: string) {
+    const query = buildAddressQuery(term)
+    if (!query) {
+      options.value = []
+      return
+    }
+    try {
+      const results = await $fetch<any[]>('/api/get/addresses', { query })
+      // Ignore stale responses that no longer match the current term.
+      if ((term ?? '').trim() === query.search) options.value = (results ?? []).slice(0, 5)
+    } catch (err) {
+      console.error('Failed to fetch address suggestions', err)
+      options.value = []
+    }
+  }
+  const debouncedFetch = debounce((term: string) => fetchOptions(term), 250)
+
+  watch(search, (term) => {
+    if (!buildAddressQuery(term)) {
+      debouncedFetch.cancel()
+      options.value = []
+      return
+    }
+    debouncedFetch(term)
+  })
+
+  function pick(opt: any) {
+    Object.assign(address.value, {
+      street: opt.address.street,
+      city: opt.address.city,
+      state: opt.address.state,
+      zip: opt.address.zip,
+    })
+    search.value = ''
+    options.value = []
+    editing.value = false
+    manual.value = false
+  }
+
+  function change() {
+    editing.value = true
+    manual.value = false
+    search.value = ''
+    options.value = []
+  }
+
+  function enterManually() {
+    manual.value = true
+    options.value = []
+  }
+</script>
+
+<template>
+  <div>
+    <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+      {{ label }}
+    </label>
+
+    <!-- Summary: address is set and we're not editing it -->
+    <div
+      v-if="showSummary"
+      class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/50"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex items-start gap-2">
+          <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
+          <span class="text-sm font-medium text-gray-900 dark:text-white">{{ summary }}</span>
+        </div>
+        <UButton
+          label="Change"
+          size="xs"
+          color="neutral"
+          variant="ghost"
+          icon="i-lucide-pencil"
+          @click="change"
+        />
+      </div>
+      <p v-if="hint" class="text-primary mt-2 flex items-center gap-1.5 text-xs">
+        <UIcon name="i-lucide-check" class="size-3.5" />
+        {{ hint }}
+      </p>
+    </div>
+
+    <!-- Entry: search + suggestions, with a manual-entry disclosure -->
+    <div v-else class="space-y-2">
+      <div v-if="!manual" class="relative">
+        <UInput
+          v-model="search"
+          icon="i-lucide-search"
+          placeholder="Search for an address…"
+          autocomplete="off"
+          class="w-full"
+        />
+        <div
+          v-if="options.length > 0 && search"
+          class="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+        >
+          <button
+            v-for="opt in options"
+            :key="opt.id"
+            type="button"
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+            @click="pick(opt)"
+          >
+            <UIcon name="i-lucide-map-pin" class="size-3.5 shrink-0 text-gray-400" />
+            <span class="truncate">{{ opt.label }}</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Manual fields -->
+      <div v-if="manual" class="space-y-2">
+        <UInput v-model="address.street" placeholder="Street address" class="w-full" />
+        <UInput v-model="address.city" placeholder="City" class="w-full" />
+        <div class="grid grid-cols-2 gap-2">
+          <UInput v-model="address.state" placeholder="State" />
+          <UInput v-model="address.zip" placeholder="Zip" />
+        </div>
+      </div>
+
+      <div class="flex items-center justify-between">
+        <UButton
+          v-if="!manual"
+          label="Enter a new address"
+          size="xs"
+          color="neutral"
+          variant="ghost"
+          icon="i-lucide-plus"
+          @click="enterManually"
+        />
+        <UButton
+          v-else
+          label="Search instead"
+          size="xs"
+          color="neutral"
+          variant="ghost"
+          icon="i-lucide-search"
+          @click="manual = false"
+        />
+        <UButton
+          v-if="isSet"
+          label="Cancel"
+          size="xs"
+          color="neutral"
+          variant="ghost"
+          @click="editing = false"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/RideCreatePanel.vue
+++ b/app/components/RideCreatePanel.vue
@@ -69,11 +69,36 @@
   const addressComplete = (a: { street: string; city: string; state: string; zip: string }) =>
     !!(a.street?.trim() && a.city?.trim() && a.state?.trim() && a.zip?.trim())
 
+  const normalizeAddress = (a: { street: string; city: string; state: string; zip: string }) =>
+    [a.street, a.city, a.state, a.zip].map((s) => (s || '').trim().toLowerCase()).join('|')
+
+  // Pickup and dropoff must differ — a ride to the same place makes no sense.
+  const sameAddress = computed(
+    () =>
+      addressComplete(state.pickup) &&
+      addressComplete(state.dropoff) &&
+      normalizeAddress(state.pickup) === normalizeAddress(state.dropoff)
+  )
+
+  // The volunteer picks the client up before the appointment, so a pickup time
+  // after it is invalid.
+  const pickupAfterAppointment = computed(
+    () =>
+      !!state.pickupTime &&
+      !!state.scheduledTime &&
+      new Date(state.pickupTime) > new Date(state.scheduledTime)
+  )
+
   // Whether the current step is complete enough to advance.
   const canContinue = computed(() => {
     if (step.value === 1)
-      return !!clientId.value && addressComplete(state.pickup) && addressComplete(state.dropoff)
-    if (step.value === 2) return !!state.scheduledTime
+      return (
+        !!clientId.value &&
+        addressComplete(state.pickup) &&
+        addressComplete(state.dropoff) &&
+        !sameAddress.value
+      )
+    if (step.value === 2) return !!state.scheduledTime && !pickupAfterAppointment.value
     return true
   })
 
@@ -207,6 +232,10 @@
         </div>
         <AddressField v-model="state.pickup" label="Pickup" :hint="pickupHint" />
         <AddressField v-model="state.dropoff" label="Dropoff" />
+        <p v-if="sameAddress" class="text-error flex items-center gap-1.5 text-xs">
+          <UIcon name="i-lucide-circle-alert" class="size-3.5 shrink-0" />
+          Pickup and dropoff can't be the same address.
+        </p>
       </div>
 
       <!-- Step 2: Schedule & details -->
@@ -222,6 +251,13 @@
             Pickup time <span class="font-normal text-gray-400">(optional)</span>
           </label>
           <UInput v-model="state.pickupTime" type="datetime-local" class="w-full" />
+          <p
+            v-if="pickupAfterAppointment"
+            class="text-error mt-1.5 flex items-center gap-1.5 text-xs"
+          >
+            <UIcon name="i-lucide-circle-alert" class="size-3.5 shrink-0" />
+            Pickup time must be before the appointment.
+          </p>
         </div>
         <div>
           <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -239,7 +275,13 @@
           <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Notes <span class="font-normal text-gray-400">(optional)</span>
           </label>
-          <UTextarea v-model="state.notes" placeholder="Additional instructions…" class="w-full" />
+          <UTextarea
+            v-model="state.notes"
+            :rows="4"
+            autoresize
+            placeholder="Additional instructions…"
+            class="w-full"
+          />
         </div>
       </div>
 
@@ -288,7 +330,9 @@
           </div>
           <div v-if="state.notes" class="p-3">
             <dt class="mb-1 text-sm text-gray-500">Notes</dt>
-            <dd class="text-sm">{{ state.notes }}</dd>
+            <dd class="text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
+              {{ state.notes }}
+            </dd>
           </div>
         </dl>
       </div>

--- a/app/components/RideCreatePanel.vue
+++ b/app/components/RideCreatePanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import { blankRideForm } from '../utils/rideForm'
 
-  // The Create Ride flow as a 4-step wizard (Client -> Route -> Schedule ->
+  // The Create Ride flow as a 3-step wizard (Client & route -> Schedule ->
   // Review). Rendered as a side pane on desktop and full-screen on mobile by the
   // parent; this component only owns the wizard itself. Create is admin-only, so
   // the parent gates it behind isAdmin (the volunteer picker is always shown).
@@ -14,10 +14,9 @@
   const toast = useToast()
 
   const STEPS = [
-    { n: 1, label: 'Client' },
-    { n: 2, label: 'Route' },
-    { n: 3, label: 'Schedule' },
-    { n: 4, label: 'Review' },
+    { n: 1, label: 'Client & route' },
+    { n: 2, label: 'Schedule' },
+    { n: 3, label: 'Review' },
   ]
   const step = ref(1)
   const submitting = ref(false)
@@ -44,20 +43,17 @@
   const selectedClient = computed(() => props.clients?.find((c) => c.id === clientId.value))
 
   // Pre-fill pickup from the client's home address when a client is chosen.
-  watch(
-    clientId,
-    (id) => {
-      const client = props.clients?.find((c) => c.id === id)
-      if (client?.homeAddress) {
-        Object.assign(state.pickup, {
-          street: client.homeAddress.street,
-          city: client.homeAddress.city,
-          state: client.homeAddress.state,
-          zip: client.homeAddress.zip,
-        })
-      }
+  watch(clientId, (id) => {
+    const client = props.clients?.find((c) => c.id === id)
+    if (client?.homeAddress) {
+      Object.assign(state.pickup, {
+        street: client.homeAddress.street,
+        city: client.homeAddress.city,
+        state: client.homeAddress.state,
+        zip: client.homeAddress.zip,
+      })
     }
-  )
+  })
 
   // Shown under the pickup summary only while pickup still matches the client's
   // home address — clears itself if the admin edits pickup to something else.
@@ -75,14 +71,14 @@
 
   // Whether the current step is complete enough to advance.
   const canContinue = computed(() => {
-    if (step.value === 1) return !!clientId.value
-    if (step.value === 2) return addressComplete(state.pickup) && addressComplete(state.dropoff)
-    if (step.value === 3) return !!state.scheduledTime
+    if (step.value === 1)
+      return !!clientId.value && addressComplete(state.pickup) && addressComplete(state.dropoff)
+    if (step.value === 2) return !!state.scheduledTime
     return true
   })
 
   function next() {
-    if (step.value < 4 && canContinue.value) step.value++
+    if (step.value < 3 && canContinue.value) step.value++
   }
   function back() {
     if (step.value > 1) step.value--
@@ -194,8 +190,8 @@
 
     <!-- Body -->
     <div class="flex-1 overflow-y-auto p-4">
-      <!-- Step 1: Client -->
-      <div v-show="step === 1" class="space-y-4">
+      <!-- Step 1: Client & route -->
+      <div v-show="step === 1" class="space-y-5">
         <div>
           <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Client
@@ -209,30 +205,12 @@
             class="w-full"
           />
         </div>
-        <div
-          v-if="selectedClient"
-          class="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-        >
-          <p class="font-semibold text-gray-900 dark:text-white">{{ selectedClient.name }}</p>
-          <p
-            v-if="selectedClient.homeAddress"
-            class="text-primary mt-1 flex items-center gap-1.5 text-xs"
-          >
-            <UIcon name="i-lucide-map-pin" class="size-3.5" />
-            Pickup will use {{ selectedClient.homeAddress.street }},
-            {{ selectedClient.homeAddress.city }}
-          </p>
-        </div>
-      </div>
-
-      <!-- Step 2: Route -->
-      <div v-show="step === 2" class="space-y-5">
         <AddressField v-model="state.pickup" label="Pickup" :hint="pickupHint" />
         <AddressField v-model="state.dropoff" label="Dropoff" />
       </div>
 
-      <!-- Step 3: Schedule & details -->
-      <div v-show="step === 3" class="space-y-4">
+      <!-- Step 2: Schedule & details -->
+      <div v-show="step === 2" class="space-y-4">
         <div>
           <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Appointment time
@@ -265,8 +243,8 @@
         </div>
       </div>
 
-      <!-- Step 4: Review -->
-      <div v-show="step === 4" class="space-y-3">
+      <!-- Step 3: Review -->
+      <div v-show="step === 3" class="space-y-3">
         <p class="text-sm text-gray-500">Check the details, then create the ride.</p>
         <dl
           class="divide-y divide-gray-100 rounded-lg border border-gray-200 dark:divide-gray-800 dark:border-gray-700"
@@ -329,10 +307,10 @@
         :disabled="submitting"
         @click="back"
       />
-      <span v-else class="text-xs text-gray-400">Step {{ step }} of 4</span>
+      <span v-else class="text-xs text-gray-400">Step {{ step }} of 3</span>
 
       <UButton
-        v-if="step < 4"
+        v-if="step < 3"
         label="Continue"
         color="primary"
         trailing-icon="i-lucide-chevron-right"

--- a/app/components/RideCreatePanel.vue
+++ b/app/components/RideCreatePanel.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+  import { blankRideForm } from '../utils/rideForm'
+
+  // The Create Ride flow as a 4-step wizard (Client -> Route -> Schedule ->
+  // Review). Rendered as a side pane on desktop and full-screen on mobile by the
+  // parent; this component only owns the wizard itself. Create is admin-only, so
+  // the parent gates it behind isAdmin (the volunteer picker is always shown).
+  const props = defineProps<{
+    clients: { id: string; name: string; homeAddress?: any }[] | null
+    volunteers: { id: string; name?: string }[] | null
+  }>()
+
+  const emit = defineEmits<{ created: []; close: [] }>()
+  const toast = useToast()
+
+  const STEPS = [
+    { n: 1, label: 'Client' },
+    { n: 2, label: 'Route' },
+    { n: 3, label: 'Schedule' },
+    { n: 4, label: 'Review' },
+  ]
+  const step = ref(1)
+  const submitting = ref(false)
+  const state = reactive(blankRideForm())
+
+  const clientItems = computed(
+    () => props.clients?.map((c) => ({ label: c.name, value: c.id })) ?? []
+  )
+  const volunteerOptions = computed(() => {
+    const list = (props.volunteers ?? []).map((v) => ({
+      label: v.name || 'Unknown Volunteer',
+      value: v.id,
+    }))
+    return [{ label: 'Unassigned', value: '' }, ...list]
+  })
+
+  // USelectMenu (value-key="value") binds the id string; normalize defensively
+  // in case it ever hands back the whole option object.
+  const clientId = computed(() =>
+    typeof state.clientId === 'object' && state.clientId
+      ? (state.clientId as { value?: string }).value
+      : state.clientId
+  )
+  const selectedClient = computed(() => props.clients?.find((c) => c.id === clientId.value))
+
+  // Pre-fill pickup from the client's home address when a client is chosen.
+  watch(
+    clientId,
+    (id) => {
+      const client = props.clients?.find((c) => c.id === id)
+      if (client?.homeAddress) {
+        Object.assign(state.pickup, {
+          street: client.homeAddress.street,
+          city: client.homeAddress.city,
+          state: client.homeAddress.state,
+          zip: client.homeAddress.zip,
+        })
+      }
+    }
+  )
+
+  // Shown under the pickup summary only while pickup still matches the client's
+  // home address — clears itself if the admin edits pickup to something else.
+  const pickupHint = computed(() => {
+    const h = selectedClient.value?.homeAddress
+    if (!h) return undefined
+    const p = state.pickup
+    const same =
+      p.street === h.street && p.city === h.city && p.state === h.state && p.zip === h.zip
+    return same ? `From ${selectedClient.value?.name}'s home address` : undefined
+  })
+
+  const addressComplete = (a: { street: string; city: string; state: string; zip: string }) =>
+    !!(a.street?.trim() && a.city?.trim() && a.state?.trim() && a.zip?.trim())
+
+  // Whether the current step is complete enough to advance.
+  const canContinue = computed(() => {
+    if (step.value === 1) return !!clientId.value
+    if (step.value === 2) return addressComplete(state.pickup) && addressComplete(state.dropoff)
+    if (step.value === 3) return !!state.scheduledTime
+    return true
+  })
+
+  function next() {
+    if (step.value < 4 && canContinue.value) step.value++
+  }
+  function back() {
+    if (step.value > 1) step.value--
+  }
+
+  const volunteerLabel = computed(() => {
+    const v = state.volunteerId
+    if (!v || (typeof v === 'object' && !v.value)) return 'Unassigned'
+    if (typeof v === 'object') return v.label
+    return volunteerOptions.value.find((o) => o.value === v)?.label ?? 'Unassigned'
+  })
+
+  function fmtDateTime(value: string) {
+    if (!value) return '—'
+    return formatDateTime(value, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  async function submit() {
+    if (submitting.value) return
+    submitting.value = true
+    try {
+      const scheduledTimeISO = new Date(state.scheduledTime).toISOString()
+      const pickupTimeISO = state.pickupTime ? new Date(state.pickupTime).toISOString() : undefined
+      const vId =
+        typeof state.volunteerId === 'object' ? state.volunteerId?.value : state.volunteerId
+      await $fetch('/api/post/rides', {
+        method: 'POST',
+        body: {
+          clientId: clientId.value,
+          pickup: state.pickup,
+          dropoff: state.dropoff,
+          notes: state.notes,
+          volunteerId: vId,
+          scheduledTime: scheduledTimeISO,
+          pickupTime: pickupTimeISO,
+        },
+      })
+      toast.add({ title: 'Ride created', color: 'success' })
+      emit('created')
+    } catch (err) {
+      console.error('Failed to create ride', err)
+      toast.add({ title: 'Error', description: 'Failed to create ride', color: 'error' })
+    } finally {
+      submitting.value = false
+    }
+  }
+</script>
+
+<template>
+  <div
+    class="flex h-full flex-col bg-white lg:rounded-xl lg:border lg:border-gray-200 dark:bg-gray-900 lg:dark:border-gray-800"
+  >
+    <!-- Header -->
+    <div
+      class="flex items-center justify-between border-b border-gray-100 p-4 dark:border-gray-800"
+    >
+      <h2 class="text-base font-bold">New ride</h2>
+      <UButton
+        icon="i-lucide-x"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        aria-label="Close"
+        @click="emit('close')"
+      />
+    </div>
+
+    <!-- Step rail -->
+    <div class="flex items-center gap-1 border-b border-gray-100 px-4 py-3 dark:border-gray-800">
+      <template v-for="(s, i) in STEPS" :key="s.n">
+        <div
+          class="flex items-center gap-1.5 text-xs font-medium"
+          :class="
+            step === s.n
+              ? 'text-gray-900 dark:text-white'
+              : step > s.n
+                ? 'text-gray-500'
+                : 'text-gray-400'
+          "
+        >
+          <span
+            class="flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
+            :class="
+              step === s.n
+                ? 'bg-primary text-white'
+                : step > s.n
+                  ? 'bg-primary/15 text-primary'
+                  : 'border border-gray-300 text-gray-400 dark:border-gray-600'
+            "
+          >
+            <UIcon v-if="step > s.n" name="i-lucide-check" class="size-3" />
+            <template v-else>{{ s.n }}</template>
+          </span>
+          <span class="hidden sm:inline">{{ s.label }}</span>
+        </div>
+        <div
+          v-if="i < STEPS.length - 1"
+          class="h-px flex-1"
+          :class="step > s.n ? 'bg-primary/40' : 'bg-gray-200 dark:bg-gray-700'"
+        />
+      </template>
+    </div>
+
+    <!-- Body -->
+    <div class="flex-1 overflow-y-auto p-4">
+      <!-- Step 1: Client -->
+      <div v-show="step === 1" class="space-y-4">
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Client
+          </label>
+          <USelectMenu
+            v-model="state.clientId"
+            :items="clientItems"
+            value-key="value"
+            placeholder="Search clients…"
+            searchable
+            class="w-full"
+          />
+        </div>
+        <div
+          v-if="selectedClient"
+          class="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+        >
+          <p class="font-semibold text-gray-900 dark:text-white">{{ selectedClient.name }}</p>
+          <p
+            v-if="selectedClient.homeAddress"
+            class="text-primary mt-1 flex items-center gap-1.5 text-xs"
+          >
+            <UIcon name="i-lucide-map-pin" class="size-3.5" />
+            Pickup will use {{ selectedClient.homeAddress.street }},
+            {{ selectedClient.homeAddress.city }}
+          </p>
+        </div>
+      </div>
+
+      <!-- Step 2: Route -->
+      <div v-show="step === 2" class="space-y-5">
+        <AddressField v-model="state.pickup" label="Pickup" :hint="pickupHint" />
+        <AddressField v-model="state.dropoff" label="Dropoff" />
+      </div>
+
+      <!-- Step 3: Schedule & details -->
+      <div v-show="step === 3" class="space-y-4">
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Appointment time
+          </label>
+          <UInput v-model="state.scheduledTime" type="datetime-local" class="w-full" />
+        </div>
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Pickup time <span class="font-normal text-gray-400">(optional)</span>
+          </label>
+          <UInput v-model="state.pickupTime" type="datetime-local" class="w-full" />
+        </div>
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Volunteer <span class="font-normal text-gray-400">(optional)</span>
+          </label>
+          <USelectMenu
+            v-model="state.volunteerId"
+            :items="volunteerOptions"
+            placeholder="Leave open for signup"
+            searchable
+            class="w-full"
+          />
+        </div>
+        <div>
+          <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Notes <span class="font-normal text-gray-400">(optional)</span>
+          </label>
+          <UTextarea v-model="state.notes" placeholder="Additional instructions…" class="w-full" />
+        </div>
+      </div>
+
+      <!-- Step 4: Review -->
+      <div v-show="step === 4" class="space-y-3">
+        <p class="text-sm text-gray-500">Check the details, then create the ride.</p>
+        <dl
+          class="divide-y divide-gray-100 rounded-lg border border-gray-200 dark:divide-gray-800 dark:border-gray-700"
+        >
+          <div class="flex justify-between gap-4 p-3">
+            <dt class="text-sm text-gray-500">Client</dt>
+            <dd class="text-right text-sm font-medium">{{ selectedClient?.name || '—' }}</dd>
+          </div>
+          <div class="p-3">
+            <dt class="mb-1 text-sm text-gray-500">Route</dt>
+            <dd class="space-y-1 text-sm font-medium">
+              <p class="flex items-start gap-2">
+                <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
+                {{
+                  [state.pickup.street, state.pickup.city, state.pickup.state, state.pickup.zip]
+                    .filter(Boolean)
+                    .join(', ')
+                }}
+              </p>
+              <p class="flex items-start gap-2">
+                <UIcon name="i-lucide-flag" class="text-error mt-0.5 size-4 shrink-0" />
+                {{
+                  [state.dropoff.street, state.dropoff.city, state.dropoff.state, state.dropoff.zip]
+                    .filter(Boolean)
+                    .join(', ')
+                }}
+              </p>
+            </dd>
+          </div>
+          <div class="flex justify-between gap-4 p-3">
+            <dt class="text-sm text-gray-500">Appointment</dt>
+            <dd class="text-right text-sm font-medium">{{ fmtDateTime(state.scheduledTime) }}</dd>
+          </div>
+          <div v-if="state.pickupTime" class="flex justify-between gap-4 p-3">
+            <dt class="text-sm text-gray-500">Pickup time</dt>
+            <dd class="text-right text-sm font-medium">{{ fmtDateTime(state.pickupTime) }}</dd>
+          </div>
+          <div class="flex justify-between gap-4 p-3">
+            <dt class="text-sm text-gray-500">Volunteer</dt>
+            <dd class="text-right text-sm font-medium">{{ volunteerLabel }}</dd>
+          </div>
+          <div v-if="state.notes" class="p-3">
+            <dt class="mb-1 text-sm text-gray-500">Notes</dt>
+            <dd class="text-sm">{{ state.notes }}</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div
+      class="flex items-center justify-between gap-2 border-t border-gray-100 p-4 dark:border-gray-800"
+    >
+      <UButton
+        v-if="step > 1"
+        label="Back"
+        color="neutral"
+        variant="ghost"
+        icon="i-lucide-chevron-left"
+        :disabled="submitting"
+        @click="back"
+      />
+      <span v-else class="text-xs text-gray-400">Step {{ step }} of 4</span>
+
+      <UButton
+        v-if="step < 4"
+        label="Continue"
+        color="primary"
+        trailing-icon="i-lucide-chevron-right"
+        :disabled="!canContinue"
+        @click="next"
+      />
+      <UButton
+        v-else
+        label="Create ride"
+        color="primary"
+        icon="i-lucide-check"
+        :loading="submitting"
+        @click="submit"
+      />
+    </div>
+  </div>
+</template>

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -46,6 +46,47 @@
   // a request per keystroke.
   const PAGE_SIZE_OPTIONS = [5, 10, 20, 50]
   const pageSize = ref<number>(prefs.value?.ridesPerPage ?? 10)
+
+  // Rides list view per breakpoint (table vs cards), seeded from the saved
+  // preference. Because prefs is fetched server-side, the CSS-driven visibility
+  // below is deterministic at SSR — no hydration flash. Defaults: desktop rows,
+  // mobile cards.
+  const desktopView = ref<string>(prefs.value?.ridesViewDesktop ?? 'table')
+  const mobileView = ref<string>(prefs.value?.ridesViewMobile ?? 'cards')
+
+  // Visibility is pure CSS (max-lg = below 1024px, lg = 1024px+), driven by the
+  // per-breakpoint preference, so both the table and cards stay in the DOM and
+  // the right one shows at each width without any JS viewport detection.
+  const tableVisibility = computed(() => [
+    mobileView.value === 'table' ? 'max-lg:block' : 'max-lg:hidden',
+    desktopView.value === 'table' ? 'lg:block' : 'lg:hidden',
+  ])
+  const cardsVisibility = computed(() => [
+    mobileView.value === 'cards' ? 'max-lg:block' : 'max-lg:hidden',
+    desktopView.value === 'cards' ? 'lg:block' : 'lg:hidden',
+  ])
+
+  // Client-only breakpoint flag — used ONLY by the view toggle to know which
+  // breakpoint's preference to read/write. Rendering never depends on it, so it
+  // can't cause an SSR/hydration mismatch.
+  const isDesktop = ref(true)
+  const onViewportChange = (e: MediaQueryListEvent) => {
+    isDesktop.value = e.matches
+  }
+  let viewportMql: MediaQueryList | undefined
+  onMounted(() => {
+    viewportMql = window.matchMedia('(min-width: 1024px)')
+    isDesktop.value = viewportMql.matches
+    viewportMql.addEventListener('change', onViewportChange)
+  })
+  onUnmounted(() => viewportMql?.removeEventListener('change', onViewportChange))
+
+  const currentView = computed(() => (isDesktop.value ? desktopView.value : mobileView.value))
+  function setView(view: 'table' | 'cards') {
+    if (isDesktop.value) desktopView.value = view
+    else mobileView.value = view
+  }
+
   const page = ref(1)
   const debouncedSearch = ref('')
   const applyDebouncedSearch = debounce((value: string) => {
@@ -100,10 +141,16 @@
         rideSort: sort.value,
         rideAssignedToMeOnly: !isAdmin.value && assignedToMe.value,
         ridesPerPage: Number(pageSize.value),
+        ridesViewDesktop: desktopView.value,
+        ridesViewMobile: mobileView.value,
       },
     }).catch((err) => console.error('Failed to save preferences', err))
   }, 400)
-  watch([selectedStatuses, sort, assignedToMe, pageSize], () => savePreferences(), { deep: true })
+  watch(
+    [selectedStatuses, sort, assignedToMe, pageSize, desktopView, mobileView],
+    () => savePreferences(),
+    { deep: true }
+  )
 
   // One-time migration off the old cookie model: if the user has no saved DB
   // preference yet but a legacy cookie exists, convert it, persist once, and
@@ -434,20 +481,49 @@
                 </div>
               </template>
             </UPopover>
+
+            <!-- View toggle: rows (table) vs cards. Flips the CURRENT breakpoint's
+                 saved view. Client-only, so SSR/hydration stay clean — the actual
+                 rendering is CSS-driven off the saved prefs. -->
+            <ClientOnly>
+              <div
+                class="inline-flex items-center rounded-lg border border-gray-200 p-0.5 dark:border-gray-700"
+              >
+                <UButton
+                  icon="i-lucide-table"
+                  size="sm"
+                  square
+                  :color="currentView === 'table' ? 'primary' : 'neutral'"
+                  :variant="currentView === 'table' ? 'subtle' : 'ghost'"
+                  aria-label="Table view"
+                  @click="setView('table')"
+                />
+                <UButton
+                  icon="i-lucide-layout-grid"
+                  size="sm"
+                  square
+                  :color="currentView === 'cards' ? 'primary' : 'neutral'"
+                  :variant="currentView === 'cards' ? 'subtle' : 'ghost'"
+                  aria-label="Card view"
+                  @click="setView('cards')"
+                />
+              </div>
+            </ClientOnly>
           </div>
         </div>
 
-        <!-- Scroll region: table (desktop) / cards (mobile) scroll here, beneath
-             the pinned pagination footer below. -->
-        <div class="min-h-0 flex-1 overflow-y-auto">
-          <!-- Desktop (lg+): the full table with a sticky header. Below lg it would
-               overflow sideways, so the ride cards render instead. -->
+        <!-- Scroll region: the chosen view (table or cards) scrolls here beneath
+             the pinned pagination footer. overflow-auto so a table can scroll
+             sideways when shown on a narrow (mobile) width. -->
+        <div class="min-h-0 flex-1 overflow-auto">
+          <!-- Table view (sticky header). Shown per the saved per-breakpoint
+               preference; on a narrow width it scrolls horizontally. -->
           <UTable
             :data="rides"
             :columns="columns"
             :loading="status === 'pending'"
             sticky
-            class="hidden w-full cursor-pointer lg:block"
+            :class="['w-full cursor-pointer', tableVisibility]"
             @select="onSelect"
           >
             <template #empty-state>
@@ -461,10 +537,13 @@
             </template>
           </UTable>
 
-          <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
-         same navigation target — only the presentation differs. -->
-          <div class="lg:hidden">
-            <div v-if="status === 'pending'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <!-- Card view: each ride as a tap-friendly card. Same data + navigation
+               as the table; shown per the saved per-breakpoint preference. -->
+          <div :class="cardsVisibility">
+            <div
+              v-if="status === 'pending'"
+              class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+            >
               <USkeleton v-for="n in 4" :key="n" class="h-44 w-full rounded-xl" />
             </div>
 
@@ -477,7 +556,7 @@
               <p class="text-sm">Try adjusting your search or filters</p>
             </div>
 
-            <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
               <NuxtLink
                 v-for="ride in rides"
                 :key="ride.id"

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
   import { h, resolveComponent } from 'vue'
   import type { TableColumn, TableRow } from '@nuxt/ui'
-  import * as z from 'zod'
   import { authClient } from '../../utils/auth-client'
   import {
     RIDE_STATUS_OPTIONS,
@@ -126,7 +125,7 @@
     legacySort.value = null
   })
 
-  const isCreateModalOpen = ref(false)
+  const isCreateOpen = ref(false)
 
   function toggleStatus(value: string) {
     selectedStatuses.value = selectedStatuses.value.includes(value)
@@ -187,130 +186,6 @@
   function clearDateRange() {
     startDate.value = ''
     endDate.value = ''
-  }
-
-  // --- Schema ---
-  const addressSchema = z.object({
-    street: z.string().min(1, 'Street is required'),
-    city: z.string().min(1, 'City is required'),
-    state: z.string().min(1, 'State is required'),
-    zip: z.string().min(1, 'Zip is required'),
-  })
-
-  const schema = z.object({
-    clientId: z.string().min(1, 'Client is required'),
-    pickup: addressSchema,
-    dropoff: addressSchema,
-    scheduledTime: z.string().min(1, 'Date is required'),
-    pickupTime: z.string().optional(),
-    notes: z.string().optional(),
-    volunteerId: z.any().optional(),
-  })
-
-  // --- State ---
-  const state = reactive(blankRideForm())
-
-  // --- Autocomplete Logic ---
-  // Query the backend with `?search=` (debounced) instead of fetching a fixed
-  // list of 20 once on mount and filtering it client-side. This lets any address
-  // in the table surface, not just the first 20 alphabetically (issue #19). The
-  // query-building and debounce logic live in a pure, unit-tested helper.
-  const pickupSearch = ref('')
-  const dropoffSearch = ref('')
-
-  const pickupOptions = ref<any[]>([])
-  const dropoffOptions = ref<any[]>([])
-
-  async function fetchAddressOptions(search: string, target: Ref<any[]>) {
-    const query = buildAddressQuery(search)
-    if (!query) {
-      target.value = []
-      return
-    }
-    try {
-      const results = await $fetch<any[]>('/api/get/addresses', { query })
-      // Ignore stale responses: only apply if the input still matches the term
-      // we searched for (avoids out-of-order results overwriting newer ones).
-      if ((search ?? '').trim() === query.search) {
-        target.value = (results ?? []).slice(0, 5)
-      }
-    } catch (err) {
-      console.error('Failed to fetch address suggestions', err)
-      target.value = []
-    }
-  }
-
-  const debouncedPickupFetch = debounce(
-    (search: string) => fetchAddressOptions(search, pickupOptions),
-    250
-  )
-  const debouncedDropoffFetch = debounce(
-    (search: string) => fetchAddressOptions(search, dropoffOptions),
-    250
-  )
-
-  watch(pickupSearch, (term) => {
-    if (!buildAddressQuery(term)) {
-      // Clear immediately (and cancel any pending fetch) when the box empties.
-      debouncedPickupFetch.cancel()
-      pickupOptions.value = []
-      return
-    }
-    debouncedPickupFetch(term)
-  })
-
-  watch(dropoffSearch, (term) => {
-    if (!buildAddressQuery(term)) {
-      debouncedDropoffFetch.cancel()
-      dropoffOptions.value = []
-      return
-    }
-    debouncedDropoffFetch(term)
-  })
-
-  const volunteerOptions = computed(() => {
-    if (!volunteers.value) return []
-    const list = volunteers.value.map((v: any) => ({
-      label: v.name || 'Unknown Volunteer',
-      value: v.id,
-    }))
-    return [{ label: 'Unassigned', value: '' }, ...list]
-  })
-
-  watch(
-    () => state.clientId,
-    (newId) => {
-      if (!newId || !clients.value) return
-      const client = clients.value.find((c: any) => c.id === newId)
-      if (client?.homeAddress) {
-        Object.assign(state.pickup, {
-          street: client.homeAddress.street,
-          city: client.homeAddress.city,
-          state: client.homeAddress.state,
-          zip: client.homeAddress.zip,
-        })
-      }
-    }
-  )
-
-  function onPickupSelect(opt: any) {
-    Object.assign(state.pickup, {
-      street: opt.address.street,
-      city: opt.address.city,
-      state: opt.address.state,
-      zip: opt.address.zip,
-    })
-    pickupSearch.value = ''
-  }
-
-  function onDropoffSelect(opt: any) {
-    Object.assign(state.dropoff, {
-      street: opt.address.street,
-      city: opt.address.city,
-      state: opt.address.state,
-      zip: opt.address.zip,
-    })
-    dropoffSearch.value = ''
   }
 
   // Filtering, searching, date-range and sorting are all applied server-side
@@ -445,48 +320,11 @@
     await navigateTo(`/rides/${row.original.id}`)
   }
 
-  async function onSubmit(event: any) {
-    try {
-      // Convert local datetime-local string to ISO string (UTC)
-      const scheduledTimeISO = new Date(event.data.scheduledTime).toISOString()
-      const pickupTimeISO = event.data.pickupTime
-        ? new Date(event.data.pickupTime).toISOString()
-        : undefined
-
-      // Handle volunteerId being an object or string
-      const vId =
-        typeof event.data.volunteerId === 'object'
-          ? event.data.volunteerId.value
-          : event.data.volunteerId
-
-      await $fetch('/api/post/rides', {
-        method: 'POST',
-        body: {
-          ...event.data,
-          volunteerId: vId,
-          scheduledTime: scheduledTimeISO,
-          pickupTime: pickupTimeISO,
-        },
-      })
-      isCreateModalOpen.value = false
-      await refreshRides()
-      // Reset state back to a blank form. Assign into the nested pickup/dropoff
-      // objects so the reactive references are preserved and the address fields
-      // actually clear (issue #11 — the old reset used non-existent
-      // `pickupDisplay`/`dropoffDisplay` keys and never cleared the addresses).
-      const blank = blankRideForm()
-      Object.assign(state.pickup, blank.pickup)
-      Object.assign(state.dropoff, blank.dropoff)
-      state.clientId = blank.clientId
-      state.scheduledTime = blank.scheduledTime
-      state.pickupTime = blank.pickupTime
-      state.notes = blank.notes
-      state.volunteerId = blank.volunteerId
-      pickupSearch.value = ''
-      dropoffSearch.value = ''
-    } catch (err) {
-      console.error('Failed to create ride', err)
-    }
+  // The create wizard (RideCreatePanel) owns the form + POST; here we just close
+  // the pane and refresh the list so the new ride shows up.
+  async function onCreated() {
+    isCreateOpen.value = false
+    await refreshRides()
   }
 </script>
 
@@ -504,339 +342,216 @@
         label="Create Ride"
         icon="i-lucide-plus"
         color="primary"
-        @click="isCreateModalOpen = true"
+        @click="isCreateOpen = true"
       />
     </div>
 
-    <!-- Toolbar: search keeps the full row width; the filter controls group and
-         wrap together beside it on wide screens instead of each stacking into a
-         tall full-width column. -->
-    <div class="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center">
-      <UInput
-        v-model="search"
-        icon="i-lucide-search"
-        placeholder="Search rides..."
-        class="w-full lg:max-w-xs lg:flex-1"
-      />
-      <div class="flex flex-wrap items-center gap-2">
-        <!-- Status filter: toggle which statuses to show. Selecting none shows
+    <!-- Rides list, with the create wizard as a side pane on desktop / full-screen
+         overlay on mobile. When the pane is open, the list shrinks to make room. -->
+    <div class="lg:flex lg:items-start lg:gap-6">
+      <div :class="isCreateOpen ? 'min-w-0 lg:flex-1' : 'w-full'">
+        <!-- Toolbar: search keeps the full row width; the filter controls group
+             and wrap together beside it on wide screens instead of each stacking
+             into a tall full-width column. -->
+        <div class="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center">
+          <UInput
+            v-model="search"
+            icon="i-lucide-search"
+            placeholder="Search rides..."
+            class="w-full lg:max-w-xs lg:flex-1"
+          />
+          <div class="flex flex-wrap items-center gap-2">
+            <!-- Status filter: toggle which statuses to show. Selecting none shows
              all. The active chip takes its status' badge colour. -->
-        <div class="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by status">
-          <UButton
-            v-for="opt in RIDE_STATUS_OPTIONS"
-            :key="opt.value"
-            :label="opt.label"
-            size="sm"
-            :color="selectedStatuses.includes(opt.value) ? statusColor(opt.value) : 'neutral'"
-            :variant="selectedStatuses.includes(opt.value) ? 'subtle' : 'ghost'"
-            :aria-pressed="selectedStatuses.includes(opt.value)"
-            @click="toggleStatus(opt.value)"
-          />
-          <UButton
-            v-if="!isAdmin"
-            label="Assigned to me"
-            icon="i-lucide-user-check"
-            size="sm"
-            :color="assignedToMe ? 'primary' : 'neutral'"
-            :variant="assignedToMe ? 'subtle' : 'ghost'"
-            :aria-pressed="assignedToMe"
-            @click="assignedToMe = !assignedToMe"
-          />
-        </div>
+            <div
+              class="flex flex-wrap items-center gap-1.5"
+              role="group"
+              aria-label="Filter by status"
+            >
+              <UButton
+                v-for="opt in RIDE_STATUS_OPTIONS"
+                :key="opt.value"
+                :label="opt.label"
+                size="sm"
+                :color="selectedStatuses.includes(opt.value) ? statusColor(opt.value) : 'neutral'"
+                :variant="selectedStatuses.includes(opt.value) ? 'subtle' : 'ghost'"
+                :aria-pressed="selectedStatuses.includes(opt.value)"
+                @click="toggleStatus(opt.value)"
+              />
+              <UButton
+                v-if="!isAdmin"
+                label="Assigned to me"
+                icon="i-lucide-user-check"
+                size="sm"
+                :color="assignedToMe ? 'primary' : 'neutral'"
+                :variant="assignedToMe ? 'subtle' : 'ghost'"
+                :aria-pressed="assignedToMe"
+                @click="assignedToMe = !assignedToMe"
+              />
+            </div>
 
-        <USelect
-          v-model="sort"
-          size="sm"
-          :items="[
-            { label: 'Oldest First', value: 'asc' },
-            { label: 'Newest First', value: 'desc' },
-          ]"
-          class="w-full sm:w-40"
-        />
+            <USelect
+              v-model="sort"
+              size="sm"
+              :items="[
+                { label: 'Oldest First', value: 'asc' },
+                { label: 'Newest First', value: 'desc' },
+              ]"
+              class="w-full sm:w-40"
+            />
 
-        <!-- Date range: one control reading "All dates" when unset; opens the
+            <!-- Date range: one control reading "All dates" when unset; opens the
              From/To pickers in a popover. This filter is transient (per-visit),
              not persisted like status/sort. -->
-        <UPopover>
-          <UButton
-            icon="i-lucide-calendar"
-            :label="dateRangeLabel"
-            size="sm"
-            color="neutral"
-            variant="outline"
-            :class="{ 'text-primary font-medium': startDate || endDate }"
-          />
-          <template #content>
-            <div class="w-72 max-w-[calc(100vw-2rem)] space-y-3 p-3">
-              <UFormField label="From">
-                <UInput v-model="startDate" type="date" class="w-full" />
-              </UFormField>
-              <UFormField label="To">
-                <UInput v-model="endDate" type="date" class="w-full" />
-              </UFormField>
-              <div class="flex justify-end">
-                <UButton
-                  label="Clear"
-                  size="sm"
-                  color="neutral"
-                  variant="ghost"
-                  :disabled="!startDate && !endDate"
-                  @click="clearDateRange"
-                />
-              </div>
+            <UPopover>
+              <UButton
+                icon="i-lucide-calendar"
+                :label="dateRangeLabel"
+                size="sm"
+                color="neutral"
+                variant="outline"
+                :class="{ 'text-primary font-medium': startDate || endDate }"
+              />
+              <template #content>
+                <div class="w-72 max-w-[calc(100vw-2rem)] space-y-3 p-3">
+                  <UFormField label="From">
+                    <UInput v-model="startDate" type="date" class="w-full" />
+                  </UFormField>
+                  <UFormField label="To">
+                    <UInput v-model="endDate" type="date" class="w-full" />
+                  </UFormField>
+                  <div class="flex justify-end">
+                    <UButton
+                      label="Clear"
+                      size="sm"
+                      color="neutral"
+                      variant="ghost"
+                      :disabled="!startDate && !endDate"
+                      @click="clearDateRange"
+                    />
+                  </div>
+                </div>
+              </template>
+            </UPopover>
+          </div>
+        </div>
+
+        <!-- Desktop (lg+): the full table. Below lg it would overflow sideways, so
+         it's hidden in favour of the ride cards below. -->
+        <UTable
+          :data="rides"
+          :columns="columns"
+          :loading="status === 'pending'"
+          class="hidden w-full cursor-pointer lg:block"
+          @select="onSelect"
+        >
+          <template #empty-state>
+            <div class="flex flex-col items-center justify-center py-12 text-center text-gray-500">
+              <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
+              <p class="font-medium">No rides found</p>
+              <p class="text-sm">Try adjusting your search or filters</p>
             </div>
           </template>
-        </UPopover>
-      </div>
-    </div>
+        </UTable>
 
-    <!-- Desktop (lg+): the full table. Below lg it would overflow sideways, so
-         it's hidden in favour of the ride cards below. -->
-    <UTable
-      :data="rides"
-      :columns="columns"
-      :loading="status === 'pending'"
-      class="hidden w-full cursor-pointer lg:block"
-      @select="onSelect"
-    >
-      <template #empty-state>
-        <div class="flex flex-col items-center justify-center py-12 text-center text-gray-500">
-          <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
-          <p class="font-medium">No rides found</p>
-          <p class="text-sm">Try adjusting your search or filters</p>
-        </div>
-      </template>
-    </UTable>
-
-    <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
+        <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
          same navigation target — only the presentation differs. -->
-    <div class="lg:hidden">
-      <div v-if="status === 'pending'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <USkeleton v-for="n in 4" :key="n" class="h-44 w-full rounded-xl" />
-      </div>
-
-      <div
-        v-else-if="rides.length === 0"
-        class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200 py-16 text-center text-gray-500 dark:border-gray-700"
-      >
-        <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
-        <p class="font-medium">No rides found</p>
-        <p class="text-sm">Try adjusting your search or filters</p>
-      </div>
-
-      <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <NuxtLink
-          v-for="ride in rides"
-          :key="ride.id"
-          :to="`/rides/${ride.id}`"
-          class="focus-visible:ring-primary block rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 focus:outline-none focus-visible:ring-2 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
-        >
-          <div class="mb-2 flex items-center justify-between gap-2">
-            <UBadge :color="statusColor(ride.status)" variant="subtle" class="capitalize">
-              {{ ride.status }}
-            </UBadge>
-            <span class="text-xs font-medium text-gray-500">
-              {{
-                formatDateTime(ride.scheduledTime, {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })
-              }}
-            </span>
-          </div>
-
-          <p class="font-semibold text-gray-900 dark:text-white">
-            {{ ride.client?.user?.name }}
-          </p>
-
-          <div class="mt-3 space-y-1.5">
-            <div class="flex items-start gap-2">
-              <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
-              <span class="text-sm text-gray-600 dark:text-gray-300">{{ ride.pickupDisplay }}</span>
-            </div>
-            <div class="flex items-start gap-2">
-              <UIcon name="i-lucide-flag" class="text-error mt-0.5 size-4 shrink-0" />
-              <span class="text-sm text-gray-600 dark:text-gray-300">{{
-                ride.dropoffDisplay
-              }}</span>
-            </div>
+        <div class="lg:hidden">
+          <div v-if="status === 'pending'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <USkeleton v-for="n in 4" :key="n" class="h-44 w-full rounded-xl" />
           </div>
 
           <div
-            class="mt-3 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-800"
+            v-else-if="rides.length === 0"
+            class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200 py-16 text-center text-gray-500 dark:border-gray-700"
           >
-            <span
-              v-if="ride.volunteer?.user?.name"
-              class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
-            >
-              <span
-                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-              >
-                {{ initials(ride.volunteer.user.name) }}
-              </span>
-              {{ ride.volunteer.user.name }}
-            </span>
-            <span v-else class="text-sm text-gray-400 italic">Unassigned</span>
-            <UIcon name="i-lucide-chevron-right" class="size-4 text-gray-400" />
+            <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
+            <p class="font-medium">No rides found</p>
+            <p class="text-sm">Try adjusting your search or filters</p>
           </div>
-        </NuxtLink>
+
+          <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <NuxtLink
+              v-for="ride in rides"
+              :key="ride.id"
+              :to="`/rides/${ride.id}`"
+              class="focus-visible:ring-primary block rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 focus:outline-none focus-visible:ring-2 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
+            >
+              <div class="mb-2 flex items-center justify-between gap-2">
+                <UBadge :color="statusColor(ride.status)" variant="subtle" class="capitalize">
+                  {{ ride.status }}
+                </UBadge>
+                <span class="text-xs font-medium text-gray-500">
+                  {{
+                    formatDateTime(ride.scheduledTime, {
+                      weekday: 'short',
+                      month: 'short',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })
+                  }}
+                </span>
+              </div>
+
+              <p class="font-semibold text-gray-900 dark:text-white">
+                {{ ride.client?.user?.name }}
+              </p>
+
+              <div class="mt-3 space-y-1.5">
+                <div class="flex items-start gap-2">
+                  <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
+                  <span class="text-sm text-gray-600 dark:text-gray-300">{{
+                    ride.pickupDisplay
+                  }}</span>
+                </div>
+                <div class="flex items-start gap-2">
+                  <UIcon name="i-lucide-flag" class="text-error mt-0.5 size-4 shrink-0" />
+                  <span class="text-sm text-gray-600 dark:text-gray-300">{{
+                    ride.dropoffDisplay
+                  }}</span>
+                </div>
+              </div>
+
+              <div
+                class="mt-3 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-800"
+              >
+                <span
+                  v-if="ride.volunteer?.user?.name"
+                  class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+                >
+                  <span
+                    class="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                  >
+                    {{ initials(ride.volunteer.user.name) }}
+                  </span>
+                  {{ ride.volunteer.user.name }}
+                </span>
+                <span v-else class="text-sm text-gray-400 italic">Unassigned</span>
+                <UIcon name="i-lucide-chevron-right" class="size-4 text-gray-400" />
+              </div>
+            </NuxtLink>
+          </div>
+        </div>
+
+        <div v-if="total > PAGE_SIZE" class="mt-4 flex justify-end">
+          <UPagination v-model:page="page" :total="total" :items-per-page="PAGE_SIZE" />
+        </div>
+      </div>
+
+      <!-- Create pane: a side pane beside the list on desktop, a full-screen
+           overlay below lg. The RideCreatePanel wizard is the same either way. -->
+      <div
+        v-if="isCreateOpen"
+        class="max-lg:fixed max-lg:inset-0 max-lg:z-50 lg:sticky lg:top-6 lg:h-[calc(100vh-8rem)] lg:w-[400px] lg:flex-none lg:self-start"
+      >
+        <RideCreatePanel
+          :clients="clients"
+          :volunteers="volunteers"
+          @created="onCreated"
+          @close="isCreateOpen = false"
+        />
       </div>
     </div>
-
-    <div v-if="total > PAGE_SIZE" class="mt-4 flex justify-end">
-      <UPagination v-model:page="page" :total="total" :items-per-page="PAGE_SIZE" />
-    </div>
-
-    <!-- Create Ride Modal -->
-    <UModal v-model:open="isCreateModalOpen" title="Create New Ride">
-      <template #content>
-        <div class="max-h-[70vh] overflow-y-auto p-4">
-          <UForm :schema="schema" :state="state" class="space-y-4" @submit="onSubmit">
-            <UFormField label="Client" name="clientId">
-              <USelect
-                v-model="state.clientId"
-                :items="clients?.map((c) => ({ label: c.name, value: c.id })) || []"
-                placeholder="Select a client"
-                class="w-full"
-              />
-            </UFormField>
-
-            <div class="space-y-2 rounded-lg border p-4 dark:border-gray-700">
-              <h3 class="text-sm font-bold text-gray-700 dark:text-gray-300">Pickup Address</h3>
-
-              <!-- Custom Autocomplete -->
-              <div class="relative mb-2">
-                <UInput
-                  v-model="pickupSearch"
-                  placeholder="Type to find existing address (e.g. Street)..."
-                  icon="i-lucide-search"
-                  autocomplete="off"
-                  class="w-full"
-                />
-                <div
-                  v-if="pickupOptions?.length > 0 && pickupSearch"
-                  class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
-                >
-                  <button
-                    v-for="opt in pickupOptions"
-                    :key="opt.id"
-                    type="button"
-                    class="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
-                    @click="onPickupSelect(opt)"
-                  >
-                    {{ opt.label }}
-                  </button>
-                </div>
-              </div>
-
-              <UFormField label="Street" name="pickup.street">
-                <UInput v-model="state.pickup.street" placeholder="Street Address" class="w-full" />
-              </UFormField>
-              <div class="grid grid-cols-3 gap-2">
-                <UFormField label="City" name="pickup.city"
-                  ><UInput v-model="state.pickup.city" placeholder="City"
-                /></UFormField>
-                <UFormField label="State" name="pickup.state"
-                  ><UInput v-model="state.pickup.state" placeholder="State"
-                /></UFormField>
-                <UFormField label="Zip" name="pickup.zip"
-                  ><UInput v-model="state.pickup.zip" placeholder="Zip"
-                /></UFormField>
-              </div>
-            </div>
-
-            <div class="space-y-2 rounded-lg border p-4 dark:border-gray-700">
-              <h3 class="text-sm font-bold text-gray-700 dark:text-gray-300">Dropoff Address</h3>
-
-              <!-- Custom Autocomplete -->
-              <div class="relative mb-2">
-                <UInput
-                  v-model="dropoffSearch"
-                  placeholder="Type to find existing address (e.g. Street)..."
-                  icon="i-lucide-search"
-                  autocomplete="off"
-                  class="w-full"
-                />
-                <div
-                  v-if="dropoffOptions?.length > 0 && dropoffSearch"
-                  class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
-                >
-                  <button
-                    v-for="opt in dropoffOptions"
-                    :key="opt.id"
-                    type="button"
-                    class="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
-                    @click="onDropoffSelect(opt)"
-                  >
-                    {{ opt.label }}
-                  </button>
-                </div>
-              </div>
-
-              <UFormField label="Street" name="dropoff.street">
-                <UInput
-                  v-model="state.dropoff.street"
-                  placeholder="Street Address"
-                  class="w-full"
-                />
-              </UFormField>
-              <div class="grid grid-cols-3 gap-2">
-                <UFormField label="City" name="dropoff.city"
-                  ><UInput v-model="state.dropoff.city" placeholder="City"
-                /></UFormField>
-                <UFormField label="State" name="dropoff.state"
-                  ><UInput v-model="state.dropoff.state" placeholder="State"
-                /></UFormField>
-                <UFormField label="Zip" name="dropoff.zip"
-                  ><UInput v-model="state.dropoff.zip" placeholder="Zip"
-                /></UFormField>
-              </div>
-            </div>
-
-            <UFormField label="Volunteer" name="volunteerId" v-if="isAdmin">
-              <USelectMenu
-                v-model="state.volunteerId"
-                :items="volunteerOptions"
-                placeholder="Select a volunteer"
-                class="w-full"
-                searchable
-                option-attribute="label"
-              />
-            </UFormField>
-
-            <div class="grid grid-cols-2 gap-4">
-              <UFormField label="Appointment Time" name="scheduledTime">
-                <UInput v-model="state.scheduledTime" type="datetime-local" class="w-full" />
-              </UFormField>
-
-              <UFormField label="Pick Up Time (Optional)" name="pickupTime">
-                <UInput v-model="state.pickupTime" type="datetime-local" class="w-full" />
-              </UFormField>
-            </div>
-
-            <UFormField label="Notes" name="notes">
-              <UTextarea
-                v-model="state.notes"
-                placeholder="Additional instructions..."
-                class="w-full"
-              />
-            </UFormField>
-
-            <div class="flex justify-end gap-2 pt-4">
-              <UButton
-                label="Cancel"
-                color="neutral"
-                variant="ghost"
-                @click="isCreateModalOpen = false"
-              />
-              <UButton type="submit" label="Create" color="primary" />
-            </div>
-          </UForm>
-        </div>
-      </template>
-    </UModal>
   </UContainer>
 </template>

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -354,12 +354,12 @@
       <div class="flex min-h-0 min-w-0 flex-1 flex-col">
         <!-- Toolbar: search keeps the row width; filter controls group and wrap
              beside it on wide screens instead of stacking into a tall column. -->
-        <div class="mb-3 flex shrink-0 flex-col gap-3 lg:flex-row lg:items-center">
+        <div class="mb-3 flex shrink-0 flex-col gap-3">
           <UInput
             v-model="search"
             icon="i-lucide-search"
             placeholder="Search rides..."
-            class="w-full lg:max-w-xs lg:flex-1"
+            class="w-full"
           />
           <div class="flex flex-wrap items-center gap-2">
             <!-- Status filter: toggle which statuses to show. Selecting none shows
@@ -554,15 +554,11 @@
             class="w-28"
           />
           <UPagination
-            v-if="total > Number(pageSize)"
             v-model:page="page"
             :total="total"
             :items-per-page="Number(pageSize)"
             size="sm"
           />
-          <span v-else class="text-xs text-gray-500"
-            >{{ total }} {{ total === 1 ? 'ride' : 'rides' }}</span
-          >
         </div>
       </div>
 

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -44,7 +44,8 @@
   // Filtering, sorting and pagination all happen on the server so the table
   // binds directly to the returned page. Debounce search so typing doesn't fire
   // a request per keystroke.
-  const PAGE_SIZE = 20
+  const PAGE_SIZE_OPTIONS = [5, 10, 20, 50]
+  const pageSize = ref<number>(prefs.value?.ridesPerPage ?? 10)
   const page = ref(1)
   const debouncedSearch = ref('')
   const applyDebouncedSearch = debounce((value: string) => {
@@ -71,7 +72,7 @@
     query: {
       sort,
       page,
-      pageSize: PAGE_SIZE,
+      pageSize,
       search: computed(() => debouncedSearch.value || undefined),
       startDate: computed(() => startDate.value || undefined),
       endDate: computed(() => endDate.value || undefined),
@@ -84,7 +85,7 @@
 
   // Any filter/search/sort change should return to the first page so results
   // aren't hidden on a page that no longer exists.
-  watch([debouncedSearch, startDate, endDate, includeParam, sort], () => {
+  watch([debouncedSearch, startDate, endDate, includeParam, sort, pageSize], () => {
     page.value = 1
   })
 
@@ -98,10 +99,11 @@
         rideStatusFilter: sanitizeStatuses(selectedStatuses.value),
         rideSort: sort.value,
         rideAssignedToMeOnly: !isAdmin.value && assignedToMe.value,
+        ridesPerPage: Number(pageSize.value),
       },
     }).catch((err) => console.error('Failed to save preferences', err))
   }, 400)
-  watch([selectedStatuses, sort, assignedToMe], () => savePreferences(), { deep: true })
+  watch([selectedStatuses, sort, assignedToMe, pageSize], () => savePreferences(), { deep: true })
 
   // One-time migration off the old cookie model: if the user has no saved DB
   // preference yet but a legacy cookie exists, convert it, persist once, and
@@ -329,10 +331,9 @@
 </script>
 
 <template>
-  <UContainer class="py-10">
-    <!-- Page header: title + live result count, with Create Ride inline (was a
-         lone right-aligned button on its own row). -->
-    <div class="mb-6 flex items-end justify-between gap-4">
+  <UContainer class="flex h-[calc(100dvh-var(--ui-header-height))] flex-col overflow-hidden py-6">
+    <!-- Page header: title + live result count, with Create Ride inline. -->
+    <div class="mb-4 flex shrink-0 items-end justify-between gap-4">
       <div>
         <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Rides</h1>
         <p class="mt-1 text-sm text-gray-500">{{ total }} {{ total === 1 ? 'ride' : 'rides' }}</p>
@@ -346,14 +347,14 @@
       />
     </div>
 
-    <!-- Rides list, with the create wizard as a side pane on desktop / full-screen
-         overlay on mobile. When the pane is open, the list shrinks to make room. -->
-    <div class="lg:flex lg:items-start lg:gap-6">
-      <div :class="isCreateOpen ? 'min-w-0 lg:flex-1' : 'w-full'">
-        <!-- Toolbar: search keeps the full row width; the filter controls group
-             and wrap together beside it on wide screens instead of each stacking
-             into a tall full-width column. -->
-        <div class="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center">
+    <!-- Rides list + create pane. Bounded to the viewport: the list region scrolls
+         internally under a pinned pagination footer, so the page itself never
+         scrolls. Pane is a side column on desktop / full-screen overlay on mobile. -->
+    <div class="flex min-h-0 flex-1 flex-col gap-4 lg:flex-row lg:gap-6">
+      <div class="flex min-h-0 min-w-0 flex-1 flex-col">
+        <!-- Toolbar: search keeps the row width; filter controls group and wrap
+             beside it on wide screens instead of stacking into a tall column. -->
+        <div class="mb-3 flex shrink-0 flex-col gap-3 lg:flex-row lg:items-center">
           <UInput
             v-model="search"
             icon="i-lucide-search"
@@ -436,106 +437,132 @@
           </div>
         </div>
 
-        <!-- Desktop (lg+): the full table. Below lg it would overflow sideways, so
-         it's hidden in favour of the ride cards below. -->
-        <UTable
-          :data="rides"
-          :columns="columns"
-          :loading="status === 'pending'"
-          class="hidden w-full cursor-pointer lg:block"
-          @select="onSelect"
-        >
-          <template #empty-state>
-            <div class="flex flex-col items-center justify-center py-12 text-center text-gray-500">
+        <!-- Scroll region: table (desktop) / cards (mobile) scroll here, beneath
+             the pinned pagination footer below. -->
+        <div class="min-h-0 flex-1 overflow-y-auto">
+          <!-- Desktop (lg+): the full table with a sticky header. Below lg it would
+               overflow sideways, so the ride cards render instead. -->
+          <UTable
+            :data="rides"
+            :columns="columns"
+            :loading="status === 'pending'"
+            sticky
+            class="hidden w-full cursor-pointer lg:block"
+            @select="onSelect"
+          >
+            <template #empty-state>
+              <div
+                class="flex flex-col items-center justify-center py-12 text-center text-gray-500"
+              >
+                <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
+                <p class="font-medium">No rides found</p>
+                <p class="text-sm">Try adjusting your search or filters</p>
+              </div>
+            </template>
+          </UTable>
+
+          <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
+         same navigation target — only the presentation differs. -->
+          <div class="lg:hidden">
+            <div v-if="status === 'pending'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <USkeleton v-for="n in 4" :key="n" class="h-44 w-full rounded-xl" />
+            </div>
+
+            <div
+              v-else-if="rides.length === 0"
+              class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200 py-16 text-center text-gray-500 dark:border-gray-700"
+            >
               <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
               <p class="font-medium">No rides found</p>
               <p class="text-sm">Try adjusting your search or filters</p>
             </div>
-          </template>
-        </UTable>
 
-        <!-- Mobile / tablet (below lg): each ride as a tap-friendly card. Same data,
-         same navigation target — only the presentation differs. -->
-        <div class="lg:hidden">
-          <div v-if="status === 'pending'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <USkeleton v-for="n in 4" :key="n" class="h-44 w-full rounded-xl" />
-          </div>
-
-          <div
-            v-else-if="rides.length === 0"
-            class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200 py-16 text-center text-gray-500 dark:border-gray-700"
-          >
-            <UIcon name="i-lucide-calendar-x" class="mb-2 size-8 text-gray-400" />
-            <p class="font-medium">No rides found</p>
-            <p class="text-sm">Try adjusting your search or filters</p>
-          </div>
-
-          <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <NuxtLink
-              v-for="ride in rides"
-              :key="ride.id"
-              :to="`/rides/${ride.id}`"
-              class="focus-visible:ring-primary block rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 focus:outline-none focus-visible:ring-2 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
-            >
-              <div class="mb-2 flex items-center justify-between gap-2">
-                <UBadge :color="statusColor(ride.status)" variant="subtle" class="capitalize">
-                  {{ ride.status }}
-                </UBadge>
-                <span class="text-xs font-medium text-gray-500">
-                  {{
-                    formatDateTime(ride.scheduledTime, {
-                      weekday: 'short',
-                      month: 'short',
-                      day: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })
-                  }}
-                </span>
-              </div>
-
-              <p class="font-semibold text-gray-900 dark:text-white">
-                {{ ride.client?.user?.name }}
-              </p>
-
-              <div class="mt-3 space-y-1.5">
-                <div class="flex items-start gap-2">
-                  <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
-                  <span class="text-sm text-gray-600 dark:text-gray-300">{{
-                    ride.pickupDisplay
-                  }}</span>
-                </div>
-                <div class="flex items-start gap-2">
-                  <UIcon name="i-lucide-flag" class="text-error mt-0.5 size-4 shrink-0" />
-                  <span class="text-sm text-gray-600 dark:text-gray-300">{{
-                    ride.dropoffDisplay
-                  }}</span>
-                </div>
-              </div>
-
-              <div
-                class="mt-3 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-800"
+            <div v-else class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <NuxtLink
+                v-for="ride in rides"
+                :key="ride.id"
+                :to="`/rides/${ride.id}`"
+                class="focus-visible:ring-primary block rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 focus:outline-none focus-visible:ring-2 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
               >
-                <span
-                  v-if="ride.volunteer?.user?.name"
-                  class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+                <div class="mb-2 flex items-center justify-between gap-2">
+                  <UBadge :color="statusColor(ride.status)" variant="subtle" class="capitalize">
+                    {{ ride.status }}
+                  </UBadge>
+                  <span class="text-xs font-medium text-gray-500">
+                    {{
+                      formatDateTime(ride.scheduledTime, {
+                        weekday: 'short',
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })
+                    }}
+                  </span>
+                </div>
+
+                <p class="font-semibold text-gray-900 dark:text-white">
+                  {{ ride.client?.user?.name }}
+                </p>
+
+                <div class="mt-3 space-y-1.5">
+                  <div class="flex items-start gap-2">
+                    <UIcon name="i-lucide-map-pin" class="text-primary mt-0.5 size-4 shrink-0" />
+                    <span class="text-sm text-gray-600 dark:text-gray-300">{{
+                      ride.pickupDisplay
+                    }}</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <UIcon name="i-lucide-flag" class="text-error mt-0.5 size-4 shrink-0" />
+                    <span class="text-sm text-gray-600 dark:text-gray-300">{{
+                      ride.dropoffDisplay
+                    }}</span>
+                  </div>
+                </div>
+
+                <div
+                  class="mt-3 flex items-center justify-between border-t border-gray-100 pt-3 dark:border-gray-800"
                 >
                   <span
-                    class="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                    v-if="ride.volunteer?.user?.name"
+                    class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
                   >
-                    {{ initials(ride.volunteer.user.name) }}
+                    <span
+                      class="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                    >
+                      {{ initials(ride.volunteer.user.name) }}
+                    </span>
+                    {{ ride.volunteer.user.name }}
                   </span>
-                  {{ ride.volunteer.user.name }}
-                </span>
-                <span v-else class="text-sm text-gray-400 italic">Unassigned</span>
-                <UIcon name="i-lucide-chevron-right" class="size-4 text-gray-400" />
-              </div>
-            </NuxtLink>
+                  <span v-else class="text-sm text-gray-400 italic">Unassigned</span>
+                  <UIcon name="i-lucide-chevron-right" class="size-4 text-gray-400" />
+                </div>
+              </NuxtLink>
+            </div>
           </div>
         </div>
 
-        <div v-if="total > PAGE_SIZE" class="mt-4 flex justify-end">
-          <UPagination v-model:page="page" :total="total" :items-per-page="PAGE_SIZE" />
+        <!-- Pinned pagination footer: rows-per-page selector + page nav; stays put
+             while the rows scroll under it. -->
+        <div
+          class="mt-3 flex shrink-0 items-center justify-between gap-3 border-t border-gray-200 pt-3 dark:border-gray-800"
+        >
+          <USelect
+            v-model="pageSize"
+            :items="PAGE_SIZE_OPTIONS.map((n) => ({ label: `${n} / page`, value: n }))"
+            size="sm"
+            class="w-28"
+          />
+          <UPagination
+            v-if="total > Number(pageSize)"
+            v-model:page="page"
+            :total="total"
+            :items-per-page="Number(pageSize)"
+            size="sm"
+          />
+          <span v-else class="text-xs text-gray-500"
+            >{{ total }} {{ total === 1 ? 'ride' : 'rides' }}</span
+          >
         </div>
       </div>
 
@@ -543,7 +570,7 @@
            overlay below lg. The RideCreatePanel wizard is the same either way. -->
       <div
         v-if="isCreateOpen"
-        class="max-lg:fixed max-lg:inset-0 max-lg:z-50 lg:sticky lg:top-6 lg:h-[calc(100vh-8rem)] lg:w-[400px] lg:flex-none lg:self-start"
+        class="max-lg:fixed max-lg:inset-0 max-lg:z-50 lg:h-full lg:w-[400px] lg:flex-none"
       >
         <RideCreatePanel
           :clients="clients"

--- a/app/plugins/clock.client.ts
+++ b/app/plugins/clock.client.ts
@@ -1,0 +1,17 @@
+import { clockHour12 } from '../utils/datetime'
+
+// Detect the viewer's 12h/24h clock preference and share it with formatDateTime
+// (app/utils/datetime.ts). Runs on the client only, AFTER the app is mounted, so
+// the first client render still matches the server's en-US default (12h) — no
+// hydration mismatch — and times then re-render in the user's preferred cycle.
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('app:mounted', () => {
+    try {
+      const cycle = new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions()
+        .hourCycle
+      clockHour12.value = cycle === 'h11' || cycle === 'h12'
+    } catch {
+      // Fall back to the 12h default if the environment can't report a cycle.
+    }
+  })
+})

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -17,19 +17,30 @@
  * server/utils/datetime.ts (issue #9).
  */
 
+import { ref } from 'vue'
+
 export const APP_TIME_ZONE = 'America/Chicago'
+
+// The viewer's 12h/24h clock preference, detected on the client AFTER hydration
+// (plugins/clock.client.ts). Left undefined on the server and during the first
+// client render so SSR and hydration agree on the en-US default (12h); once set,
+// time displays reactively re-render in the user's preferred cycle. A Vue ref
+// (never mutated on the server) so it can't leak across SSR requests.
+export const clockHour12 = ref<boolean | undefined>(undefined)
 
 /**
  * Format an instant in the app's fixed locale + timezone. Extra
  * `Intl.DateTimeFormatOptions` are merged in so each call site keeps its own
- * date/time style; only the locale and timezone are forced.
+ * date/time style; only the locale and timezone are forced. The hour cycle
+ * follows the viewer's system preference once detected (12h by default).
  */
 export function formatDateTime(
   value: string | number | Date,
-  options: Intl.DateTimeFormatOptions = {},
+  options: Intl.DateTimeFormatOptions = {}
 ): string {
   return new Date(value).toLocaleString('en-US', {
     timeZone: APP_TIME_ZONE,
+    hour12: clockHour12.value,
     ...options,
   })
 }

--- a/prisma/migrations/20260720174443_add_rides_per_page/migration.sql
+++ b/prisma/migrations/20260720174443_add_rides_per_page/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "user_preference" ADD COLUMN "ridesPerPage" INTEGER;
+

--- a/prisma/migrations/20260721200731_add_rides_view/migration.sql
+++ b/prisma/migrations/20260721200731_add_rides_view/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "user_preference" ADD COLUMN "ridesViewDesktop" TEXT;
+ALTER TABLE "user_preference" ADD COLUMN "ridesViewMobile" TEXT;
+

--- a/prisma/schema/preference.prisma
+++ b/prisma/schema/preference.prisma
@@ -22,6 +22,12 @@ model UserPreference {
   // devices. null = client default (10).
   ridesPerPage Int?
 
+  // Rides list view per breakpoint: "table" | "cards". Stored separately so the
+  // desktop and mobile choices are independent. null = client default
+  // (desktop -> table, mobile -> cards).
+  ridesViewDesktop String?
+  ridesViewMobile  String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/prisma/schema/preference.prisma
+++ b/prisma/schema/preference.prisma
@@ -18,6 +18,10 @@ model UserPreference {
   // Volunteers only: limit the rides list to rides assigned to me.
   rideAssignedToMeOnly Boolean @default(false)
 
+  // Rows-per-page for the rides list, persisted so it follows the user across
+  // devices. null = client default (10).
+  ridesPerPage Int?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/server/api/get/preferences.ts
+++ b/server/api/get/preferences.ts
@@ -23,5 +23,6 @@ export default defineEventHandler(async (event) => {
       pref?.rideStatusFilter != null ? pref.rideStatusFilter.split(',').filter(Boolean) : null,
     rideSort: pref?.rideSort ?? null,
     rideAssignedToMeOnly: pref?.rideAssignedToMeOnly ?? false,
+    ridesPerPage: pref?.ridesPerPage ?? null,
   }
 })

--- a/server/api/get/preferences.ts
+++ b/server/api/get/preferences.ts
@@ -24,5 +24,7 @@ export default defineEventHandler(async (event) => {
     rideSort: pref?.rideSort ?? null,
     rideAssignedToMeOnly: pref?.rideAssignedToMeOnly ?? false,
     ridesPerPage: pref?.ridesPerPage ?? null,
+    ridesViewDesktop: pref?.ridesViewDesktop ?? null,
+    ridesViewMobile: pref?.ridesViewMobile ?? null,
   }
 })

--- a/server/api/put/preferences.ts
+++ b/server/api/put/preferences.ts
@@ -16,6 +16,8 @@ const prefSchema = z
     rideSort: z.enum(['asc', 'desc']).optional(),
     rideAssignedToMeOnly: z.boolean().optional(),
     ridesPerPage: z.number().int().positive().max(100).optional(),
+    ridesViewDesktop: z.enum(['table', 'cards']).optional(),
+    ridesViewMobile: z.enum(['table', 'cards']).optional(),
   })
   .strict()
 
@@ -35,6 +37,8 @@ export default defineEventHandler(async (event) => {
     rideSort?: string
     rideAssignedToMeOnly?: boolean
     ridesPerPage?: number
+    ridesViewDesktop?: string
+    ridesViewMobile?: string
   } = {}
   if (body.rideStatusFilter !== undefined) {
     data.rideStatusFilter = Array.from(new Set(body.rideStatusFilter)).join(',')
@@ -44,6 +48,8 @@ export default defineEventHandler(async (event) => {
     data.rideAssignedToMeOnly = body.rideAssignedToMeOnly
   }
   if (body.ridesPerPage !== undefined) data.ridesPerPage = body.ridesPerPage
+  if (body.ridesViewDesktop !== undefined) data.ridesViewDesktop = body.ridesViewDesktop
+  if (body.ridesViewMobile !== undefined) data.ridesViewMobile = body.ridesViewMobile
 
   const pref = await prisma.userPreference.upsert({
     where: { userId },
@@ -57,5 +63,7 @@ export default defineEventHandler(async (event) => {
     rideSort: pref.rideSort ?? null,
     rideAssignedToMeOnly: pref.rideAssignedToMeOnly,
     ridesPerPage: pref.ridesPerPage ?? null,
+    ridesViewDesktop: pref.ridesViewDesktop ?? null,
+    ridesViewMobile: pref.ridesViewMobile ?? null,
   }
 })

--- a/server/api/put/preferences.ts
+++ b/server/api/put/preferences.ts
@@ -15,6 +15,7 @@ const prefSchema = z
     rideStatusFilter: z.array(z.enum(RIDE_STATUSES)).optional(),
     rideSort: z.enum(['asc', 'desc']).optional(),
     rideAssignedToMeOnly: z.boolean().optional(),
+    ridesPerPage: z.number().int().positive().max(100).optional(),
   })
   .strict()
 
@@ -33,6 +34,7 @@ export default defineEventHandler(async (event) => {
     rideStatusFilter?: string
     rideSort?: string
     rideAssignedToMeOnly?: boolean
+    ridesPerPage?: number
   } = {}
   if (body.rideStatusFilter !== undefined) {
     data.rideStatusFilter = Array.from(new Set(body.rideStatusFilter)).join(',')
@@ -41,6 +43,7 @@ export default defineEventHandler(async (event) => {
   if (body.rideAssignedToMeOnly !== undefined) {
     data.rideAssignedToMeOnly = body.rideAssignedToMeOnly
   }
+  if (body.ridesPerPage !== undefined) data.ridesPerPage = body.ridesPerPage
 
   const pref = await prisma.userPreference.upsert({
     where: { userId },
@@ -53,5 +56,6 @@ export default defineEventHandler(async (event) => {
       pref.rideStatusFilter != null ? pref.rideStatusFilter.split(',').filter(Boolean) : null,
     rideSort: pref.rideSort ?? null,
     rideAssignedToMeOnly: pref.rideAssignedToMeOnly,
+    ridesPerPage: pref.ridesPerPage ?? null,
   }
 })

--- a/tests/e2e/preferences.test.ts
+++ b/tests/e2e/preferences.test.ts
@@ -12,6 +12,7 @@ type Prefs = {
   rideStatusFilter: string[] | null
   rideSort: string | null
   rideAssignedToMeOnly: boolean
+  ridesPerPage: number | null
 }
 
 describe('user preferences API', () => {
@@ -21,6 +22,19 @@ describe('user preferences API', () => {
     expect(res.rideStatusFilter).toBeNull()
     expect(res.rideSort).toBeNull()
     expect(res.rideAssignedToMeOnly).toBe(false)
+    expect(res.ridesPerPage).toBeNull()
+  })
+
+  it('persists rows-per-page (ridesPerPage) and reads it back', async () => {
+    const cookie = await loginAs('bob@example.com')
+    const put = await $fetch<Prefs>('/api/put/preferences', {
+      method: 'PUT',
+      headers: { cookie },
+      body: { ridesPerPage: 50 },
+    })
+    expect(put.ridesPerPage).toBe(50)
+    const get = await $fetch<Prefs>('/api/get/preferences', { headers: { cookie } })
+    expect(get.ridesPerPage).toBe(50)
   })
 
   it('persists a PUT and reads it back (status filter round-trips as an array)', async () => {

--- a/tests/e2e/preferences.test.ts
+++ b/tests/e2e/preferences.test.ts
@@ -13,6 +13,8 @@ type Prefs = {
   rideSort: string | null
   rideAssignedToMeOnly: boolean
   ridesPerPage: number | null
+  ridesViewDesktop: string | null
+  ridesViewMobile: string | null
 }
 
 describe('user preferences API', () => {
@@ -23,6 +25,33 @@ describe('user preferences API', () => {
     expect(res.rideSort).toBeNull()
     expect(res.rideAssignedToMeOnly).toBe(false)
     expect(res.ridesPerPage).toBeNull()
+    expect(res.ridesViewDesktop).toBeNull()
+    expect(res.ridesViewMobile).toBeNull()
+  })
+
+  it('persists per-breakpoint view (ridesViewDesktop/Mobile) independently', async () => {
+    const cookie = await loginAs('bob@example.com')
+    const put = await $fetch<Prefs>('/api/put/preferences', {
+      method: 'PUT',
+      headers: { cookie },
+      body: { ridesViewDesktop: 'cards', ridesViewMobile: 'table' },
+    })
+    expect(put.ridesViewDesktop).toBe('cards')
+    expect(put.ridesViewMobile).toBe('table')
+    const get = await $fetch<Prefs>('/api/get/preferences', { headers: { cookie } })
+    expect(get.ridesViewDesktop).toBe('cards')
+    expect(get.ridesViewMobile).toBe('table')
+  })
+
+  it('rejects an invalid view value with 400', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    await expect(
+      $fetch('/api/put/preferences', {
+        method: 'PUT',
+        headers: { cookie },
+        body: { ridesViewDesktop: 'grid' },
+      })
+    ).rejects.toMatchObject({ statusCode: 400 })
   })
 
   it('persists rows-per-page (ridesPerPage) and reads it back', async () => {
@@ -90,7 +119,7 @@ describe('user preferences API', () => {
         method: 'PUT',
         headers: { cookie },
         body: { rideStatusFilter: ['BOGUS'] },
-      }),
+      })
     ).rejects.toMatchObject({ statusCode: 400 })
   })
 
@@ -101,14 +130,14 @@ describe('user preferences API', () => {
         method: 'PUT',
         headers: { cookie },
         body: { evil: true },
-      }),
+      })
     ).rejects.toMatchObject({ statusCode: 400 })
   })
 
   it('requires authentication', async () => {
     await expect($fetch('/api/get/preferences')).rejects.toMatchObject({ statusCode: 401 })
     await expect(
-      $fetch('/api/put/preferences', { method: 'PUT', body: { rideSort: 'asc' } }),
+      $fetch('/api/put/preferences', { method: 'PUT', body: { rideSort: 'asc' } })
     ).rejects.toMatchObject({ statusCode: 401 })
   })
 })


### PR DESCRIPTION
The rides-management UX work (builds on phase A #115 and phase B #116, on the `stage` line).

### Create Ride — a wizard instead of a modal
- Replaced the long create modal with a 3-step wizard (Client & route → Schedule → Review) rendered as a **side pane beside the list on desktop** and a **full-screen flow on mobile** (`RideCreatePanel.vue`).
- Search-first address entry (`AddressField.vue`): pick an existing address or "Enter a new address"; pickup pre-fills from the client's home with a visible hint.
- Validation: blocks same pickup/dropoff and a pickup time after the appointment; Create shows a spinner (no double-submit).
- Notes textarea has a 4-row min; the review value wraps instead of overflowing.

### Rides list — bounded, configurable, toggleable
- **No page scroll**: the list is bounded to the viewport; the table/cards scroll internally under a **pinned pagination footer**. Desktop table has a sticky header.
- **Rows-per-page** selector (5/10/20/50, default 10), pinned in the footer, always shown.
- **Table/cards view toggle**, usable at either width; defaults desktop→rows, mobile→cards.
- Search no longer collapses at intermediate widths.

### Persisted preferences (DB, cross-device)
- Extended `UserPreference` with `ridesPerPage`, `ridesViewDesktop`, `ridesViewMobile` (migrations included); GET/PUT validated; the list seeds from and debounce-saves them. Rendering stays CSS-driven off the SSR-known prefs (no hydration flash).

### Misc
- Times now follow the viewer's 12h/24h system clock (detected post-hydration, so no mismatch).

Full e2e suite green (46 files / 217 tests). Deferred to a follow-up: the maps/geocoding + address-verification work (open-source MapLibre stack under discussion).