### PR TITLE
Fix 24-hour time on the rides table (clock-format preference)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -212,7 +212,7 @@ is not documentation that can rot — it is enforced.
 | R-303 | Admin audit page: bounded table, action/user filters | `app/pages/admin/audit.vue` | auto | browser: `admin-flows.spec.ts` |
 | R-304 | Pages hydrate without mismatches (SSR output == client render): SSR-rendered dates are timezone-stable so server (UTC) and browser (local TZ) agree | `app/utils/datetime.ts`, rides/index.vue, rides/[id].vue, admin/audit.vue | auto [#98](https://github.com/UTDallasEPICS/wcoa/issues/98) | `hydration-datetime.test.ts` (server-side determinism) + browser: `admin-flows.spec.ts` (`/rides` hydrates clean) |
 | R-305 | Success/error toasts on every mutating UI action | all pages | auto | browser specs (asserted on key flows) |
-| R-306 | Rides list preferences (status filter, sort, rows-per-page, and table/cards view per breakpoint) persist per-user in the DB — cross-device — via `GET`/`PUT /api/*/preferences`; validated + session-scoped; the list seeds from and debounce-saves them | `UserPreference` model + `get/put preferences.ts` | auto | `preferences.test.ts` |
+| R-306 | Rides list preferences (status filter, sort, rows-per-page, table/cards view per breakpoint, and clock format auto/12h/24h) persist per-user in the DB — cross-device — via `GET`/`PUT /api/*/preferences`; validated + session-scoped; the list seeds from and debounce-saves them. The clock-format override exists because Chrome/V8 ignore macOS's force-24h flag for en-US | `UserPreference` model + `get/put preferences.ts` | auto | `preferences.test.ts` |
 
 ## Known non-requirements / accepted behavior
 

--- a/app/pages/rides/index.vue
+++ b/app/pages/rides/index.vue
@@ -54,6 +54,23 @@
   const desktopView = ref<string>(prefs.value?.ridesViewDesktop ?? 'table')
   const mobileView = ref<string>(prefs.value?.ridesViewMobile ?? 'cards')
 
+  // Clock format for rendered times: 'auto' follows the browser's detected
+  // cycle; '12h'/'24h' force it. Needed because Chrome/V8 ignore macOS's
+  // force-24h flag for en-US, so auto-detection can't see that setting. Applied
+  // to the shared clockHour12 ref CLIENT-SIDE only (never during SSR, so the ref
+  // can't leak across requests and hydration stays clean).
+  const CLOCK_OPTIONS = [
+    { label: 'Auto', value: 'auto' },
+    { label: '12h', value: '12h' },
+    { label: '24h', value: '24h' },
+  ]
+  const clockFormat = ref<string>(prefs.value?.clockFormat ?? 'auto')
+  function applyClockFormat(fmt: string) {
+    clockHour12.value = fmt === '24h' ? false : fmt === '12h' ? true : detectHour12()
+  }
+  onMounted(() => applyClockFormat(clockFormat.value))
+  watch(clockFormat, (fmt) => applyClockFormat(fmt))
+
   // Visibility is pure CSS (max-lg = below 1024px, lg = 1024px+), driven by the
   // per-breakpoint preference, so both the table and cards stay in the DOM and
   // the right one shows at each width without any JS viewport detection.
@@ -143,11 +160,12 @@
         ridesPerPage: Number(pageSize.value),
         ridesViewDesktop: desktopView.value,
         ridesViewMobile: mobileView.value,
+        clockFormat: clockFormat.value,
       },
     }).catch((err) => console.error('Failed to save preferences', err))
   }, 400)
   watch(
-    [selectedStatuses, sort, assignedToMe, pageSize, desktopView, mobileView],
+    [selectedStatuses, sort, assignedToMe, pageSize, desktopView, mobileView, clockFormat],
     () => savePreferences(),
     { deep: true }
   )
@@ -506,6 +524,27 @@
                   :variant="currentView === 'cards' ? 'subtle' : 'ghost'"
                   aria-label="Card view"
                   @click="setView('cards')"
+                />
+              </div>
+            </ClientOnly>
+
+            <!-- Clock format: Auto follows the browser; 12h/24h force it. Needed
+                 because Chrome ignores macOS's force-24h flag for en-US. Saved
+                 per-user and applied app-wide. Client-only so SSR/hydration stay
+                 clean (times render 12h until the cycle is applied post-mount). -->
+            <ClientOnly>
+              <div
+                class="inline-flex items-center rounded-lg border border-gray-200 p-0.5 dark:border-gray-700"
+                aria-label="Time format"
+              >
+                <UButton
+                  v-for="opt in CLOCK_OPTIONS"
+                  :key="opt.value"
+                  :label="opt.label"
+                  size="sm"
+                  :color="clockFormat === opt.value ? 'primary' : 'neutral'"
+                  :variant="clockFormat === opt.value ? 'subtle' : 'ghost'"
+                  @click="clockFormat = opt.value"
                 />
               </div>
             </ClientOnly>

--- a/app/plugins/clock.client.ts
+++ b/app/plugins/clock.client.ts
@@ -1,17 +1,25 @@
-import { clockHour12 } from '../utils/datetime'
+import { clockHour12, detectHour12 } from '../utils/datetime'
 
-// Detect the viewer's 12h/24h clock preference and share it with formatDateTime
+// Decide the viewer's 12h/24h clock cycle and share it with formatDateTime
 // (app/utils/datetime.ts). Runs on the client only, AFTER the app is mounted, so
 // the first client render still matches the server's en-US default (12h) — no
-// hydration mismatch — and times then re-render in the user's preferred cycle.
+// hydration mismatch — and times then re-render in the resolved cycle.
+//
+// An explicit per-user preference (clockFormat: "12h" | "24h") wins; "auto" (or
+// no preference) falls back to browser detection. The override exists because
+// Chrome/V8 don't honor macOS's force-24h flag for en-US, so detection alone
+// can't respect that setting.
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.hook('app:mounted', () => {
+  nuxtApp.hook('app:mounted', async () => {
+    let clockFormat: string | null = null
     try {
-      const cycle = new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions()
-        .hourCycle
-      clockHour12.value = cycle === 'h11' || cycle === 'h12'
+      const pref = await $fetch<{ clockFormat: string | null }>('/api/get/preferences')
+      clockFormat = pref?.clockFormat ?? null
     } catch {
-      // Fall back to the 12h default if the environment can't report a cycle.
+      // Not signed in / no preference — fall through to detection.
     }
+    if (clockFormat === '12h') clockHour12.value = true
+    else if (clockFormat === '24h') clockHour12.value = false
+    else clockHour12.value = detectHour12()
   })
 })

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -29,6 +29,23 @@ export const APP_TIME_ZONE = 'America/Chicago'
 export const clockHour12 = ref<boolean | undefined>(undefined)
 
 /**
+ * Detect whether the browser's default locale uses a 12-hour clock. Client-only
+ * (call after mount). Note: Chrome/V8 report the locale's CLDR default here and
+ * do NOT reflect macOS's "24-Hour Time" force flag for en-US — which is why an
+ * explicit user preference can override this (see plugins/clock.client.ts).
+ * Defaults to 12h (true) if the environment can't report a cycle.
+ */
+export function detectHour12(): boolean {
+  try {
+    const cycle = new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions()
+      .hourCycle
+    return cycle === 'h11' || cycle === 'h12'
+  } catch {
+    return true
+  }
+}
+
+/**
  * Format an instant in the app's fixed locale + timezone. Extra
  * `Intl.DateTimeFormatOptions` are merged in so each call site keeps its own
  * date/time style; only the locale and timezone are forced. The hour cycle

--- a/prisma/migrations/20260721233531_add_clock_format/migration.sql
+++ b/prisma/migrations/20260721233531_add_clock_format/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "user_preference" ADD COLUMN "clockFormat" TEXT;
+

--- a/prisma/schema/preference.prisma
+++ b/prisma/schema/preference.prisma
@@ -28,6 +28,12 @@ model UserPreference {
   ridesViewDesktop String?
   ridesViewMobile  String?
 
+  // Clock format for all rendered times: "auto" | "12h" | "24h". null/"auto" =
+  // follow the browser's detected hour cycle. An explicit override is needed
+  // because Chrome/V8 ignore macOS's "24-Hour Time" (AppleICUForce24HourTime)
+  // flag for en-US, so auto-detection can't see that preference.
+  clockFormat String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/server/api/get/preferences.ts
+++ b/server/api/get/preferences.ts
@@ -26,5 +26,6 @@ export default defineEventHandler(async (event) => {
     ridesPerPage: pref?.ridesPerPage ?? null,
     ridesViewDesktop: pref?.ridesViewDesktop ?? null,
     ridesViewMobile: pref?.ridesViewMobile ?? null,
+    clockFormat: pref?.clockFormat ?? null,
   }
 })

--- a/server/api/put/preferences.ts
+++ b/server/api/put/preferences.ts
@@ -18,6 +18,7 @@ const prefSchema = z
     ridesPerPage: z.number().int().positive().max(100).optional(),
     ridesViewDesktop: z.enum(['table', 'cards']).optional(),
     ridesViewMobile: z.enum(['table', 'cards']).optional(),
+    clockFormat: z.enum(['auto', '12h', '24h']).optional(),
   })
   .strict()
 
@@ -39,6 +40,7 @@ export default defineEventHandler(async (event) => {
     ridesPerPage?: number
     ridesViewDesktop?: string
     ridesViewMobile?: string
+    clockFormat?: string
   } = {}
   if (body.rideStatusFilter !== undefined) {
     data.rideStatusFilter = Array.from(new Set(body.rideStatusFilter)).join(',')
@@ -50,6 +52,7 @@ export default defineEventHandler(async (event) => {
   if (body.ridesPerPage !== undefined) data.ridesPerPage = body.ridesPerPage
   if (body.ridesViewDesktop !== undefined) data.ridesViewDesktop = body.ridesViewDesktop
   if (body.ridesViewMobile !== undefined) data.ridesViewMobile = body.ridesViewMobile
+  if (body.clockFormat !== undefined) data.clockFormat = body.clockFormat
 
   const pref = await prisma.userPreference.upsert({
     where: { userId },
@@ -65,5 +68,6 @@ export default defineEventHandler(async (event) => {
     ridesPerPage: pref.ridesPerPage ?? null,
     ridesViewDesktop: pref.ridesViewDesktop ?? null,
     ridesViewMobile: pref.ridesViewMobile ?? null,
+    clockFormat: pref.clockFormat ?? null,
   }
 })

--- a/tests/e2e/preferences.test.ts
+++ b/tests/e2e/preferences.test.ts
@@ -15,6 +15,7 @@ type Prefs = {
   ridesPerPage: number | null
   ridesViewDesktop: string | null
   ridesViewMobile: string | null
+  clockFormat: string | null
 }
 
 describe('user preferences API', () => {
@@ -27,6 +28,30 @@ describe('user preferences API', () => {
     expect(res.ridesPerPage).toBeNull()
     expect(res.ridesViewDesktop).toBeNull()
     expect(res.ridesViewMobile).toBeNull()
+    expect(res.clockFormat).toBeNull()
+  })
+
+  it('persists clockFormat (12h/24h override) and reads it back', async () => {
+    const cookie = await loginAs('alice@example.com')
+    const put = await $fetch<Prefs>('/api/put/preferences', {
+      method: 'PUT',
+      headers: { cookie },
+      body: { clockFormat: '24h' },
+    })
+    expect(put.clockFormat).toBe('24h')
+    const get = await $fetch<Prefs>('/api/get/preferences', { headers: { cookie } })
+    expect(get.clockFormat).toBe('24h')
+  })
+
+  it('rejects an invalid clockFormat with 400', async () => {
+    const cookie = await loginAs('reachtusharwani@gmail.com')
+    await expect(
+      $fetch('/api/put/preferences', {
+        method: 'PUT',
+        headers: { cookie },
+        body: { clockFormat: 'military' },
+      })
+    ).rejects.toMatchObject({ statusCode: 400 })
   })
 
   it('persists per-breakpoint view (ridesViewDesktop/Mobile) independently', async () => {


### PR DESCRIPTION
The rides table showed 12-hour times even when the Mac was set to 24-hour time.

**Root cause:** macOS's *24-Hour Time* toggle (`AppleICUForce24HourTime`) with an `en_US` region is an Apple-specific override that **Chrome/V8 do not honor** (they bundle their own ICU and report the en-US default, h12). So the app's `Intl`-based auto-detection can't see the preference — only Safari would. Confirmed the table re-render + detection machinery are fine (an `en-GB` locale renders 24h correctly).

**Fix:** an explicit per-user clock-format preference that overrides detection.
- `UserPreference.clockFormat`: `auto` | `12h` | `24h` (migration `add_clock_format`); GET/PUT validate + round-trip it.
- `plugins/clock.client.ts` applies it app-wide post-mount; `auto`/unset falls back to `detectHour12()`. `clockHour12` stays undefined during SSR → no hydration mismatch.
- Rides toolbar gets an Auto/12h/24h segmented control, debounce-saved with the other list prefs.

**Verification:** an en-US browser (reports h12, like the affected Chrome) with `clockFormat=24h` renders the table as `19:01 / 13:32`. Full e2e **45/218 green**, trace **122/122** (R-306 updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)